### PR TITLE
feat(android): prefer upstream skills endpoint

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,15 @@
 # Hermes-Relay — Dev Log
 
+## 2026-06-05 — Prefer upstream `/v1/skills` with legacy fallback
+
+**Context.** Upstream Hermes Agent now has baseline skill/session API surface area, while Axiom's fork still preserves richer Relay-specific `/api/*` compatibility routes. The Android client should begin consuming upstream-compatible skill listings when present without breaking older fork/bootstrap installs.
+
+**What changed.** `HermesApiClient.getSkills()` now tries `/v1/skills` first, then falls back to `/api/skills`. Skill parsing accepts upstream OpenAI-style list envelopes (`{"object":"list","data":[...]}`), legacy fork envelopes (`{"skills":[...]}` / `{"items":[...]}`), and direct arrays.
+
+**Verification.** Added pure Kotlin unit coverage for endpoint order and `/v1/skills` `data` parsing. Verified with `ANDROID_HOME=$HOME/Android/Sdk ./gradlew :app:testGooglePlayDebugUnitTest --tests 'com.hermesandroid.relay.network.HermesApiClientTest'` → BUILD SUCCESSFUL. `git diff --check` passes.
+
+---
+
 ## 2026-05-26 — Fix voice-mode crash: ExoPlayer audio session id read off-main (barge-in + legacy TTS)
 
 **Report.** Discord user, sideload latest: voice chat crashes the instant Hermes starts answering — "I hear just 2 letters and it crashes." Stack: `IllegalStateException: Player is accessed on the wrong thread. Current thread: 'DefaultDispatcher-worker-4', Expected thread: 'main'` with the Media3 `player-accessed-on-wrong-thread` doc link and a `Suppressed: ... Dispatchers.IO`.

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/HermesApiClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/HermesApiClient.kt
@@ -99,6 +99,24 @@ data class ServerCapabilities(
     }
 }
 
+internal val HERMES_SKILL_ENDPOINTS = listOf("/v1/skills", "/api/skills")
+
+internal fun parseSkillListBody(json: Json, body: String): List<SkillInfo>? {
+    try {
+        val parsed = json.decodeFromString<SkillListResponse>(body)
+        val skills = parsed.skills ?: parsed.items ?: parsed.data
+        if (skills != null) return skills
+    } catch (_: Exception) {
+        // Fall through to direct-array compatibility below.
+    }
+
+    try {
+        return json.decodeFromString<List<SkillInfo>>(body)
+    } catch (_: Exception) {
+        return null
+    }
+}
+
 /**
  * Direct HTTP/SSE client for the Hermes API Server.
  *
@@ -342,27 +360,21 @@ class HermesApiClient(
     // --- Skills ---
 
     suspend fun getSkills(): List<SkillInfo> = withContext(Dispatchers.IO) {
-        try {
-            val request = authRequest("$baseUrl/api/skills").get().build()
-            client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return@withContext emptyList()
-                val body = response.body?.string() ?: return@withContext emptyList()
-                // Try structured response: { "skills": [...] } or { "items": [...] }
-                try {
-                    val parsed = json.decodeFromString<SkillListResponse>(body)
-                    val skills = parsed.skills ?: parsed.items
+        for (endpoint in HERMES_SKILL_ENDPOINTS) {
+            try {
+                val request = authRequest("$baseUrl$endpoint").get().build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use
+                    val body = response.body?.string() ?: return@use
+                    val skills = parseSkillListBody(json, body)
                     if (skills != null) return@withContext skills
-                } catch (_: Exception) { /* fall through */ }
-                // Try direct array: [...]
-                try {
-                    return@withContext json.decodeFromString<List<SkillInfo>>(body)
-                } catch (_: Exception) { /* fall through */ }
-                emptyList()
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to fetch skills from $endpoint: ${e.message}")
             }
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to fetch skills: ${e.message}")
-            emptyList()
         }
+
+        emptyList()
     }
 
     // --- Server personalities ---

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/models/SessionModels.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/models/SessionModels.kt
@@ -300,5 +300,6 @@ data class SkillInfo(
 @Serializable
 data class SkillListResponse(
     val skills: List<SkillInfo>? = null,
-    val items: List<SkillInfo>? = null
+    val items: List<SkillInfo>? = null,
+    val data: List<SkillInfo>? = null
 )

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/HermesApiClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/HermesApiClientTest.kt
@@ -1,5 +1,7 @@
 package com.hermesandroid.relay.network
 
+import com.hermesandroid.relay.network.models.SkillListResponse
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -218,6 +220,46 @@ class HermesApiClientTest {
         val baseUrl = "http://localhost:8642"
         val url = "$baseUrl/v1/models"
         assertEquals("http://localhost:8642/v1/models", url)
+    }
+
+    // --- Skills endpoint compatibility ---
+
+    @Test
+    fun skillEndpointOrder_prefersUpstreamV1ThenLegacyApiFallback() {
+        assertEquals(listOf("/v1/skills", "/api/skills"), HERMES_SKILL_ENDPOINTS)
+    }
+
+    @Test
+    fun skillListResponse_parsesUpstreamV1DataEnvelope() {
+        val body = """
+            {
+                "object": "list",
+                "data": [
+                    {"name": "android", "description": "Control phone", "category": "android"}
+                ]
+            }
+        """.trimIndent()
+
+        val parsed = Json { ignoreUnknownKeys = true }.decodeFromString<SkillListResponse>(body)
+
+        assertEquals(1, parsed.data?.size)
+        assertEquals("android", parsed.data?.first()?.name)
+    }
+
+    @Test
+    fun parseSkillListBody_acceptsUpstreamV1DataEnvelope() {
+        val body = """
+            {
+                "object": "list",
+                "data": [
+                    {"name": "android", "description": "Control phone", "category": "android"}
+                ]
+            }
+        """.trimIndent()
+
+        val parsed = parseSkillListBody(Json { ignoreUnknownKeys = true }, body)
+
+        assertEquals(listOf("android"), parsed?.map { it.name })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Prefer upstream-compatible `/v1/skills` before falling back to legacy `/api/skills`.
- Accept upstream OpenAI-style skill envelopes with `data: [...]` alongside existing `skills`, `items`, and direct-array responses.
- Add regression coverage for endpoint order and `/v1/skills` data parsing.
- Record the deprecation/migration step in `DEVLOG.md`.

## Test Plan
- Initial plain Gradle run reproduced the environment blocker: `SDK location not found` without `ANDROID_HOME`.
- `ANDROID_HOME=$HOME/Android/Sdk ./gradlew :app:testGooglePlayDebugUnitTest --tests 'com.hermesandroid.relay.network.HermesApiClientTest'` — BUILD SUCCESSFUL.
- `git diff --check`

## Notes
This is the client-side half of the API cleanup: Relay can start using upstream baseline skill listing where available while preserving compatibility with older fork/bootstrap installs that only expose `/api/skills`.
