### PR TITLE
chore(ci): add Required-checks sentinel — fixes branch protection drift

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,49 @@
+# Required-checks sentinel — always runs on every PR + push to main/dev so
+# branch protection on `main` has a check name it can rely on, regardless
+# of which paths the PR touches.
+#
+# Why this exists. The other CI workflows (`ci-android.yml`, `ci-relay.yml`,
+# `ci-desktop.yml`) are scoped via `paths:` filters so a docs-only or
+# desktop-only PR doesn't spin up the Android toolchain. Branch protection's
+# "required status checks" treat a check that doesn't run as failing — so
+# any PR that didn't touch the protected paths was blocked from merging,
+# even with all the relevant gates green. We were admin-overriding every
+# desktop-only PR. Same for relay-touching PRs (the protection rule named
+# `Relay Check (Python)` didn't even match any actual job — broken since
+# day one).
+#
+# This sentinel + claude-review become the only required checks. The
+# path-filtered workflows still run when relevant and surface their
+# results on the PR — visible, clickable, but advisory rather than
+# blocking. Reviewers (human + claude-review) eyeball them. This is the
+# standard pattern for monorepos with path-filtered CI.
+#
+# Trade-off acknowledged: a broken Android build on an Android-touching
+# PR could merge if the reviewer ignores the failing CI badge. Mitigation:
+# claude-review reads CI conclusions in its review prompt + the project's
+# release-merge cadence catches issues before they reach a tag. If a
+# stricter gate is later wanted, fold it into this workflow as a job that
+# fans out to the path-filtered work — but the simplest version (just an
+# `echo`) is what's needed to make branch protection useful again today.
+
+name: Required checks
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+# Cancel in-progress runs for the same branch/PR. Doesn't matter much for
+# a 5-second job, but matches every other workflow's concurrency shape.
+concurrency:
+  group: ci-required-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+
+jobs:
+  guard:
+    name: Required checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: OK
+        run: echo "Required-checks sentinel — see ci-required.yml header for context."


### PR DESCRIPTION
## Summary

Fixes the branch protection drift surfaced during PR #42 — admin-override was needed to merge a desktop-only PR because all four required check names on \`main\` were either path-filtered (don't run on desktop PRs) or misnamed (\`Relay Check (Python)\` never matched any actual job).

## What changed

Added \`.github/workflows/ci-required.yml\` — a sentinel workflow that always runs on every push/PR to main/dev. Its single job emits a \`Required checks\` status that branch protection can rely on.

Path-filtered workflows (\`ci-android.yml\`, \`ci-relay.yml\`, \`ci-desktop.yml\`) are unchanged. They continue to surface real signal on PRs that touch their paths — just no longer block merging.

## Follow-up: branch protection update

Once this lands on main, run:

\`\`\`bash
gh api -X PUT repos/Codename-11/hermes-relay/branches/main/protection \
  -F required_status_checks.contexts[]='Required checks' \
  -F required_status_checks.contexts[]='claude-review' \
  -F required_status_checks.strict=true
\`\`\`

(Will execute automatically as part of the deploy after merge.)

## Trade-off (documented in workflow header)

Loosens the gate from "Android CI must pass" to "reviewer + claude-review approve". Matches actual practice for this repo's release cadence. If stricter gating is later wanted, fold the path-filtered work into this sentinel as fan-out jobs.

## Test plan

- [ ] CI on this PR: ci-relay should NOT run (no relay paths), ci-android should NOT run, ci-desktop should NOT run, **Required checks should run and pass**, claude-review should run
- [ ] After dev → main release-merge, update protection contexts to match
- [ ] Next desktop-only PR merges without admin override

🤖 Generated with [Claude Code](https://claude.com/claude-code)