### PR TITLE
test(android): un-defer voice/audio test suite (#32) + fix barge-in resume regression

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,28 @@
 # Hermes-Relay — Dev Log
 
+## 2026-05-23 — Un-defer the voice/audio test suite (issue #32) + barge-in resume bug
+
+**Context.** GitHub issue #32 tracked 5 voice/audio unit tests `@Ignore`'d during the v0.5.1 release because the full `:app:testGooglePlayDebugUnitTest` task "hung indefinitely." Scope had quietly grown to **8** ignored classes (3 of the "pure-logic, should-work" ones got swept in defensively). Branch `fix/voice-test-suite`.
+
+**Root-cause of the hang.** Not Robolectric's classloader (the v0.5.1 hypothesis) — it was `BargeInPreferencesTest` building its DataStore on a `TestScope(StandardTestDispatcher() + Job())` whose scheduler is **never advanced**. DataStore's reader actor never ran, so `repo.flow.first()` suspended forever. Fixed by backing the DataStore with a real dispatcher scope (`CoroutineScope(Dispatchers.IO + Job())`); the `runTest{}` bodies still drive the suspend calls within the dispatch timeout.
+
+**Real product bug found (not just test infra).** Un-ignoring `VoiceViewModelBargeInTest` surfaced a genuine regression: the barge-in **"resume after interruption"** feature was silently broken. `onBargeInDetected()` → `interruptSpeaking()` → `startTtsConsumer()` restarts the play worker, which immediately hits an empty `audioQueue`, fires `onQueueDrained` → `clearSpokenChunksState()` **synchronously** (on `Dispatchers.Main.immediate`) — wiping `spokenChunks` before the 600 ms resume watchdog reads it. The watchdog always saw an empty tail and dropped the resume. Fixed by snapshotting the un-played tail (`pendingResumeTail`) synchronously in `onBargeInDetected()`, the instant the interrupt fires, instead of re-reading live state later.
+
+**VoicePlayerTest / Robolectric.** No separate source set needed (the issue's proposed Phase 3). The "Robolectric leaks across forks and hangs the suite" symptom was a misattribution of the DataStore hang. With that fixed, VoicePlayerTest runs cleanly in the normal `test` source set under `@RunWith(RobolectricTestRunner) @Config(sdk=[34])` — added `robolectric 4.14.1` (testImplementation) + `unitTests.isIncludeAndroidResources = true`.
+
+**Result.** All 8 issue-#32 classes un-ignored and green. Full suite: **525 completed, 12 skipped, 0 failed, no hang (~30 s)**. The 12 skipped are unrelated pre-existing `@Ignore`s (`ConnectionStoreTest` et al.).
+
+**Also fixed (pre-existing failures surfaced while greening the suite):**
+
+- **`CardDispatchSyncBuilder` bug** — `buildSyntheticMessages` short-circuited on `msg.cards.isEmpty()`, silently dropping dispatches whose card was trimmed from the rolling buffer. This directly contradicted the SUT's own docstring (and `CardDispatchSyncBuilderTest.buildSyntheticMessages_unknownCardKey_stillEmitsBareEnvelope`), which require a bare-envelope audit record in that case. Fixed the guard to gate on `cardDispatches.isEmpty()` only; the `card == null` fallback already handles the missing-card path.
+- **4 lint errors in sideload-only bridge code compiled into googlePlay.** `NotificationPermission` (`AutoDisableWorker`) — the real `hasPostNotificationsPermission()` early-return guard was already correct; the existing `@SuppressLint("MissingPermission")` just used the wrong ID, so added `"NotificationPermission"`. `ForegroundServiceType` ×3 (`BridgeForegroundService`) — the service + its `FOREGROUND_SERVICE_*`/`POST_NOTIFICATIONS` permissions are declared only in the **sideload** manifest; googlePlay deliberately omits them (no device-control, Play-Store compliance), making the code unreachable there. Suppressed with a justification rather than weakening googlePlay.
+
+**Verified.** `:app:testGooglePlayDebugUnitTest` green (0 failures); `:app:lint` green (0 errors).
+
+**Next.** Commit, merge `fix/voice-test-suite` → `dev`, close issue #32.
+
+---
+
 ## 2026-05-19 — Experimental Realtime Hermes Voice Agent
 
 **Plan.** [docs/plans/2026-05-19-realtime-hermes-voice-agent.md](docs/plans/2026-05-19-realtime-hermes-voice-agent.md) — add a switchable Android voice engine that brokers a realtime provider session (OpenAI first, xAI ready) while keeping Hermes as authority for profiles, sessions, memory, tool execution, Android bridge safety, confirmations, and cancellation. Stable `Hermes chat + voice output` remains the default and is untouched.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,9 @@ android {
     // both failing with RuntimeException from unmocked Log.w calls.
     testOptions {
         unitTests.isReturnDefaultValues = true
+        // Robolectric (VoicePlayerTest) needs merged Android resources +
+        // manifest on the unit-test classpath to bootstrap its sandbox.
+        unitTests.isIncludeAndroidResources = true
     }
 }
 
@@ -257,6 +260,7 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
+    testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotlinx.serialization.json)
     // MockWebServer for ADR 24 EndpointResolver tests — probes HEAD /health

--- a/app/src/main/kotlin/com/hermesandroid/relay/bridge/AutoDisableWorker.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/bridge/AutoDisableWorker.kt
@@ -70,8 +70,10 @@ class AutoDisableWorker(private val context: Context) {
     // call is also wrapped in runCatching to swallow SecurityException as
     // a belt-and-braces. Suppress here rather than inlining the check —
     // the helper exists so the same gate can grow more conditions later
-    // without each call site re-implementing it.
-    @SuppressLint("MissingPermission")
+    // without each call site re-implementing it. Both IDs are needed:
+    // `NotificationPermission` is the notify()-specific check (POST_NOTIFICATIONS
+    // on API 33+); `MissingPermission` is the generic fallback.
+    @SuppressLint("MissingPermission", "NotificationPermission")
     private fun postNotification() {
         ensureChannel()
         if (!hasPostNotificationsPermission()) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/bridge/BridgeForegroundService.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/bridge/BridgeForegroundService.kt
@@ -1,5 +1,6 @@
 package com.hermesandroid.relay.bridge
 
+import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -300,6 +301,16 @@ class BridgeForegroundService : Service() {
         super.onDestroy()
     }
 
+    // ForegroundServiceType: lint requires the manifest `<service>` to declare
+    // `foregroundServiceType` for targetSdk >= 34. The SIDELOAD manifest does
+    // (specialUse|mediaProjection) + declares the matching FOREGROUND_SERVICE_*
+    // permissions. The GOOGLEPLAY flavor deliberately omits this service AND
+    // those permissions (no device-control capability for Play-Store
+    // compliance), so this code is unreachable there — the service can't be
+    // started without a manifest declaration. Lint analyzes the merged
+    // googlePlay manifest and can't see the sideload guarantee, so suppress
+    // here rather than weaken googlePlay by granting it specialUse.
+    @SuppressLint("ForegroundServiceType")
     private fun startForegroundNotification() {
         ensureChannel()
         val notification = buildNotification()

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/CardDispatchSyncBuilder.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/CardDispatchSyncBuilder.kt
@@ -82,7 +82,14 @@ object CardDispatchSyncBuilder {
         idGenerator: () -> String = { java.util.UUID.randomUUID().toString() },
     ): JsonArray = buildJsonArray {
         for (msg in history) {
-            if (msg.cards.isEmpty() || msg.cardDispatches.isEmpty()) continue
+            // Only the dispatch list gates emission. A message whose cards
+            // were trimmed from the rolling buffer (cards empty, dispatches
+            // present) MUST still sync its dispatches as bare envelopes —
+            // see the class docstring + the card==null fallback below. The
+            // old `msg.cards.isEmpty()` short-circuit silently dropped those
+            // audit records (regression caught by
+            // CardDispatchSyncBuilderTest.buildSyntheticMessages_unknownCardKey_stillEmitsBareEnvelope).
+            if (msg.cardDispatches.isEmpty()) continue
 
             // Index cards by their resolved cardKey so the dispatch
             // lookup is O(1). Mirrors the key formula in MessageBubble.kt

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -599,6 +599,20 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
      */
     private var lastInterruptedAtChunkIndex: Int? = null
 
+    /**
+     * Un-played [spokenChunks] tail captured synchronously the instant a
+     * barge-in interrupt fires, before [interruptSpeaking] runs. This MUST
+     * be snapshotted here rather than re-read by the resume watchdog 600 ms
+     * later: [interruptSpeaking] restarts the TTS consumer, whose play
+     * worker immediately hits an empty audioQueue and fires
+     * `onQueueDrained` → [clearSpokenChunksState] synchronously (on
+     * `Dispatchers.Main.immediate`). That clears [spokenChunks] long before
+     * the watchdog reads it, so reading live state would always yield an
+     * empty tail and silently drop the resume (regression caught by
+     * `VoiceViewModelBargeInTest`, GitHub issue #32).
+     */
+    private var pendingResumeTail: List<String> = emptyList()
+
     /** True while TTS volume is ducked from a `maybeSpeech` event. */
     @Volatile private var isDucked: Boolean = false
 
@@ -2859,6 +2873,14 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         if (isBargeInStartupGuardActive()) return
         duckingWatchdog?.cancel(); duckingWatchdog = null
         lastInterruptedAtChunkIndex = _currentPlayingChunkIndex.value
+        // Snapshot the un-played tail NOW, before interruptSpeaking restarts
+        // the consumer and its play worker clears spokenChunks out from under
+        // the resume watchdog. See [pendingResumeTail].
+        val resumeStartIdx = (lastInterruptedAtChunkIndex ?: -1) + 1
+        pendingResumeTail = synchronized(spokenChunks) {
+            val snapshot = spokenChunks.toList()
+            if (resumeStartIdx in snapshot.indices) snapshot.drop(resumeStartIdx) else emptyList()
+        }
         _voiceStats.update { it.copy(bargeInCount = it.bargeInCount + 1) }
         Log.i(TAG, "Barge-in detected; interrupting speech at chunk=$lastInterruptedAtChunkIndex")
 
@@ -2968,10 +2990,11 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                 return@launch
             }
 
-            // Silence + resume enabled → re-enqueue un-played chunks.
-            val startIdx = (lastInterruptedAtChunkIndex ?: -1) + 1
-            val snapshot: List<String> = synchronized(spokenChunks) { spokenChunks.toList() }
-            val tail = if (startIdx in snapshot.indices) snapshot.drop(startIdx) else emptyList()
+            // Silence + resume enabled → re-enqueue un-played chunks. The
+            // tail was snapshotted synchronously in [onBargeInDetected]; we
+            // can't re-read [spokenChunks] here because interruptSpeaking's
+            // consumer restart has already cleared it (see [pendingResumeTail]).
+            val tail = pendingResumeTail
 
             // Cancel the recorder that was pre-warmed for a user turn
             // that didn't materialize.

--- a/app/src/test/kotlin/com/hermesandroid/relay/audio/BargeInListenerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/audio/BargeInListenerTest.kt
@@ -21,7 +21,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -51,12 +50,6 @@ import java.util.concurrent.atomic.AtomicInteger
  *    run (the degraded-AEC path).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-// Tracked in GitHub issue #32. BargeInListenerTest's SharedFlow collectors
-// used .cancel() without .join(), which left jobs in "cancelling" state and
-// made runTest{} hang on child-job drain at scope exit. The cancelAndJoin
-// fix landed 2026-04-18 but full-suite verification was blocked by v0.5.1
-// release timeline — we'll validate when the follow-up infra PR lands.
-@Ignore("Tracked in GitHub issue #32 — cancelAndJoin fix applied, full-suite validation deferred")
 class BargeInListenerTest {
 
     @Before

--- a/app/src/test/kotlin/com/hermesandroid/relay/audio/VadEngineTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/audio/VadEngineTest.kt
@@ -4,7 +4,6 @@ import com.hermesandroid.relay.data.BargeInSensitivity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.sin
@@ -34,10 +33,6 @@ import kotlin.math.sin
  * the right shape a production caller (B3's audio loop) will pass. The fake
  * client ignores their content and returns the pre-programmed verdict.
  */
-// Tracked in GitHub issue #32. Deferred with BargeInListenerTest + the
-// VoiceViewModel coroutine tests pending the test-infra follow-up PR
-// (separate source set or proper fork strategy).
-@Ignore("Tracked in GitHub issue #32 — voice test suite validation deferred")
 class VadEngineTest {
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/audio/VoicePlayerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/audio/VoicePlayerTest.kt
@@ -21,8 +21,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 
 /**
@@ -48,24 +50,23 @@ import java.io.File
  * Objenesis to load the `ExoPlayer` class, and its static init chain
  * references `android.os.Looper` which isn't available on the pure JVM.
  *
- * TODO(2026-04-18): `@Ignore`d pending follow-up PR. Tried Robolectric
- * 4.14.1 with `@RunWith(RobolectricTestRunner::class)` + `@Config(sdk=34)`
- * + `forkEvery=1` — the test itself passed in isolation (2m53s) but
- * the full unit-test suite hung indefinitely at
- * `:app:testGooglePlayDebugUnitTest`, both locally and in CI. Robolectric's
- * shadow classloader appears to leak into sibling test JVMs in ways
- * `forkEvery=1` didn't resolve. Clean fix is a separate Gradle test task
- * or source set that runs only Robolectric-annotated tests — deferred
- * because the v0.5.1 release blocks on this.
+ * Runs under [RobolectricTestRunner] so `android.os.Looper` (pulled in by
+ * ExoPlayer's static init when MockK/Objenesis loads the class) resolves
+ * against Robolectric's sandbox instead of throwing
+ * `ExceptionInInitializerError` on the bare JVM classpath. `@Config(sdk=[34])`
+ * pins the emulated SDK to a Robolectric-4.14.1-supported level (the app
+ * compiles against a newer SDK, but the test only needs a working Looper).
  *
- * Tracked in GitHub issue (opened alongside this PR) and in the memory
- * `deferred_items.md` entry — search for "VoicePlayerTest Robolectric".
- * When the follow-up lands, delete `@Ignore` and add the Robolectric
- * annotations back. The test source itself is correct and passes under
- * Robolectric; only the test-infra wiring needs finishing.
+ * History (GitHub issue #32): a prior un-ignore attempt blamed Robolectric's
+ * shadow classloader for hanging the full suite under `forkEvery=1`. The
+ * real culprit was an unrelated DataStore deadlock in `BargeInPreferencesTest`
+ * (a never-pumped `StandardTestDispatcher` scope); once that was fixed this
+ * test runs cleanly in the normal `test` source set with no isolation
+ * gymnastics required.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@Ignore("Tracked in GitHub issue #32 — Robolectric wiring hangs full suite; fix via separate source set")
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class VoicePlayerTest {
 
     private lateinit var context: Context

--- a/app/src/test/kotlin/com/hermesandroid/relay/data/BargeInPreferencesTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/data/BargeInPreferencesTest.kt
@@ -4,18 +4,16 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -30,7 +28,6 @@ import java.io.File
  * test pattern and is why [BargeInPreferencesRepository] exposes a
  * `DataStore<Preferences>`-accepting constructor alongside the Context one.
  */
-@Ignore("Tracked in GitHub issue #32 — voice test suite validation deferred (DataStore scope may collect flows that don't terminate in runTest)")
 class BargeInPreferencesTest {
 
     @get:Rule
@@ -42,7 +39,15 @@ class BargeInPreferencesTest {
 
     @Before
     fun setUp() {
-        scope = TestScope(StandardTestDispatcher() + Job())
+        // DataStore's internal reader/writer actor runs on this scope. It
+        // must be a REAL dispatcher, not a StandardTestDispatcher: the latter
+        // only runs queued work when its scheduler is advanced, and nothing
+        // here advances it — so dataStore.data would never emit and
+        // repo.flow.first() would suspend forever (the indefinite hang that
+        // got this class deferred under issue #32). The test bodies still use
+        // runTest{}; the suspend calls complete against the real IO scope well
+        // within runTest's dispatch timeout.
+        scope = CoroutineScope(Dispatchers.IO + Job())
         val file: File = tempFolder.newFile("barge_in_test.preferences_pb")
         // We want a fresh empty store — delete the newFile() sentinel so
         // PreferenceDataStoreFactory starts from clean state each test.

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
@@ -35,7 +35,6 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -55,7 +54,6 @@ import org.junit.Test
  * supervisor or synthesize real MP3s on disk.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@Ignore("Tracked in GitHub issue #32 — voice test suite validation deferred")
 class VoiceViewModelBargeInTest {
 
     private val mainDispatcher = UnconfinedTestDispatcher()

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelChunkingTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelChunkingTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -32,7 +31,6 @@ import org.junit.Test
  * instead of reaching into the ViewModel (which needs an Application +
  * wired dependencies) so the coroutine semantics stay observable.
  */
-@Ignore("Tracked in GitHub issue #32 — voice test suite validation deferred")
 class VoiceViewModelChunkingTest {
 
     // ── Short-sentence coalescing ────────────────────────────────────────

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelPipelineTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelPipelineTest.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -38,7 +37,6 @@ import java.util.Collections
  * rather than `N * (synth + playback)`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@Ignore("Tracked in GitHub issue #32 — voice test suite validation deferred")
 class VoiceViewModelPipelineTest {
 
     @get:Rule

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelSanitizerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelSanitizerTest.kt
@@ -5,7 +5,6 @@ import com.hermesandroid.relay.viewmodel.sanitizeForTts
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -20,7 +19,6 @@ import org.junit.Test
  *
  * Pure top-level function; no Android, no coroutines, no ViewModel.
  */
-@Ignore("Tracked in GitHub issue #32 — voice test suite validation deferred (conservative; pure-logic but defer-blocked by v0.5.1 timeline)")
 class VoiceViewModelSanitizerTest {
 
     // ── Code fences ────────────────────────────────────────────────────

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ okhttp = "5.3.2"
 kotlinx-serialization = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 mockk = "1.14.9"
+robolectric = "4.14.1"
 security-crypto = "1.1.0"
 lifecycle = "2.10.0"
 activity-compose = "1.9.3"
@@ -109,6 +110,7 @@ splashscreen = { group = "androidx.core", name = "core-splashscreen", version.re
 # Testing
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
## Summary

Resolves #32 — un-defers the 8 voice/audio unit test classes that were `@Ignore`'d during v0.5.1 because the full unit suite "hung indefinitely." Along the way this fixes a **real product regression** the deferral was hiding, plus two pre-existing failures.

## Root cause of the hang (was misdiagnosed)
Not Robolectric's classloader. `BargeInPreferencesTest` built its DataStore on a `TestScope(StandardTestDispatcher() + Job())` whose scheduler is **never advanced** → DataStore's reader actor never runs → `repo.flow.first()` suspends forever (hung ~9.5h in one run). Fixed by backing the DataStore with a real `Dispatchers.IO` scope.

## Real product bug fixed
Barge-in **"resume after interruption" was silently broken**: `interruptSpeaking()` restarts the TTS consumer, whose play worker synchronously fires `onQueueDrained → clearSpokenChunksState()` (on `Main.immediate`), wiping `spokenChunks` before the 600 ms resume watchdog reads it. Fixed by snapshotting the un-played tail (`pendingResumeTail`) at interrupt time.

## VoicePlayerTest / Robolectric
**No separate source set needed** (the issue's proposed Phase 3). Once the DataStore hang was fixed, VoicePlayerTest runs cleanly in the normal `test` source set under `@RunWith(RobolectricTestRunner) @Config(sdk=[34])`. Added `robolectric 4.14.1` + `unitTests.isIncludeAndroidResources = true`.

## Pre-existing failures also fixed
- **`CardDispatchSyncBuilder`**: `buildSyntheticMessages` dropped dispatches whose card was trimmed from the rolling buffer, contradicting its own docstring + test. Gated emission on `cardDispatches.isEmpty()` only.
- **4 lint errors** in sideload-only bridge code compiled into googlePlay: `NotificationPermission` (wrong `@SuppressLint` ID — the runtime guard was already correct) and 3× `ForegroundServiceType` (sideload-only service unreachable in googlePlay; suppressed with justification rather than granting googlePlay device-control permissions).

## Verification
- `:app:testGooglePlayDebugUnitTest` — **525 completed, 0 failed, 12 skipped, no hang (~30 s)**. The 12 skipped are unrelated pre-existing `@Ignore`s (`ConnectionStoreTest` et al.).
- `:app:lint` — **0 errors**.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)