### PR TITLE
fix(dashboard): remove color:inherit from form-control reset — fixes unreadable button text

### DIFF
--- a/plugin/dashboard/dist/style.css
+++ b/plugin/dashboard/dist/style.css
@@ -58,7 +58,10 @@
 .hermes-relay-plugin select,
 .hermes-relay-plugin textarea {
   font: inherit;
-  color: inherit;
+  /* color: inherit intentionally omitted — it leaks the container text colour
+     onto button backgrounds, making text unreadable when both resolve to the
+     same value (e.g. --hr-text cream on a cream-background button).
+     Each button variant controls its own colour via class utilities. */
 }
 
 .hermes-relay-plugin button {

--- a/plugin/dashboard/src/styles.css
+++ b/plugin/dashboard/src/styles.css
@@ -58,7 +58,10 @@
 .hermes-relay-plugin select,
 .hermes-relay-plugin textarea {
   font: inherit;
-  color: inherit;
+  /* color: inherit intentionally omitted — it leaks the container text colour
+     onto button backgrounds, making text unreadable when both resolve to the
+     same value (e.g. --hr-text cream on a cream-background button).
+     Each button variant controls its own colour via class utilities. */
 }
 
 .hermes-relay-plugin button {


### PR DESCRIPTION
## Summary

Removes the `color: inherit` declaration from the `.hermes-relay-plugin` form-control reset rule.

### Root cause

```css
/* before */
.hermes-relay-plugin button,
.hermes-relay-plugin input,
.hermes-relay-plugin select,
.hermes-relay-plugin textarea {
  font: inherit;
  color: inherit;   /* <-- the culprit */
}
```

On the Hermes Dashboard the `.hermes-relay-plugin` container inherits `--hr-text` (cream `#ffe6cb` in the default LENS_0 theme). `color: inherit` then forces that cream text colour onto every button, regardless of what background the button component sets — when both are cream, the text becomes invisible.

### Fix

```css
/* after */
.hermes-relay-plugin button,
.hermes-relay-plugin input,
.hermes-relay-plugin select,
.hermes-relay-plugin textarea {
  font: inherit;
  /* color: inherit omitted — leaks container text onto button bg */
}
```

`font: inherit` is sufficient for the font-stack normalisation goal. Button text colour is already handled by each button variant's own utility classes; no call site needs updating.

### Changes

- `plugin/dashboard/src/styles.css` — remove `color: inherit`, add explanatory comment
- `plugin/dashboard/dist/style.css` — rebuilt from source

Closes #71