### PR TITLE
feat(voice): persistent Realtime Agent conversation (one socket across turns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Persistent Realtime Agent conversation.** Realtime Agent voice now keeps one provider session/socket open across turns instead of creating a fresh session per utterance, so the provider retains the live conversation (follow-up references work) and turns skip session-setup latency. The relay needed no change — it already supported multiple turns on one socket. A **Voice Settings → Realtime Agent → Persistent session** toggle (default on) falls back to the legacy per-utterance path. See `docs/plans/2026-05-24-realtime-persistent-session.md`.
+
 - **Background Hermes runs in Realtime Agent voice (ADR 33).** Long Hermes tasks no longer freeze the realtime conversation. A run that exceeds a grace window is promoted to a tracked background task: the provider speaks a short handoff ("I'm on it"), the conversation stays responsive, and the answer is spoken once the run finishes. `hermes_run_task(mode="background")` starts a durable run immediately. New relay events `hermes.run.promoted` and `hermes.run.background_completed`, plus `tier`/`floor` fields on `hermes.run.progress`.
 
 - **Relay audio floor owner.** A single-owner audio floor (provider / relay-TTS / Android-filler) makes explicit the serialization that the old blocking design provided implicitly, so a completed background result never barges in and two voices never overlap.

--- a/app/src/main/kotlin/com/hermesandroid/relay/data/VoicePreferences.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/VoicePreferences.kt
@@ -29,6 +29,13 @@ data class VoiceSettings(
     val autoTts: Boolean = false,
     val language: String = "",
     val realtimeTraceDetails: Boolean = false,
+    /**
+     * When true (default), Realtime Agent keeps one provider session/socket open
+     * across turns (persistent conversation). When false, falls back to the
+     * legacy one-session-per-utterance path. See
+     * docs/plans/2026-05-24-realtime-persistent-session.md.
+     */
+    val realtimePersistentSession: Boolean = true,
 )
 
 enum class VoiceEngineMode(val storageValue: String) {
@@ -52,6 +59,8 @@ class VoicePreferencesRepository(private val dataStore: DataStore<Preferences>) 
         private val KEY_AUTO_TTS = booleanPreferencesKey("voice_auto_tts")
         private val KEY_LANGUAGE = stringPreferencesKey("voice_language")
         private val KEY_REALTIME_TRACE_DETAILS = booleanPreferencesKey("voice_realtime_trace_details")
+        private val KEY_REALTIME_PERSISTENT_SESSION =
+            booleanPreferencesKey("voice_realtime_persistent_session")
 
         const val DEFAULT_ENGINE_MODE = "hermes_voice_output"
         const val DEFAULT_INTERACTION_MODE = "tap"
@@ -59,6 +68,7 @@ class VoicePreferencesRepository(private val dataStore: DataStore<Preferences>) 
         const val DEFAULT_AUTO_TTS = false
         const val DEFAULT_LANGUAGE = ""
         const val DEFAULT_REALTIME_TRACE_DETAILS = false
+        const val DEFAULT_REALTIME_PERSISTENT_SESSION = true
     }
 
     val settings: Flow<VoiceSettings> = dataStore.data
@@ -73,6 +83,8 @@ class VoicePreferencesRepository(private val dataStore: DataStore<Preferences>) 
                 language = prefs[KEY_LANGUAGE] ?: DEFAULT_LANGUAGE,
                 realtimeTraceDetails = prefs[KEY_REALTIME_TRACE_DETAILS]
                     ?: DEFAULT_REALTIME_TRACE_DETAILS,
+                realtimePersistentSession = prefs[KEY_REALTIME_PERSISTENT_SESSION]
+                    ?: DEFAULT_REALTIME_PERSISTENT_SESSION,
             )
         }
         .distinctUntilChanged()
@@ -99,5 +111,9 @@ class VoicePreferencesRepository(private val dataStore: DataStore<Preferences>) 
 
     suspend fun setRealtimeTraceDetails(enabled: Boolean) {
         dataStore.edit { it[KEY_REALTIME_TRACE_DETAILS] = enabled }
+    }
+
+    suspend fun setRealtimePersistentSession(enabled: Boolean) {
+        dataStore.edit { it[KEY_REALTIME_PERSISTENT_SESSION] = enabled }
     }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/RelayVoiceClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/RelayVoiceClient.kt
@@ -1191,6 +1191,22 @@ class RelayVoiceClient(
         }
     }
 
