### PR TITLE
fix(android): read ExoPlayer audio session id on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Provider idle-tolerance probe.** `scripts/realtime-provider-idle-probe.py` records a per-provider verdict (hold-floor-ok / needs-keepalive / must-reopen) for holding a realtime socket quiescent during a background run; see `docs/realtime-voice-poc.md`.
 
+### Fixed
+
+- **Voice mode crash with barge-in on legacy TTS playback.** When barge-in was enabled and the relay served audio over the legacy `/voice/synthesize` (Media3) path, the first agent sentence played for ~2 syllables and then the app crashed with `IllegalStateException: Player is accessed on the wrong thread`. The barge-in listener's `Dispatchers.IO` reader was reading `ExoPlayer.getAudioSessionId()` (a thread-confined accessor) to attach the echo canceller. `VoicePlayer.audioSessionId` now serves a `@Volatile` cache populated from main-thread Media3 callbacks, so it is safe to read from any thread.
+
 ## [0.8.0] - 2026-05-23
 
 ### Added

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,19 @@
 # Hermes-Relay — Dev Log
 
+## 2026-05-26 — Fix voice-mode crash: ExoPlayer audio session id read off-main (barge-in + legacy TTS)
+
+**Report.** Discord user, sideload latest: voice chat crashes the instant Hermes starts answering — "I hear just 2 letters and it crashes." Stack: `IllegalStateException: Player is accessed on the wrong thread. Current thread: 'DefaultDispatcher-worker-4', Expected thread: 'main'` with the Media3 `player-accessed-on-wrong-thread` doc link and a `Suppressed: ... Dispatchers.IO`.
+
+**Root cause.** `Dispatchers.IO` threads are named `DefaultDispatcher-worker-N` (IO and Default share one scheduler pool), so the crash is on an IO coroutine. `BargeInListener` runs its mic reader on `Dispatchers.IO` and, to attach `AcousticEchoCanceler`, polls an `audioSessionIdProvider` lambda. On the **legacy `/voice/synthesize` (Media3) playback path**, `VoiceViewModel` wires that provider to `{ player.audioSessionId }` → `exoPlayer.audioSessionId`. ExoPlayer is thread-confined; its `getAudioSessionId()` getter calls `verifyApplicationThread()` and throws when read off-main. The realtime PCM path is unaffected because it wires the provider to an `AudioTrack` session id (thread-safe), which is why the bug only hit legacy/fallback setups. Sequence: first sentence starts → `runPlayWorker.onFileReady` → `startBargeInListenerIfEnabled()` → IO reader → `awaitNonZeroSessionId()` → off-main getter → crash ~2 syllables in.
+
+**Fix.** `VoicePlayer.audioSessionId` now serves a `@Volatile cachedAudioSessionId` instead of the raw thread-confined getter. The cache is populated from main-thread Media3 callbacks: an `AnalyticsListener.onAudioSessionIdChanged` hook (authoritative, fires when Media3 allocates/reallocates the AudioTrack) plus a belt-and-braces read inside the existing `onIsPlayingChanged`. Reads from any thread are now safe.
+
+**Tests.** Added `VoicePlayerTest` coverage: getter reflects the analytics-listener-cached id, never re-invokes `exoPlayer.audioSessionId` (the off-main call), and defaults to 0 before allocation. Captured the `AnalyticsListener` in the MockK harness. Verified locally: `:app:lintGooglePlayDebug` + `:app:testGooglePlayDebugUnitTest --tests VoicePlayerTest` both green (BUILD SUCCESSFUL).
+
+**Next.** Branch `fix/voice-barge-in-wrong-thread` off `dev`, PR to `dev`.
+
+---
+
 ## 2026-05-24 — Background Hermes runs in Realtime Agent voice (ADR 33)
 
 **Context.** Realtime Agent ran each Hermes turn synchronously *inside* the provider event pump (`_run_brokered_tool` did `return await task`), so a long research/multi-tool/desktop run froze the whole realtime session until it finished. ADR 33 + `docs/plans/2026-05-24-realtime-background-hermes-runs.md` define a three-tier model (foreground / promoted / durable) with the relay as an explicit audio-floor owner. Branch `feature/realtime-background-hermes-runs`.

