### PR TITLE
fix(ci): unblock Claude review for bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,11 @@ jobs:
       # alone — a title-format match (e.g. "release:") is fragile and silently
       # let a "Release v1.0.0 …"-titled PR run the full review and time out.
       IS_RELEASE_PR: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev' }}
+      # Bot-authored PRs such as Dependabot do not receive the same secret
+      # surface as human-authored PRs, and Claude Code rejects bot actors unless
+      # explicitly allow-listed. Keep the required check green with a no-op and
+      # rely on the dependency CI/status checks for those PRs.
+      IS_BOT_PR: ${{ github.event.pull_request.user.type == 'Bot' }}
 
     steps:
       - name: Skip aggregate release PR review
@@ -38,14 +43,40 @@ jobs:
           echo "Skipping Claude Code Review for aggregate dev -> main release PR."
           echo "Feature work is reviewed before it lands on dev; release PRs are gated by CI and release metadata checks."
 
+      - name: Skip bot-authored PR review
+        if: env.IS_BOT_PR == 'true'
+        run: |
+          echo "Skipping Claude Code Review for bot-authored PR."
+          echo "Bot PRs are gated by Required checks plus their path-specific CI jobs."
+
       - name: Checkout repository
-        if: env.IS_RELEASE_PR != 'true'
+        if: env.IS_RELEASE_PR != 'true' && env.IS_BOT_PR != 'true'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # Depth 2 includes the pull_request merge commit's first parent, which
+          # lets the next step detect whether this PR changes the workflow file.
+          fetch-depth: 2
+
+      - name: Detect Claude review workflow changes
+        if: env.IS_RELEASE_PR != 'true' && env.IS_BOT_PR != 'true'
+        id: changed-workflow
+        shell: bash
+        run: |
+          if git rev-parse --verify HEAD^1 >/dev/null 2>&1 &&
+             git diff --name-only HEAD^1 HEAD | grep -Fxq ".github/workflows/claude-code-review.yml"; then
+            echo "claude_review_workflow=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "claude_review_workflow=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Claude review workflow self-change
+        if: env.IS_RELEASE_PR != 'true' && env.IS_BOT_PR != 'true' && steps.changed-workflow.outputs.claude_review_workflow == 'true'
+        run: |
+          echo "Skipping Claude Code Review because this PR changes the review workflow itself."
+          echo "The Claude action requires this workflow file to match the default branch before it can exchange the app token."
 
       - name: Run Claude Code Review
-        if: env.IS_RELEASE_PR != 'true'
+        if: env.IS_RELEASE_PR != 'true' && env.IS_BOT_PR != 'true' && steps.changed-workflow.outputs.claude_review_workflow != 'true'
         timeout-minutes: 15
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,13 @@
 # Hermes-Relay — Dev Log
 
+## 2026-06-15 — Claude review required check and Dependabot PR cleanup
+
+**Why.** Open Dependabot PRs targeting `main` were blocked by the required `claude-review` check. Re-running a current Dependabot PR showed the Claude GitHub App token exchange succeeds, but `anthropics/claude-code-action` stops before review because the actor is `dependabot[bot]` and bot actors are not allow-listed. Dependabot-triggered runs also do not expose the same secret surface as human-authored PRs, so forcing Claude review on those PRs is the wrong gate.
+
+- **Workflow fix.** `.github/workflows/claude-code-review.yml` now detects bot-authored PRs with `github.event.pull_request.user.type == 'Bot'` and emits a passing no-op `claude-review` job. Human-authored PRs still run the full Claude Code Review action; aggregate `dev` -> `main` release PRs still use the existing no-op skip.
+- **Workflow self-change guard.** PRs that edit `claude-code-review.yml` now also no-op after checkout when the changed-file list includes that workflow. The Claude action requires the workflow file to match the default branch before app-token exchange, so workflow maintenance PRs must not invoke the action they are changing.
+- **Verification.** Confirmed `CLAUDE_CODE_OAUTH_TOKEN` was refreshed in repository secrets after Claude Code GitHub setup. Re-ran Claude Code Review on PR #46 and confirmed the current blocker was bot-actor policy, not GitHub App installation. `git diff --check` passes.
+
 ## 2026-06-14 — profile chat: turn-complete wipe + cross-transport session continuity
 
 **Why.** v1.0.0 polish (on `dev`, into release PR #61). After the per-profile session work landed, on-device testing of a non-default agent showed: a turn streamed fine (thinking + reply), then on turn-complete the chat **switched to a new/empty session** untouched; the just-finished conversation only reappeared in the drawer a moment later. Watched `adb logcat` during a repro to confirm root cause.


### PR DESCRIPTION
## Summary
- skip Claude Code Review for bot-authored PRs such as Dependabot
- skip Claude review when a PR edits the Claude review workflow itself
- keep aggregate dev -> main release PRs on the existing no-op path

## Verification
- cherry-picked the already-green dev PR fix onto a narrow main hotfix branch
- local diff check: \git diff --check origin/main..HEAD\`n
This is intentionally scoped to CI workflow behavior so the existing main-targeted Dependabot PRs can use the fixed required check without pulling unreleased dev changes into main.