### PR TITLE
fix(voice): classify realtime voice.error for a clear, actionable message

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -2424,19 +2424,22 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                 }
                 "voice.error" -> {
                     realtimeConfirmationControl = null
+                    val rawDetail = event.message ?: "Realtime agent failed"
                     DiagnosticsLog.record(
                         category = DiagnosticCategory.Voice,
                         severity = DiagnosticSeverity.Error,
                         title = "Realtime voice error",
-                        detail = event.message ?: "Realtime agent failed",
+                        detail = rawDetail,
                     )
-                    _uiState.update {
-                        it.copy(
-                            state = VoiceState.Error,
-                            error = event.message ?: "Realtime agent failed",
-                            hermesConfirmation = null,
-                        )
-                    }
+                    _uiState.update { it.copy(hermesConfirmation = null) }
+                    // Route the raw relay message through the classifier so
+                    // provider-auth (and other) failures surface a clear,
+                    // actionable message + a Voice-settings snackbar action
+                    // instead of a raw "xAI Realtime auth ..." provider string.
+                    surfaceError(
+                        java.io.IOException(rawDetail),
+                        context = "voice_config",
+                    )
                 }
                 }
             }


### PR DESCRIPTION
When a realtime turn hit a relay-side `voice.error` (e.g. the xAI provider auth expiring), the overlay showed the **raw** provider string. This routes the in-stream `voice.error` through the existing `surfaceError` → `classifyError("voice_config")` path — the same one the result-failure path already uses — so the user gets:

- a clear banner: *"Realtime provider auth unavailable — refresh provider auth on the relay or choose another provider"*,
- a one-shot snackbar via `errorEvents` with a **Voice settings** action,

instead of `xAI Realtime auth is not configured ...`. Raw detail still goes to the Diagnostics log. The classifier already had the mapping (covered by `RelayErrorClassifierTest`); this just wires the realtime in-stream path to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)