--- a/app/src/main/kotlin/com/hermesandroid/relay/audio/VoicePlayer.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/audio/VoicePlayer.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -83,9 +84,33 @@ class VoicePlayer(
     private var visualizer: Visualizer? = null
     private var visualizerAttached = false
 
+    // Thread-safe mirror of [ExoPlayer.getAudioSessionId]. ExoPlayer is
+    // thread-confined — every accessor (the audioSessionId getter included)
+    // calls verifyApplicationThread() and throws "Player is accessed on the
+    // wrong thread" if touched off the player's construction thread. The
+    // barge-in pipeline reads [audioSessionId] from BargeInListener's
+    // Dispatchers.IO reader coroutine to attach AcousticEchoCanceler, so we
+    // can't expose the raw getter. Instead we cache the id from the
+    // main-thread Media3 callbacks below and serve the getter from this
+    // @Volatile field. (Fixes the legacy-TTS + barge-in crash where the
+    // first sentence played for ~2 syllables before the IO read threw.)
+    @Volatile private var cachedAudioSessionId: Int = 0
+
     private val exoPlayer: ExoPlayer = exoPlayerFactory(context.applicationContext)
 
     init {
+        // AnalyticsListener callbacks are delivered on the player's
+        // application (main) thread, so caching the id here is the
+        // authoritative, thread-correct way to track it as Media3 allocates
+        // and reallocates the underlying AudioTrack.
+        exoPlayer.addAnalyticsListener(object : AnalyticsListener {
+            override fun onAudioSessionIdChanged(
+                eventTime: AnalyticsListener.EventTime,
+                audioSessionId: Int,
+            ) {
+                cachedAudioSessionId = audioSessionId
+            }
+        })
         exoPlayer.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 _isPlaying.value = isPlaying
@@ -94,8 +119,16 @@ class VoicePlayer(
                 // actually begins — the audio session id is stable from
                 // player construction on Media3 1.x but some OEM pipelines
                 // don't allocate the track until playback starts.
-                if (isPlaying && !visualizerAttached) {
-                    attachVisualizer(exoPlayer.audioSessionId)
+                if (isPlaying) {
+                    // Belt-and-braces with the analytics listener above: this
+                    // runs on the main thread too, so reading the getter here
+                    // is safe and guarantees the cache is warm by the time
+                    // playback is audible (and thus by the time barge-in
+                    // starts its IO reader).
+                    cachedAudioSessionId = exoPlayer.audioSessionId
+                    if (!visualizerAttached) {
+                        attachVisualizer(cachedAudioSessionId)
+                    }
                 }
             }
 
@@ -211,13 +244,20 @@ class VoicePlayer(
      * poll this property briefly rather than assume it's hot-ready at
      * [VoicePlayer] construction time.
      *
-     * Exposed read-only. Internally the same id drives the Visualizer
-     * attach logic in [attachVisualizer]; B4 reads it via a provider
-     * lambda so the listener can re-check across the 1 s poll window
-     * without holding a stale reference.
+     * **Thread-safe.** Backed by [cachedAudioSessionId] rather than the raw
+     * `ExoPlayer.getAudioSessionId()` getter, because ExoPlayer is
+     * thread-confined and [BargeInListener] reads this from its
+     * `Dispatchers.IO` reader coroutine. Reading the raw getter off-main
+     * throws `IllegalStateException: Player is accessed on the wrong thread`.
+     * The cache is populated from main-thread Media3 callbacks (the
+     * [AnalyticsListener.onAudioSessionIdChanged] hook and `onIsPlayingChanged`).
+     *
+     * Exposed read-only. B4 reads it via a provider lambda so the listener
+     * can re-check across the 1 s poll window without holding a stale
+     * reference.
      */
     val audioSessionId: Int
-        get() = exoPlayer.audioSessionId
+        get() = cachedAudioSessionId
 
     /**
      * Set the playback volume of the underlying ExoPlayer.

--- a/app/src/test/kotlin/com/hermesandroid/relay/audio/VoicePlayerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/audio/VoicePlayerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -72,6 +73,7 @@ class VoicePlayerTest {
     private lateinit var context: Context
     private lateinit var exoPlayer: ExoPlayer
     private var listener: Player.Listener? = null
+    private var analyticsListener: AnalyticsListener? = null
 
     // Mirrors the real ExoPlayer's counter so the test's view and the
     // VoicePlayer's view agree without having to drive every listener
@@ -97,6 +99,14 @@ class VoicePlayerTest {
         val listenerSlot = slot<Player.Listener>()
         every { exoPlayer.addListener(capture(listenerSlot)) } answers {
             listener = listenerSlot.captured
+        }
+
+        // Capture the AnalyticsListener too — VoicePlayer registers one to
+        // mirror the audio session id onto the main thread (the barge-in
+        // wrong-thread crash fix).
+        val analyticsSlot = slot<AnalyticsListener>()
+        every { exoPlayer.addAnalyticsListener(capture(analyticsSlot)) } answers {
+            analyticsListener = analyticsSlot.captured
         }
 
         // Queue + state inspection read from the fake counters so the
@@ -139,6 +149,7 @@ class VoicePlayerTest {
     fun tearDown() {
         unmockkAll()
         listener = null
+        analyticsListener = null
         fakeMediaItemCount = 0
         fakeIsPlaying = false
         fakePlaybackState = Player.STATE_IDLE
@@ -226,5 +237,34 @@ class VoicePlayerTest {
 
         verify { exoPlayer.volume = 1.0f }
         assertEquals(1.0f, fakeVolume, 0.0001f)
+    }
+
+    @Test
+    fun `audioSessionId is served from the cached id, not the thread-confined getter`() {
+        // Regression: ExoPlayer is thread-confined, so reading
+        // exoPlayer.audioSessionId off the main thread (BargeInListener's
+        // Dispatchers.IO reader) throws "Player is accessed on the wrong
+        // thread" and crashed voice mode mid-playback. The getter must read
+        // a cached value instead — populated from main-thread callbacks.
+        val voicePlayer = VoicePlayer(context) { exoPlayer }
+
+        // Media3 reports a freshly-allocated session id on the main thread.
+        analyticsListener?.onAudioSessionIdChanged(mockk(relaxed = true), 42)
+
+        assertEquals(42, voicePlayer.audioSessionId)
+
+        // Reading the property again must not touch the raw ExoPlayer getter
+        // (that's the off-main call that throws). The only legitimate read of
+        // exoPlayer.audioSessionId happens inside onIsPlayingChanged on the
+        // main thread, which this test never triggers.
+        voicePlayer.audioSessionId
+        voicePlayer.audioSessionId
+        verify(exactly = 0) { exoPlayer.audioSessionId }
+    }
+
+    @Test
+    fun `audioSessionId defaults to zero before any session is allocated`() {
+        val voicePlayer = VoicePlayer(context) { exoPlayer }
+        assertEquals(0, voicePlayer.audioSessionId)
     }
 }


### PR DESCRIPTION
## Problem

Discord report (sideload, latest): voice chat crashes the instant Hermes starts replying — *"I hear just 2 letters and it crashes."*

```
java.lang.IllegalStateException: Player is accessed on the wrong thread.
Current thread: 'DefaultDispatcher-worker-4'
Expected thread: 'main'
```

## Root cause

- `Dispatchers.IO` threads are named `DefaultDispatcher-worker-N` (IO and Default share one `CoroutineScheduler` pool), so the crash is on an **IO coroutine** — confirmed by the `Suppressed: ... Dispatchers.IO` in the trace.
- Every `ExoPlayer` accessor is **thread-confined**, including the `getAudioSessionId()` getter — it calls `verifyApplicationThread()` and throws off-main.
- `BargeInListener` runs its mic reader on `Dispatchers.IO` and polls an `audioSessionIdProvider` lambda to attach `AcousticEchoCanceler`. On the **legacy `/voice/synthesize` (Media3) playback path**, `VoiceViewModel` wires that to `{ player.audioSessionId }` → `exoPlayer.audioSessionId`, read off-main → crash.
- The realtime PCM path was immune: it provides an `AudioTrack` session id (thread-safe). That's why this only bit legacy/fallback setups with barge-in enabled.

Sequence: first sentence starts → `runPlayWorker.onFileReady` → `startBargeInListenerIfEnabled()` → IO reader → `awaitNonZeroSessionId()` → off-main getter → crash ~2 syllables in.

## Fix

`VoicePlayer.audioSessionId` now serves a `@Volatile cachedAudioSessionId` instead of the raw thread-confined getter. The cache is populated from main-thread Media3 callbacks:
- `AnalyticsListener.onAudioSessionIdChanged` (authoritative — fires when Media3 allocates/reallocates the AudioTrack)
- a belt-and-braces read inside the existing `onIsPlayingChanged`

Safe to read from any thread.

## Tests

Added `VoicePlayerTest` coverage: the getter reflects the analytics-listener-cached id, never re-invokes `exoPlayer.audioSessionId`, and defaults to `0` before allocation. Captured the `AnalyticsListener` in the MockK harness.

Verified locally: `:app:lintGooglePlayDebug` + `:app:testGooglePlayDebugUnitTest --tests VoicePlayerTest` → **BUILD SUCCESSFUL**, 0 lint errors.

## Tracking

Reaches `main` via the release-merge tracking PR #61 (`dev` → `main`), to be merged at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
