### PR TITLE
claude/fix-privacy-policy-rendering-OM3EU

### DIFF
--- a/user-docs/privacy.md
+++ b/user-docs/privacy.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: doc
 title: Privacy Policy
 description: Privacy policy for the Hermes-Relay Android app
 ---


### PR DESCRIPTION
The privacy page used `layout: page` which renders content without the
`vp-doc` CSS class wrapper, breaking all document styling (tables,
typography, headings, custom blocks). Switch to `layout: doc`.

https://claude.ai/code/session_01C4typoCNZQBLCqqaZuUDqC