+    /**
+     * Run a Realtime Agent voice session.
+     *
+     * **One-shot (default):** with [turnInputs] null, this opens a session, sends
+     * the single [inputPcm]/[prompt] turn, and completes + closes the socket on
+     * `voice.response.done` — the historical per-utterance behavior used by the
+     * Voice Lab and the one-shot fallback.
+     *
+     * **Persistent (ADR follow-up, see docs/plans/2026-05-24-realtime-persistent-session.md):**
+     * with [turnInputs] non-null the socket stays open across turns. The first
+     * turn is [inputPcm]/[prompt]; each subsequent [RealtimeTurnInput] read from
+     * the channel is sent on the *same* socket, so the provider keeps a live
+     * conversation. `voice.response.done` invokes [onTurnComplete] instead of
+     * closing; the call returns only when the channel closes (voice-mode exit) or
+     * a fatal socket/provider error occurs.
+     */
     suspend fun runRealtimeAgent(
         prompt: String,
         inputPcm: ByteArray,
@@ -1198,8 +1214,11 @@ class RelayVoiceClient(
         chatSessionId: String? = null,
         conversationContext: List<RealtimeConversationContextMessage> = emptyList(),
         onHandoff: (VoiceHandoffEvent) -> Unit = {},
+        turnInputs: kotlinx.coroutines.channels.ReceiveChannel<RealtimeTurnInput>? = null,
+        onTurnComplete: (RealtimeVoiceSummary) -> Unit = {},
         onEvent: (RealtimeVoiceEvent, RealtimeAgentSessionControl) -> Unit,
     ): Result<RealtimeVoiceSummary> = withContext(Dispatchers.IO) {
+        val persistent = turnInputs != null
         val httpBase = resolveHttpBase()
             ?: return@withContext Result.failure(IllegalStateException("Relay URL not configured"))
         val wsBase = resolveWebSocketBase()
@@ -1230,8 +1249,11 @@ class RelayVoiceClient(
         val lastAudioEventId = AtomicLong(0L)
         val lastPlayedAudioEventId = AtomicLong(0L)
         val lastInputChunkId = AtomicLong(0L)
-        val turnStartedAtMs = System.currentTimeMillis()
-        val lastEventAtMs = AtomicLong(turnStartedAtMs)
+        val turnStartedAtMs = AtomicLong(System.currentTimeMillis())
+        val lastEventAtMs = AtomicLong(turnStartedAtMs.get())
+        // True while a turn is awaiting its response. In persistent mode the idle
+        // guard only applies while a turn is active; between-turn idle is normal.
+        val activeTurn = AtomicBoolean(true)
         val inputChunks = buildList {
             var offset = 0
             var chunkId = 1L
@@ -1242,8 +1264,33 @@ class RelayVoiceClient(
                 offset = end
             }
         }
+        // Highest input chunk id sent on this session. The relay dedups by
+        // input_chunk_seq, so subsequent turns must continue past this.
+        val sessionMaxChunkId = AtomicLong(inputChunks.size.toLong())
         var audioChunks = 0
         var audioBytes = 0
+
+        // Persistent-mode: chunk + send one more utterance on the open socket.
+        fun sendTurnPcm(webSocket: WebSocket, pcm: ByteArray, sampleRate: Int) {
+            var offset = 0
+            var sentAny = false
+            while (offset < pcm.size) {
+                val end = (offset + REALTIME_INPUT_CHUNK_BYTES).coerceAtMost(pcm.size)
+                val chunkId = sessionMaxChunkId.incrementAndGet()
+                val encoded = Base64.getEncoder().encodeToString(pcm.copyOfRange(offset, end))
+                webSocket.send(
+                    """{"type":"input_audio.append","chunk_id":$chunkId,"sample_rate":$sampleRate,"audio_base64":"$encoded"}"""
+                )
+                sentAny = true
+                offset = end
+            }
+            if (sentAny) {
+                webSocket.send("""{"type":"input_audio.commit"}""")
+            }
+            turnStartedAtMs.set(System.currentTimeMillis())
+            lastEventAtMs.set(System.currentTimeMillis())
+            activeTurn.set(true)
+        }
         fun activateSocket(webSocket: WebSocket, generation: Long): Boolean {
             while (true) {
                 val activeGeneration = activeSocketGeneration.get()
@@ -1390,24 +1437,28 @@ class RelayVoiceClient(
                         inputChunkId = event.inputChunkId,
                     )
                     if (event.type == "voice.response.done") {
-                        if (completed.compareAndSet(false, true)) {
-                            finished.complete(
-                                Result.success(
-                                    RealtimeVoiceSummary(
-                                        provider = event.provider ?: session.provider,
-                                        model = event.model ?: session.model,
-                                        voice = event.voice ?: session.voice,
-                                        sampleRate = session.sampleRate,
-                                        audioChunks = audioChunks,
-                                        audioBytes = audioBytes,
-                                        firstAudioMs = event.firstAudioMs,
-                                        responseDoneMs = event.responseDoneMs,
-                                        eventLogPath = event.eventLogPath ?: session.eventLogPath,
-                                    )
-                                )
-                            )
+                        val summary = RealtimeVoiceSummary(
+                            provider = event.provider ?: session.provider,
+                            model = event.model ?: session.model,
+                            voice = event.voice ?: session.voice,
+                            sampleRate = session.sampleRate,
+                            audioChunks = audioChunks,
+                            audioBytes = audioBytes,
+                            firstAudioMs = event.firstAudioMs,
+                            responseDoneMs = event.responseDoneMs,
+                            eventLogPath = event.eventLogPath ?: session.eventLogPath,
+                        )
+                        if (persistent) {
+                            // Turn boundary, not session boundary: keep the socket
+                            // open for the next utterance.
+                            activeTurn.set(false)
+                            onTurnComplete(summary)
+                        } else {
+                            if (completed.compareAndSet(false, true)) {
+                                finished.complete(Result.success(summary))
+                            }
+                            webSocket.close(1000, "done")
                         }
-                        webSocket.close(1000, "done")
                     } else if (event.type == "voice.error" || event.type == "voice.session.resume_failed") {
                         completeFailure(event.message ?: "Realtime agent error")
                         webSocket.close(1011, "provider error")
@@ -1510,23 +1561,83 @@ class RelayVoiceClient(
         suspend fun awaitRealtimeAgentCompletion(): Result<RealtimeVoiceSummary> {
             while (true) {
                 val now = System.currentTimeMillis()
-                val turnElapsedMs = now - turnStartedAtMs
-                val idleElapsedMs = now - lastEventAtMs.get()
-                if (turnElapsedMs >= REALTIME_AGENT_MAX_TURN_MS) {
-                    throw IOException("Realtime agent exceeded the turn limit")
+                // In persistent mode the turn/idle guards only apply while a turn
+                // is actually in flight; between-turn idle is expected and must
+                // not trip the stall timeout. The session ends when the turn
+                // channel closes or a fatal error completes `finished`.
+                val guardActive = !persistent || activeTurn.get()
+                if (guardActive) {
+                    val turnElapsedMs = now - turnStartedAtMs.get()
+                    val idleElapsedMs = now - lastEventAtMs.get()
+                    if (turnElapsedMs >= REALTIME_AGENT_MAX_TURN_MS) {
+                        throw IOException("Realtime agent exceeded the turn limit")
+                    }
+                    if (idleElapsedMs >= REALTIME_AGENT_IDLE_TIMEOUT_MS) {
+                        throw IOException("Realtime agent stalled waiting for relay events")
+                    }
+                    val waitMs = minOf(
+                        REALTIME_AGENT_WAIT_SLICE_MS,
+                        REALTIME_AGENT_MAX_TURN_MS - turnElapsedMs,
+                        REALTIME_AGENT_IDLE_TIMEOUT_MS - idleElapsedMs,
+                    ).coerceAtLeast(1L)
+                    withTimeoutOrNull(waitMs) {
+                        finished.await()
+                    }?.let { return it }
+                } else {
+                    withTimeoutOrNull(REALTIME_AGENT_WAIT_SLICE_MS) {
+                        finished.await()
+                    }?.let { return it }
                 }
-                if (idleElapsedMs >= REALTIME_AGENT_IDLE_TIMEOUT_MS) {
-                    throw IOException("Realtime agent stalled waiting for relay events")
-                }
-                val waitMs = minOf(
-                    REALTIME_AGENT_WAIT_SLICE_MS,
-                    REALTIME_AGENT_MAX_TURN_MS - turnElapsedMs,
-                    REALTIME_AGENT_IDLE_TIMEOUT_MS - idleElapsedMs,
-                ).coerceAtLeast(1L)
-                withTimeoutOrNull(waitMs) {
-                    finished.await()
-                }?.let { return it }
             }
+        }
+
+        // Persistent mode: drain further utterances and feed each onto the open
+        // socket as a new turn. Closing the channel (voice-mode exit) ends the
+        // session by completing `finished`.
+        val turnReader: Job? = if (turnInputs != null) {
+            launch {
+                try {
+                    for (turn in turnInputs) {
+                        val ws = currentSocket.get() ?: continue
+                        if (turn.prompt.isNotBlank() && turn.inputPcm.isEmpty()) {
+                            ws.send(
+                                buildRealtimeResponseCreate(
+                                    text = turn.prompt,
+                                    toolScaffold = false,
+                                    renderMode = "verbatim",
+                                )
+                            )
+                            turnStartedAtMs.set(System.currentTimeMillis())
+                            lastEventAtMs.set(System.currentTimeMillis())
+                            activeTurn.set(true)
+                        } else {
+                            sendTurnPcm(ws, turn.inputPcm, turn.sampleRate)
+                        }
+                    }
+                } finally {
+                    // Channel closed -> end the persistent session cleanly.
+                    if (completed.compareAndSet(false, true)) {
+                        finished.complete(
+                            Result.success(
+                                RealtimeVoiceSummary(
+                                    provider = session.provider,
+                                    model = session.model,
+                                    voice = session.voice,
+                                    sampleRate = session.sampleRate,
+                                    audioChunks = audioChunks,
+                                    audioBytes = audioBytes,
+                                    firstAudioMs = null,
+                                    responseDoneMs = null,
+                                    eventLogPath = session.eventLogPath,
+                                )
+                            )
+                        )
+                    }
+                    currentSocket.get()?.close(1000, "session ended")
+                }
+            }
+        } else {
+            null
         }
 
         val socket = openSocket(resume = false)
@@ -1549,6 +1660,7 @@ class RelayVoiceClient(
             Result.failure(IOException(e.message ?: "Realtime agent timed out", e))
         } finally {
             routeWatcher?.cancel()
+            turnReader?.cancel()
         }
     }
 
@@ -2551,6 +2663,33 @@ data class RealtimeVoiceSummary(
     val responseDoneMs: Double?,
     val eventLogPath: String?,
 )
+
+/**
+ * One utterance fed into a persistent Realtime Agent session
+ * (see [RelayVoiceClient.runRealtimeAgent] persistent mode). A blank [inputPcm]
+ * with a non-blank [prompt] sends a text turn; otherwise the PCM is chunked and
+ * committed as a spoken turn.
+ */
+data class RealtimeTurnInput(
+    val inputPcm: ByteArray,
+    val sampleRate: Int = 16_000,
+    val prompt: String = "",
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RealtimeTurnInput) return false
+        return sampleRate == other.sampleRate &&
+            prompt == other.prompt &&
+            inputPcm.contentEquals(other.inputPcm)
+    }
+
+    override fun hashCode(): Int {
+        var result = inputPcm.contentHashCode()
+        result = 31 * result + sampleRate
+        result = 31 * result + prompt.hashCode()
+        return result
+    }
+}
 
 data class VoiceOutputSummary(
     val provider: String,

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/VoiceSettingsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/VoiceSettingsScreen.kt
@@ -941,6 +941,26 @@ fun VoiceSettingsScreen(
                             },
                         )
                     }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text("Persistent session", style = MaterialTheme.typography.bodyLarge)
+                            Text(
+                                text = "Keep one provider conversation open across turns. Turn off to fall back to a fresh session per utterance.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = voiceSettings.realtimePersistentSession,
+                            onCheckedChange = { enabled ->
+                                scope.launch { prefsRepo.setRealtimePersistentSession(enabled) }
+                            },
+                        )
+                    }
                     Spacer(Modifier.height(4.dp))
                     ProviderRow(
                         label = "Status",

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -17,6 +17,7 @@ import com.hermesandroid.relay.data.BargeInPreferencesRepository
 import com.hermesandroid.relay.data.BargeInSensitivity
 import com.hermesandroid.relay.data.ChatMessage
 import com.hermesandroid.relay.data.MessageRole
+import com.hermesandroid.relay.data.RealtimeConversationContextMessage
 import com.hermesandroid.relay.data.ToolCall
 import com.hermesandroid.relay.data.VoiceEngineMode
 import com.hermesandroid.relay.data.VoiceIntentTrace
@@ -26,6 +27,8 @@ import com.hermesandroid.relay.diagnostics.DiagnosticsLog
 import com.hermesandroid.relay.network.ChannelMultiplexer
 import com.hermesandroid.relay.network.RelayVoiceClient
 import com.hermesandroid.relay.network.RealtimeAgentSessionControl
+import com.hermesandroid.relay.network.RealtimeTurnInput
+import com.hermesandroid.relay.network.RealtimeVoiceSummary
 import com.hermesandroid.relay.network.RealtimeVoiceEvent
 import com.hermesandroid.relay.network.VoiceHandoffEvent
 import com.hermesandroid.relay.network.handlers.LocalDispatchResult
@@ -401,8 +404,28 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     private var voicePreferencesJob: Job? = null
     private var voiceEngineMode: VoiceEngineMode = VoiceEngineMode.HermesVoiceOutput
     private var realtimeTraceDetails: Boolean = false
+    private var realtimePersistentSession: Boolean = true
     private var realtimeAgentControl: RealtimeAgentSessionControl? = null
     private var realtimeConfirmationControl: RealtimeAgentSessionControl? = null
+
+    // === Persistent realtime-agent session (one socket across turns) ===
+    // The long-lived call to RelayVoiceClient.runRealtimeAgent(persistent) runs
+    // in realtimeSessionJob; further utterances are fed on realtimeTurnChannel.
+    // The per-turn event holders below are hoisted to fields so the single
+    // session-lived event callback can serve every turn; submitRealtimeTurn /
+    // the open path reset them at each turn boundary.
+    private var realtimeSessionJob: Job? = null
+    private var realtimeTurnChannel: kotlinx.coroutines.channels.Channel<RealtimeTurnInput>? = null
+    private var rtUserText: String = ""
+    private var rtAssistantMessageId: String = ""
+    private var rtConversationContext: List<RealtimeConversationContextMessage> = emptyList()
+    private val audioSeen = AtomicBoolean(false)
+    private val audioBytes = AtomicInteger(0)
+    private val bargeInStarted = AtomicBoolean(false)
+    private val lastRealtimeAudioEventId = AtomicLong(0L)
+    private var responseText = StringBuilder()
+    private var inputTranscript = StringBuilder()
+    private val spokenStatusKeys = mutableSetOf<String>()
     private var voiceRelayPreflight: (suspend () -> Result<Unit>)? = null
 
     // === PHASE3-voice-intents: voice→bridge intent routing ===
@@ -826,8 +849,18 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                                 "realtimeTraceDetails=${settings.realtimeTraceDetails}",
                         )
                     }
+                    // Switching engine away from Realtime Agent (or disabling the
+                    // persistent toggle) must drop any open persistent session.
+                    if (
+                        (voiceEngineMode == VoiceEngineMode.RealtimeAgent &&
+                            nextEngineMode != VoiceEngineMode.RealtimeAgent) ||
+                        (realtimePersistentSession && !settings.realtimePersistentSession)
+                    ) {
+                        closeRealtimeSession()
+                    }
                     voiceEngineMode = nextEngineMode
                     realtimeTraceDetails = settings.realtimeTraceDetails
+                    realtimePersistentSession = settings.realtimePersistentSession
                     val mode = when (settings.interactionMode.lowercase()) {
                         "hold" -> InteractionMode.HoldToTalk
                         "continuous" -> InteractionMode.Continuous
@@ -1083,6 +1116,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         // Chime BEFORE teardown — AudioTrack release would cut it off otherwise.
         try { sfxPlayer?.playExit() } catch (_: Exception) { /* ignore */ }
         cancelRealtimeAgentTurn("exit voice mode")
+        closeRealtimeSession()
         // B4: tear down the barge-in listener + timers before we kill the
         // player so AEC doesn't try to track a released audio session.
         stopBargeInListener()
@@ -1755,6 +1789,31 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                     responseText = "",
                 )
             }
+            if (realtimePersistentSession) {
+                // Persistent conversation: one socket across turns. Open lazily on
+                // the first turn (the long-lived call runs in realtimeSessionJob),
+                // then feed further utterances on the channel. Fallback to one-shot
+                // if the toggle is off (Voice Settings).
+                if (realtimeSessionJob?.isActive == true && realtimeTurnChannel != null) {
+                    submitRealtimeTurn(chatVm, inputPcm, inputSampleRate)
+                } else {
+                    closeRealtimeSession()
+                    realtimeTurnChannel = kotlinx.coroutines.channels.Channel(
+                        kotlinx.coroutines.channels.Channel.UNLIMITED,
+                    )
+                    realtimeSessionJob = viewModelScope.launch {
+                        runRealtimeAgentTurn(
+                            client = client,
+                            chatVm = chatVm,
+                            userText = "",
+                            inputPcm = inputPcm,
+                            inputSampleRate = inputSampleRate,
+                            persistentOpen = true,
+                        )
+                    }
+                }
+                return
+            }
             runRealtimeAgentTurn(
                 client = client,
                 chatVm = chatVm,
@@ -2019,6 +2078,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         userText: String,
         inputPcm: ByteArray,
         inputSampleRate: Int,
+        persistentOpen: Boolean = false,
     ) {
         providerRealtimeAgentTurnActive.set(true)
         streamObserverJob?.cancel()
@@ -2046,19 +2106,23 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             )
         }
 
-        val conversationContext = chatVm.realtimeAgentContextMessages()
-        val assistantMessageId = chatVm.startRealtimeAgentTurn(
+        // Per-turn event state is hoisted to fields so one session-lived callback
+        // serves every turn in persistent mode; reset them for this turn.
+        audioSeen.set(false)
+        audioBytes.set(0)
+        bargeInStarted.set(false)
+        lastRealtimeAudioEventId.set(0L)
+        responseText = StringBuilder()
+        inputTranscript = StringBuilder()
+        spokenStatusKeys.clear()
+        rtUserText = userText
+        rtConversationContext = chatVm.realtimeAgentContextMessages()
+        rtAssistantMessageId = chatVm.startRealtimeAgentTurn(
             userText = userText,
             chatSessionId = chatVm.currentSessionId.value,
         )
+        val conversationContext = rtConversationContext
         val pcmPlayer = realtimePcmPlayer
-        val audioSeen = AtomicBoolean(false)
-        val audioBytes = AtomicInteger(0)
-        val bargeInStarted = AtomicBoolean(false)
-        val lastRealtimeAudioEventId = AtomicLong(0L)
-        val responseText = StringBuilder()
-        val inputTranscript = StringBuilder()
-        val spokenStatusKeys = mutableSetOf<String>()
 
         fun emitStatus(
             key: String,
@@ -2120,10 +2184,12 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                 chatSessionId = chatVm.currentSessionId.value,
                 conversationContext = conversationContext,
                 onHandoff = ::recordVoiceHandoff,
+                turnInputs = if (persistentOpen) realtimeTurnChannel else null,
+                onTurnComplete = { summary -> onRealtimeTurnComplete(summary) },
             ) { event, control ->
                 realtimeAgentControl = control
                 chatVm.applyRealtimeAgentEvent(
-                    assistantMessageId = assistantMessageId,
+                    assistantMessageId = rtAssistantMessageId,
                     event = event,
                     showDetailedTrace = realtimeTraceDetails,
                 )
@@ -2134,13 +2200,13 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                         it.copy(
                             state = VoiceState.Listening,
                             outputAudioActive = false,
-                            transcribedText = inputTranscript.toString().ifBlank { userText },
+                            transcribedText = inputTranscript.toString().ifBlank { rtUserText },
                         )
                     }
                 }
                 "voice.input_transcript.final" -> {
                     inputTranscript.clear()
-                    inputTranscript.append(event.text ?: userText)
+                    inputTranscript.append(event.text ?: rtUserText)
                     _uiState.update {
                         it.copy(
                             state = VoiceState.Thinking,
@@ -2399,7 +2465,76 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             title = "Realtime voice turn failed",
             detail = err?.message ?: "Unknown error",
         )
+        // A persistent session ending in error must drop so the next turn opens
+        // a fresh one rather than submitting into a dead channel.
+        closeRealtimeSession()
         surfaceError(err, context = "voice_config")
+    }
+
+    /**
+     * Per-turn completion in a persistent realtime session (ADR follow-up). The
+     * socket stays open; this just finalizes the spoken turn and re-arms
+     * continuous listening if enabled.
+     */
+    private fun onRealtimeTurnComplete(summary: RealtimeVoiceSummary) {
+        DiagnosticsLog.record(
+            category = DiagnosticCategory.Voice,
+            severity = DiagnosticSeverity.Info,
+            title = "Realtime voice turn complete",
+        )
+        Log.i(
+            TAG,
+            "Realtime persistent turn complete provider=${summary.provider} " +
+                "audioChunks=${summary.audioChunks}",
+        )
+        pendingInTtsQueue.set(0)
+        maybeAutoResume()
+    }
+
+    /**
+     * Submit a follow-up utterance onto the already-open persistent session
+     * (turns 2+). Mirrors the per-turn reset the open path does for turn 1.
+     */
+    private fun submitRealtimeTurn(chatVm: ChatViewModel, inputPcm: ByteArray, inputSampleRate: Int) {
+        val channel = realtimeTurnChannel ?: return
+        drainQueuedLocalTts()
+        try { player?.stop() } catch (_: Exception) { /* ignore */ }
+        firstFrameWatchdogJob?.cancel(); firstFrameWatchdogJob = null
+        clearSpokenChunksState()
+        audioSeen.set(false)
+        audioBytes.set(0)
+        bargeInStarted.set(false)
+        lastRealtimeAudioEventId.set(0L)
+        responseText = StringBuilder()
+        inputTranscript = StringBuilder()
+        spokenStatusKeys.clear()
+        rtUserText = ""
+        rtConversationContext = chatVm.realtimeAgentContextMessages()
+        rtAssistantMessageId = chatVm.startRealtimeAgentTurn(
+            userText = "",
+            chatSessionId = chatVm.currentSessionId.value,
+        )
+        providerRealtimeAgentTurnActive.set(true)
+        _uiState.update {
+            it.copy(
+                state = VoiceState.Thinking,
+                outputAudioActive = false,
+                transcribedText = null,
+                responseText = "",
+            )
+        }
+        val sent = channel.trySend(RealtimeTurnInput(inputPcm, inputSampleRate)).isSuccess
+        Log.i(TAG, "Realtime persistent turn submitted sent=$sent pcmBytes=${inputPcm.size}")
+    }
+
+    /** Tear down the persistent realtime session (voice-mode exit / engine switch). */
+    private fun closeRealtimeSession() {
+        val hadSession = realtimeTurnChannel != null || realtimeSessionJob != null
+        realtimeTurnChannel?.close()
+        realtimeTurnChannel = null
+        realtimeSessionJob?.cancel()
+        realtimeSessionJob = null
+        if (hadSession) Log.i(TAG, "Realtime persistent session closed")
     }
 
     private fun realtimeToolStatusLine(toolName: String?): String {
@@ -3963,6 +4098,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
 
     override fun onCleared() {
         super.onCleared()
+        closeRealtimeSession()
         // B4: release the listener + VAD engine native resources before
         // anything else. stopBargeInListener is defensive / idempotent.
         stopBargeInListener()

--- a/docs/plans/2026-05-24-realtime-persistent-session.md
+++ b/docs/plans/2026-05-24-realtime-persistent-session.md
@@ -1,0 +1,83 @@
+# Plan: Persistent realtime-agent session (one socket across turns)
+
+> **Purpose.** Make Realtime Agent voice a *persistent conversation* instead of a
+> new session per utterance. Today each turn calls
+> `RelayVoiceClient.runRealtimeAgent()` which `createRealtimeAgentSession()`s a
+> fresh relay session + provider socket and closes it on `voice.response.done`.
+> The provider therefore has no live memory of prior turns (only relay-seeded
+> context snippets), and every turn pays session-setup latency.
+>
+> **Key finding.** This is a **client-only** change. The relay already supports
+> many turns on one socket — `_handle_provider_native_ws` loops over
+> `input_audio.append` / `input_audio.commit` / `response.create` and only tears
+> the session down when the WebSocket disconnects. `voice.response.done` is a
+> *turn* boundary, not a *session* boundary. The client is what closes the socket
+> on `voice.response.done` (`RelayVoiceClient.kt:1410`).
+
+## Design
+
+Keep one relay session + provider socket open for the lifetime of a Realtime
+Agent voice-mode session; feed each utterance as a new turn on that socket.
+
+### RelayVoiceClient
+- Add an opt-in **persistent mode** to `runRealtimeAgent` via two optional params
+  (one-shot path is byte-for-byte unchanged when they're null):
+  - `turnInputs: ReceiveChannel<RealtimeTurnInput>?` — when non-null, the call is
+    a long-lived session: after the first turn it reads further turns off the
+    channel and sends their `input_audio.append`+`commit` on the open socket.
+  - `onTurnComplete: (RealtimeVoiceSummary) -> Unit` — invoked at each
+    `voice.response.done` instead of completing+closing.
+- In persistent mode:
+  - `voice.response.done` → call `onTurnComplete`, **do not** close the socket or
+    complete `finished`.
+  - A reader coroutine drains `turnInputs` and sends each turn's PCM chunks.
+  - `finished` completes only when the channel closes (voice-mode exit) or on a
+    fatal socket/provider error.
+  - The per-turn idle/turn-limit guards in `awaitRealtimeAgentCompletion` are
+    scoped to an *active* turn only — between-turn idle is expected and must not
+    trip `REALTIME_AGENT_IDLE_TIMEOUT_MS`.
+- `RealtimeTurnInput(inputPcm, sampleRate, prompt)` data class.
+
+### VoiceViewModel
+- Hold a `realtimeLiveSession` (the persistent call's `Job` + the
+  `SendChannel<RealtimeTurnInput>`), opened lazily on the first Realtime Agent
+  turn and reused for subsequent turns.
+- Per utterance: instead of a fresh `runRealtimeAgentTurn`, do the per-turn UI
+  setup (state reset, watchdog, `chatVm.startRealtimeAgentTurn`) and
+  `realtimeLiveSession.submit(RealtimeTurnInput(...))`.
+- Close the session (`channel.close()` + cancel job) on `exitVoiceMode`, engine
+  switch away from Realtime Agent, and `onCleared`.
+- The continuous event callback (the `when(event.type)` block) is registered once
+  for the session and handles every turn's events.
+
+### Fallback flag (risk control)
+- `VoicePreferences.realtimePersistentSession` (default **true**). When false,
+  fall back to the current one-shot `runRealtimeAgentTurn` path. Lets the user
+  flip back on-device without a rebuild if the persistent path misbehaves.
+
+## Non-Goals
+- No relay changes (the relay already supports multi-turn sockets).
+- No change to the one-shot path used by the Voice Lab / stable engine.
+- Not changing barge-in semantics beyond keeping them working per turn.
+
+## Risks / must-validate-on-device
+- Feeding new input while a prior turn's audio is still draining (barge-in vs.
+  new turn). Mitigation: reuse existing barge-in/cancel before submitting a turn.
+- Per-turn UI state resets must not tear down the shared session.
+- Between-turn idle must not trip the stall timeout.
+- Provider/relay session longevity across long pauses (the socket stays open, so
+  no resume-TTL dependency — but confirm providers don't idle-close; see ADR 33
+  Phase 0 `hold-floor-ok`).
+
+## Test strategy
+- Unit-test the pure pieces: `RealtimeTurnInput` chunking, the persistent-vs-
+  one-shot branch decision, idle-guard gating by active-turn.
+- On-device (post-merge, by Bailey): multi-turn conversation with follow-up
+  references ("what did you just say?"), background promotion mid-conversation,
+  barge-in, exit/re-enter voice mode, engine switch.
+
+## Key Files
+- `app/src/main/kotlin/com/hermesandroid/relay/network/RelayVoiceClient.kt`
+- `app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt`
+- `app/src/main/kotlin/com/hermesandroid/relay/data/VoicePreferences.kt`
+- `docs/relay-protocol.md` (note: turn vs. session boundary)


### PR DESCRIPTION
Realtime Agent voice kept creating a fresh provider session per utterance (`resume=false` new socket each turn), so the provider had no live memory across turns. This keeps **one session/socket open across turns** so the provider retains the conversation.

**Client-only** — the relay already supports multiple turns on one socket (`_handle_provider_native_ws` loops over `input_audio`/`commit`/`response`; `voice.response.done` is a turn boundary, not a session boundary).

## What's here
- **RelayVoiceClient**: opt-in persistent mode on `runRealtimeAgent` (new `turnInputs` channel + `onTurnComplete`). Socket stays open; subsequent `RealtimeTurnInput`s sent with monotonic chunk ids; idle/turn guards scoped to an active turn; ends when the channel closes. One-shot path unchanged when `turnInputs=null`.
- **VoiceViewModel**: opens the session on the first turn (in `realtimeSessionJob`), feeds further turns on the channel; per-turn event state hoisted to fields for the session-lived callback; `closeRealtimeSession` on exit / engine switch / onCleared / error.
- **Fallback flag**: `VoicePreferences.realtimePersistentSession` (default on) + a **Voice Settings → Realtime Agent → Persistent session** toggle → falls back to the legacy one-shot path with no rebuild.

Plan: `docs/plans/2026-05-24-realtime-persistent-session.md`.

## Testing
- Compiles clean locally (`compileSideloadDebugKotlin`); CI runs lint/test/build.
- **Needs on-device validation** (per the flag-guarded plan): multi-turn follow-up references, barge-in, background promotion mid-conversation, exit/re-enter, engine switch. Flag falls back to one-shot if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)