### PR TITLE
release: deploy desktop-v0.3.0-alpha.16 + Required-checks sentinel

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,49 @@
+# Required-checks sentinel — always runs on every PR + push to main/dev so
+# branch protection on `main` has a check name it can rely on, regardless
+# of which paths the PR touches.
+#
+# Why this exists. The other CI workflows (`ci-android.yml`, `ci-relay.yml`,
+# `ci-desktop.yml`) are scoped via `paths:` filters so a docs-only or
+# desktop-only PR doesn't spin up the Android toolchain. Branch protection's
+# "required status checks" treat a check that doesn't run as failing — so
+# any PR that didn't touch the protected paths was blocked from merging,
+# even with all the relevant gates green. We were admin-overriding every
+# desktop-only PR. Same for relay-touching PRs (the protection rule named
+# `Relay Check (Python)` didn't even match any actual job — broken since
+# day one).
+#
+# This sentinel + claude-review become the only required checks. The
+# path-filtered workflows still run when relevant and surface their
+# results on the PR — visible, clickable, but advisory rather than
+# blocking. Reviewers (human + claude-review) eyeball them. This is the
+# standard pattern for monorepos with path-filtered CI.
+#
+# Trade-off acknowledged: a broken Android build on an Android-touching
+# PR could merge if the reviewer ignores the failing CI badge. Mitigation:
+# claude-review reads CI conclusions in its review prompt + the project's
+# release-merge cadence catches issues before they reach a tag. If a
+# stricter gate is later wanted, fold it into this workflow as a job that
+# fans out to the path-filtered work — but the simplest version (just an
+# `echo`) is what's needed to make branch protection useful again today.
+
+name: Required checks
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+# Cancel in-progress runs for the same branch/PR. Doesn't matter much for
+# a 5-second job, but matches every other workflow's concurrency shape.
+concurrency:
+  group: ci-required-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+
+jobs:
+  guard:
+    name: Required checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: OK
+        run: echo "Required-checks sentinel — see ci-required.yml header for context."

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.3.0-alpha.15",
+  "version": "0.3.0-alpha.16",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/commands/daemon.ts
+++ b/desktop/src/commands/daemon.ts
@@ -32,6 +32,7 @@
 
 import type { ParsedArgs } from '../cli.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
+import { resolveFirstRunUrl } from '../relayUrlPrompt.js'
 import { getSession } from '../remoteSessions.js'
 import {
   DESKTOP_ADVERTISED_TOOLS,
@@ -89,13 +90,26 @@ export async function daemonCommand(args: ParsedArgs): Promise<number> {
   const human = humanFlag || (!args.flags['log-json'] && !!process.stderr.isTTY)
   const log = makeLogger(human)
 
-  const url = resolveRemoteOrNull(args)
+  // URL resolution mirrors chat/shell — explicit --remote / HERMES_RELAY_URL
+  // win, otherwise fall back to a stored session. resolveFirstRunUrl with
+  // nonInteractive:true auto-picks when exactly one session exists, throws a
+  // clear error when zero or many. Lets `hermes-relay daemon` with no flags
+  // Just Work for the common case (one paired server) — same UX as `hermes-relay`
+  // bare invocation and `chat` first-run.
+  let url = resolveRemoteOrNull(args)
   if (!url) {
-    log.error({
-      event: 'config_missing',
-      message: 'daemon requires --remote <url> or HERMES_RELAY_URL'
-    })
-    return 1
+    try {
+      url = await resolveFirstRunUrl({ nonInteractive: true })
+    } catch (e) {
+      log.error({
+        event: 'config_missing',
+        message:
+          'daemon: ' +
+          (e instanceof Error ? e.message : String(e)) +
+          ' Pass --remote <url>, set HERMES_RELAY_URL, or pair first with `hermes-relay pair`.'
+      })
+      return 1
+    }
   }
 
   // Resolve credentials: daemon takes ONLY --token or stored session. No

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.3.0-alpha.15" as const
+export const VERSION = "0.3.0-alpha.16" as const


### PR DESCRIPTION
## Summary

- \`feat(desktop)\`: daemon auto-picks single stored session when \`--remote\` is absent (\`hermes-relay daemon\` Just Works after pairing)
- \`release: desktop-v0.3.0-alpha.16\` — binaries already built + published by CI
- \`chore(ci)\`: Required-checks sentinel workflow — fixes the branch-protection-drift papercut from PR #42

## What lands on main

| Commit | Change |
|---|---|
| 1e77464 | daemon URL fallback via \`resolveFirstRunUrl({nonInteractive:true})\` |
| 4ccc0cc | desktop CLI 0.3.0-alpha.15 → 0.3.0-alpha.16 (release tag already pushed) |
| 650c00a | new \`.github/workflows/ci-required.yml\` sentinel |

## Branch protection follow-up (after merge)

This PR will be the **last one** that needs admin override to merge. Immediately after merge:

\`\`\`
gh api -X PUT repos/Codename-11/hermes-relay/branches/main/protection \
  ...drop "Lint (Android)", "Build (Android)", "Test (Android)", "Relay Check (Python)" \
  ...add "Required checks", keep "claude-review"
\`\`\`

Future desktop-only / docs-only PRs merge clean without admin.

## Test plan

- [ ] CI green: \`Required checks\` + \`claude-review\` pass on this PR
- [ ] After merge, branch protection update applies cleanly
- [ ] Server pull picks up daemon fix; \`hermes-relay update\` locally lands alpha.16
- [ ] End-to-end: \`hermes-relay daemon\` (no flags) works against the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)