### PR TITLE
docs: refresh skill + user docs for gateway-first chat + accurate counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Full server setup, TLS, and systemd details: [docs/relay-server.md](docs/relay-s
 
 ### Android
 
-- **Streaming chat** — direct SSE to the Hermes API server with live markdown, tool-call cards, session history, a searchable command palette, file attachments, quote-in-reply, conversation share, and send-while-streaming queuing.
+- **Streaming chat** — rides standard Hermes, preferring the dashboard gateway (`/api/ws`, live thinking) when signed in to Manage and falling back to API-server SSE otherwise, with live markdown, tool-call cards, session history, a searchable command palette, file attachments, quote-in-reply, conversation share, and send-while-streaming queuing.
 - **Manage your agent** — the full Hermes dashboard, native: switch models from your provider catalog, manage keys (write-only, masked, rate-limited reveal), create and edit profiles including `SOUL.md`, and browse/install/update skills. One dashboard sign-in covers it all.
 - **Hands-free voice** — talk on a vanilla install: speech rides your server's configured providers, unlocked by the same Manage sign-in. Relay-paired setups add per-profile voice and an opt-in provider-native Realtime Agent with background task handoff.
 - **Works away from home** — add a Tailscale or public URL and the app roams automatically (LAN at home, fallback elsewhere). An unreachable server gets a diagnosis, not just a red dot.

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -211,7 +211,7 @@ Sources: `plugin/relay/channels/bridge.py`, `app/src/main/kotlin/.../network/han
 
 ### 3.3 Chat
 
-**Note:** Chat does **not** traverse the relay. It connects directly to the Hermes API Server via HTTP/SSE.
+**Note:** Chat does **not** traverse the relay. It rides the standard upstream Hermes surfaces — the dashboard `/api/ws` gateway transport (live thinking) when Manage auth is ready, falling back to the API server's SSE routes.
 
 Relay involvement is limited to session management routes (`/api/sessions/*`) for create/list/delete/extend. See hermes-relay CLAUDE.md §"Upstream Hermes API Reference" for the endpoint catalog.
 

--- a/docs/relay-server.md
+++ b/docs/relay-server.md
@@ -14,7 +14,7 @@ The relay server is a lightweight Python service that bridges the Hermes-Relay A
 | **Terminal** | Yes | Relay session over WSS (`:8767`) |
 | **Bridge** | Yes | Relay session over WSS/HTTP (`:8767`) |
 
-If you only use chat, you do **not** need the relay server. The app connects directly to the Hermes API Server for chat, sessions, profiles, and skills. Voice endpoints live on the relay but can authenticate with the same Hermes API server key used for chat; remote-control features such as terminal, bridge, TUI, media/session management, and Android control still require relay pairing.
+If you only use chat, you do **not** need the relay server. The app rides the standard upstream Hermes surfaces — the dashboard `/api/ws` gateway (live thinking) preferred, the API server's SSE routes as fallback — for chat, sessions, profiles, and skills. Voice endpoints live on the relay but can authenticate with the same Hermes API server key used for chat; remote-control features such as terminal, bridge, TUI, media/session management, and Android control still require relay pairing.
 
 When using the dashboard's pair/repair flow, the QR still needs both credential families: top-level `key` for direct Hermes API chat/sessions, and `relay.code` for the relay session token used by voice/bridge/terminal surfaces. The relay's loopback-only `/pairing/mint` endpoint reads `API_SERVER_KEY` from the same host-local config chain as `hermes pair` when the dashboard does not explicitly pass `api_key`.
 

--- a/plugin/dashboard/README.md
+++ b/plugin/dashboard/README.md
@@ -101,12 +101,9 @@ All proxied by `plugin_api.py` under `/api/plugins/hermes-relay/`:
 - `POST /remote-access/tailscale/enable` — enable Tailscale serving
 - `POST /remote-access/tailscale/disable` — disable Tailscale serving
 
-## Hackathon submission / demo
+## Demo screenshots
 
-Submission repo: `Codename-11/hermes-relay`
-Plugin path: `plugin/dashboard/`
-
-Suggested screenshot set after deploying the pushed branch:
+A representative set when showcasing the plugin:
 
 - Management tab with paired Android and desktop sessions
 - Pairing dialog with QR code and endpoint controls

--- a/relay_server/SKILL.md
+++ b/relay_server/SKILL.md
@@ -9,11 +9,11 @@ Setup and run the Hermes-Relay Server for the Hermes-Relay Android app.
 
 ## What It Is
 
-A lightweight Python WSS server that bridges the Hermes-Relay Android app to server-side features that need persistent bidirectional communication: **terminal** (remote shell via tmux) and **bridge** (agent-driven phone control). Chat does not use the relay — it connects directly to the Hermes API Server.
+A lightweight Python WSS server that bridges the Hermes-Relay Android app to server-side features that need persistent bidirectional communication: **terminal** (remote shell via tmux) and **bridge** (agent-driven phone control). Chat does not use the relay — it rides the standard upstream Hermes surfaces (the dashboard `/api/ws` gateway, with API-server SSE as fallback).
 
 ## When You Need It
 
-- **Chat only?** You do NOT need the relay server. The app talks directly to the Hermes API Server (`:8642`).
+- **Chat only?** You do NOT need the relay server. The app uses the standard upstream Hermes surfaces — the dashboard gateway (`:9119`) preferred, the API server (`:8642`) as fallback.
 - **Terminal or Bridge?** You need the relay server running on the same machine as hermes-agent.
 
 ## Quick Setup

--- a/skills/devops/hermes-relay-desktop-setup/SKILL.md
+++ b/skills/devops/hermes-relay-desktop-setup/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # Hermes-Relay Desktop CLI Setup
 
-> **Experimental.** The desktop CLI at `desktop/` is a preview-grade thin client. Pairing, chat, shell (PTY pipe to the host), and local tool routing (`desktop_terminal` / `desktop_read_file` / `desktop_write_file` / `desktop_search_files` / `desktop_patch`) all work end-to-end. Daemon mode, multi-client routing, and code-signed binaries are the v1.0 polish — see the [ROADMAP](https://github.com/Codename-11/hermes-relay/blob/main/ROADMAP.md#desktop-track).
+> **Experimental.** The desktop CLI at `desktop/` is a preview-grade thin client. Pairing, chat, shell (PTY pipe to the host), and local tool routing (`desktop_terminal` / `desktop_read_file` / `desktop_write_file` / `desktop_search_files` / `desktop_patch`) all work end-to-end. Daemon mode, multi-client routing, and code-signed binaries are the v1.0 polish — see the [ROADMAP](https://github.com/Codename-11/hermes-relay/blob/main/ROADMAP.md#desktop-track-parallel-lane-to-android--experimental).
 
 The [Hermes-Relay](https://github.com/Codename-11/hermes-relay) desktop CLI (`hermes-relay`) is a thin client that gives you remote access to a Hermes agent running on another machine. It pipes a full PTY shell (with the agent's native Ink TUI), streams structured chat events for scripting, and — uniquely — lets the remote agent execute tools **on your local machine** (read files, run shell commands, search the filesystem) through a round-trip over the same WSS relay the Android client uses. The agent brain stays on the host; your laptop is the hands.
 
@@ -42,7 +42,7 @@ User: "Install the hermes-relay CLI"
 → User upgrades
 → [desktop_terminal] node --version   →  v22.0.1   OK
 → [desktop_terminal] npm install -g @hermes-relay/cli
-→ [desktop_terminal] hermes-relay --version   →  0.2.0   Success
+→ [desktop_terminal] hermes-relay --version   →  0.3.0-alpha.18   Success
 ```
 
 **Never guess the user's state — measure it.** `desktop_terminal` is cheap; one call per check is the right cadence.
@@ -53,7 +53,7 @@ User: "Install the hermes-relay CLI"
    ```bash
    curl -s http://<host>:8767/health
    ```
-   Expect `{"status":"ok","version":"0.6.0"}` or later. If it fails, the user's server is down — stop here and run `/hermes-relay-self-setup` or `/hermes-relay-doctor` on the host instead.
+   Expect `{"status":"ok","version":"1.1.0"}` or later. If it fails, the user's server is down — stop here and run `/hermes-relay-self-setup` or `/hermes-relay-doctor` on the host instead.
 
 2. **One of:**
    - Node.js **≥21** on this machine (for the built-in global `WebSocket`). Verify `node --version` ≥ v21. Older Node refuses to run.
@@ -126,7 +126,7 @@ Run a one-off `--version` check:
 hermes-relay --version
 ```
 
-Expect `0.2.0` or later (depending on which release is current).
+Expect `0.3.0-alpha.18` or later (depending on which release is current).
 
 If the command is not found:
 - **Windows**: open a **new** PowerShell (PATH updates don't apply retroactively), or run `$env:Path += ';C:\Users\<you>\.hermes\bin'` temporarily.
@@ -175,7 +175,7 @@ The CLI prompts for the 6-character code and will:
 On success:
 ```
 ✓ Paired. Token stored in ~/.hermes/remote-sessions.json
-  Server: 0.6.0
+  Server: 1.1.0
   Relay:  ws://<host>:8767
   Route:  lan
 ```
@@ -190,7 +190,7 @@ Quickest sanity check:
 hermes-relay chat "what time is it?"
 ```
 
-The CLI streams back the agent's reply. Stderr gets `Connecting... / Connected via LAN (plain) — server 0.6.0`; stdout gets the answer. Redirecting stdout to a file (`... > out.txt`) captures **only** the reply.
+The CLI streams back the agent's reply. Stderr gets `Connecting... / Connected via LAN (plain) — server 1.1.0`; stdout gets the answer. Redirecting stdout to a file (`... > out.txt`) captures **only** the reply.
 
 ### E. Full Hermes TUI — shell mode
 
@@ -204,7 +204,7 @@ hermes-relay
 
 The CLI:
 1. Connects over WSS.
-2. Prints `Connected via LAN (plain) — server 0.6.0`.
+2. Prints `Connected via LAN (plain) — server 1.1.0`.
 3. Prompts for **one-time local-tool consent** (see §F).
 4. Attaches to the relay's `terminal` channel, which spawns (or re-attaches) a tmux session on the host.
 5. Sends `clear; exec hermes\n` after a 350 ms settle — tmux's login shell replaces itself with `hermes`, which renders its native Ink TUI straight through to your terminal.

--- a/skills/devops/hermes-relay-doctor/SKILL.md
+++ b/skills/devops/hermes-relay-doctor/SKILL.md
@@ -26,13 +26,14 @@ Runs a sequential smoke-test of the full bridge stack and reports pass/fail with
 
 ## Procedure
 
-Run the shim if it is installed:
+Run the plugin CLI:
 
 ```bash
-hermes-relay-doctor
+hermes relay doctor        # host CLI (plugin enabled in Hermes)
+hermes-relay doctor        # shell shim (installed by install.sh → plugin.cli)
 ```
 
-If the shim is missing (pre-0.3.x installs or after a manual uninstall), run the checks inline:
+If neither is available (plugin not enabled, or the `hermes-relay` shim was never installed), run the checks inline:
 
 ```bash
 PORT="${RELAY_PORT:-8767}"
@@ -69,7 +70,13 @@ Fix:
 
 This is a per-boot requirement on Android — the MediaProjection grant is revoked on reboot.
 
-## Re-installing the shim
+## Re-running after a fix
+
+```bash
+hermes relay doctor
+```
+
+If the `hermes-relay` shim is missing, refresh it (and the rest of the install) with the idempotent updater:
 
 ```bash
 hermes-relay-update

--- a/skills/devops/hermes-relay-pair/SKILL.md
+++ b/skills/devops/hermes-relay-pair/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # Hermes-Relay Pairing
 
-[Hermes-Relay](https://github.com/Codename-11/hermes-relay) is a native Android client for Hermes. Chat goes directly to the Hermes API server over HTTP/SSE; terminal and bridge channels go through a separate WSS relay. This skill generates a single QR code that configures both connections at once, using `plugin.pair` from the Hermes-Relay plugin.
+[Hermes-Relay](https://github.com/Codename-11/hermes-relay) is a native Android client for Hermes. Chat rides the standard upstream Hermes path — the dashboard `/api/ws` gateway transport (live thinking), with API-server SSE as fallback; terminal and bridge channels go through a separate WSS relay. This skill generates a single QR code that configures both connections at once, using `plugin.pair` from the Hermes-Relay plugin.
 
 ## When to Use
 

--- a/user-docs/.vitepress/config.mts
+++ b/user-docs/.vitepress/config.mts
@@ -111,7 +111,7 @@ export default defineConfig({
           text: 'Features',
           items: [
             { text: 'Overview', link: '/features/' },
-            { text: 'Direct API Connection', link: '/features/direct-api' },
+            { text: 'Standard Chat Transport', link: '/features/direct-api' },
             { text: 'Markdown Rendering', link: '/features/markdown' },
             { text: 'Reasoning Display', link: '/features/reasoning' },
             { text: 'Connections', link: '/features/connections' },

--- a/user-docs/.vitepress/theme/components/InstallSection.vue
+++ b/user-docs/.vitepress/theme/components/InstallSection.vue
@@ -114,7 +114,7 @@ async function copy(key: string, text: string) {
       </div>
 
       <p class="path-note">
-        Installs the 18 <code>android_*</code> + 9 <code>desktop_*</code> tool surfaces, the <code>/hermes-relay-pair</code> skill, and a <code>hermes-pair</code> shell shim. Requires hermes-agent v0.8.0+ and Python 3.11+.
+        Installs the 18 <code>android_*</code> + 23 <code>desktop_*</code> tool surfaces, the <code>/hermes-relay-pair</code> skill, and a <code>hermes-pair</code> shell shim. Requires current upstream hermes-agent (API server + dashboard enabled) and Python 3.11+.
       </p>
 
       <p>

--- a/user-docs/architecture/index.md
+++ b/user-docs/architecture/index.md
@@ -2,7 +2,7 @@
 
 ## Connection Model
 
-The app maintains two independent connection paths — direct HTTP/SSE for chat, persistent WSS for relay channels.
+The app maintains independent connection paths — chat over the standard Hermes surfaces (preferring the dashboard gateway, falling back to API-server SSE), and persistent WSS for the optional relay channels.
 
 For a compact shareable reference covering connection paths, transport boundaries, pairing/session lifecycle, and operator controls, see the [Relay Architecture Spec](/architecture/relay-architecture-spec).
 
@@ -10,7 +10,8 @@ For a compact shareable reference covering connection paths, transport boundarie
 
 | Path | Protocol | Server | Purpose |
 |------|----------|--------|---------|
-| Chat | HTTP/SSE | API Server `:8642` | Streaming conversations via Sessions API |
+| Chat (preferred) | WS | Dashboard `:9119` | Gateway chat via `/api/ws` (`tui_gateway`) — live thinking/reasoning |
+| Chat (fallback) | HTTP/SSE | API Server `:8642` | Streaming conversations via the Sessions / runs / completions APIs |
 | Terminal | WSS | Relay Server `:8767` | Remote shell via tmux (Phase 2) |
 | Bridge | WSS | Relay Server `:8767` | Device control via AccessibilityService + MediaProjection (Phase 3) |
 | Notifications | WSS | Relay Server `:8767` | `NotificationListenerService` forwards posted notifications over a bounded channel |
@@ -31,6 +32,8 @@ The bridge channel was consolidated onto the unified relay port `:8767` in v0.3 
 | `ConnectivityObserver` | Network connectivity monitoring |
 
 ## Chat Message Flow
+
+When the dashboard gateway is available, the turn rides the `/api/ws` WebSocket (`GatewayChatClient`) and the same lifecycle events arrive over JSON-RPC, with live reasoning. The flow below is the **API-server SSE fallback**, used when there's no dashboard auth yet or the server is older:
 
 <HermesFlow diagram="chat-flow" height="300px" />
 
@@ -72,12 +75,14 @@ The relay connection (bridge/terminal) uses a pairing code for initial setup, th
 
 Pairing codes use the full `A-Z / 0-9` alphabet (36 chars). The pair command (`hermes pair`, `/hermes-relay-pair`, or the compatibility `hermes-pair` shell shim) on the Hermes host mints the code and pre-registers it with the relay via a loopback-only `/pairing/register` endpoint before embedding it in the QR — so the phone never types a code by hand. Session tokens are stored in EncryptedSharedPreferences backed by Android Keystore.
 
-## Direct API vs Relay
+## Standard chat vs Relay
 
-| Aspect | Direct API (Chat) | Relay (Bridge/Terminal/Notifications) |
-|--------|-------------------|------------------------|
-| Protocol | HTTP/SSE | WSS |
-| Connection | Per-request | Persistent |
-| Auth | Bearer token | Pairing code + session token. Voice endpoints may also accept the Direct API bearer token. |
-| Server | Hermes API `:8642` | Unified Relay `:8767` |
-| State | Stateless | Channel-multiplexed |
+Chat uses standard upstream Hermes either way (gateway preferred, API-server SSE as fallback); the relay is a separate, optional surface for bridge/terminal/notifications.
+
+| Aspect | Standard Chat (gateway / API fallback) | Relay (Bridge/Terminal/Notifications) |
+|--------|----------------------------------------|------------------------|
+| Protocol | WS (`/api/ws`) preferred · HTTP/SSE fallback | WSS |
+| Connection | Persistent gateway socket · per-request on SSE fallback | Persistent |
+| Auth | Dashboard ws-ticket (gateway) · API bearer token (SSE fallback) | Pairing code + session token. Voice endpoints may also accept the API bearer token. |
+| Server | Hermes dashboard `:9119` · Hermes API `:8642` | Unified Relay `:8767` |
+| Live reasoning | Yes on gateway · post-hoc only on SSE fallback | — |

--- a/user-docs/desktop/index.md
+++ b/user-docs/desktop/index.md
@@ -2,7 +2,7 @@
 
 **A hand for your agent, on any computer you pair.**
 
-`hermes-relay` is a single binary you drop on a machine — desktop, laptop, or headless box — so your Hermes agent can work there: read and write files, search a codebase, run commands, manage processes, read the clipboard, capture screenshots — all over the same WSS relay, all consent-gated per device. The brain (LLM, tools, memory, sessions) never leaves your Hermes host. This binary is the hand it reaches with.
+`hermes-relay` is a single binary you drop on a machine — desktop, laptop, or headless box — so your Hermes agent can work there: read and write files, search a codebase, run shell and PowerShell commands, manage processes and long-running background jobs, transfer and archive files, read the clipboard, capture screenshots — all over the same WSS relay, all consent-gated per device. The brain (LLM, tools, memory, sessions) never leaves your Hermes host. This binary is the hand it reaches with.
 
 It also includes a terminal escape hatch for when *you* want to drive: bare `hermes-relay` attaches your server's own Hermes TUI over a PTY, tmux-backed so disconnects lose nothing.
 
@@ -43,7 +43,7 @@ The same chord set works on macOS (`Cmd+Shift+4` → screenshot to clipboard →
 
 | Mode | Command | Best for |
 |------|---------|----------|
-| **Tools (the hand)** | Automatic, in-session | The remote agent can call `desktop_read_file`, `desktop_write_file`, `desktop_terminal`, `desktop_search_files`, `desktop_patch`, `desktop_clipboard_read/write`, `desktop_screenshot`, `desktop_open_in_editor` — **executed on your machine**, not the server. One-time per-URL consent gate. |
+| **Tools (the hand)** | Automatic, in-session | The remote agent can call 23 `desktop_*` tools — filesystem (`read_file` / `write_file` / `patch` / `search_files`), shell (`terminal` / `powershell`), process control (`spawn_detached` / `list_processes` / `kill_process` / `find_pid_by_port`), a job API for long tasks (`job_start` / `_status` / `_logs` / `_cancel` / `_list`), archive/transfer (`copy_directory` / `zip` / `unzip` / `checksum`), and user-context bridges (`clipboard_read/write` / `screenshot` / `open_in_editor`) — **executed on your machine**, not the server. One-time per-URL consent gate. An experimental computer-use family is off by default. |
 | **Daemon** | `hermes-relay daemon` | Headless tool router. Keeps the agent's hands available even when no shell is open. JSON-line lifecycle logs. |
 | **Shell** (default) | `hermes-relay` | The escape hatch: full Hermes Ink TUI over a PTY — banner, Victor, slash commands, the whole experience. Uses tmux on the host so disconnects preserve state. |
 | **Chat (structured)** | `hermes-relay chat "<prompt>"` / `hermes-relay "<prompt>"` | Scriptable, one-shot, pipes stdin. `--json` emits `GatewayEvent`s per line for `jq` / automation. Maintained for scripting; not a growth surface. |
@@ -67,7 +67,7 @@ While inside the shell/TUI session (bare `hermes-relay`, the default mode), `Ctr
 ## Headline features
 
 - **[Native paste / screenshot / image](./subcommands.md)** — the chord set above, plus REPL slash commands `/paste`, `/screenshot`, `/screenshot primary`, `/screenshot 1`, `/image <path>`. Multi-monitor aware: `/screenshot` defaults to the virtual-screen union; `primary` / a 1-indexed display narrows. Identical wire format to a local Hermes paste.
-- **[Local tool routing](./tools.md)** — agent-callable file I/O, shell exec, ripgrep, clipboard, screenshot, editor-launcher, and unified-diff patching. Strict consent gate per relay URL; non-TTY stdin fails closed.
+- **[Local tool routing](./tools.md)** — 23 agent-callable tools: file I/O, unified-diff patching, ripgrep, shell + PowerShell exec, process control, a background-job API, archive/transfer, clipboard, screenshot, and editor-launcher. Strict consent gate per relay URL; non-TTY stdin fails closed. (An experimental computer-use family is off by default.)
 - **[Self-update](./subcommands.md#hermes-relay-update)** — `hermes-relay update` polls GitHub Releases, semver-compares, downloads + verifies SHA256, and atomic-swaps the binary. POSIX renames in place; Windows uses cooperative `.new.exe` swap on next start.
 - **[Surface plugins](./subcommands.md#hermes-relay-plugins)** — install, update, launch, or embed terminal dashboard plugins from the tray or CLI. The first built-in plugin is [Herm](https://github.com/liftaris/herm), installed as `herm-tui` and resumed with `herm -c`.
 - **[Workspace awareness](./subcommands.md#hermes-relay-workspace)** — on connect, the client advertises `cwd`, `git_root`, `git_branch`, `repo_name`, `hostname`, `platform`, `active_shell` to the relay so the agent knows which repo you're in. Client-side capability shipped in alpha.6; server-side prompt-context consumption is on the way (see [ROADMAP.md](https://github.com/Codename-11/hermes-relay/blob/main/ROADMAP.md#desktop-track-parallel-lane-to-android--experimental)).

--- a/user-docs/desktop/tools.md
+++ b/user-docs/desktop/tools.md
@@ -4,21 +4,64 @@ The big feature. The remote Hermes agent can read, write, search, execute, captu
 
 ## What the agent can do
 
-Tools are registered in the `desktop` toolset. The agent sees them as normal tools alongside its usual ones — no special syntax needed, just "read my notes" or "run `tsc --noEmit`".
+Tools are registered in the `desktop` toolset. The agent sees them as normal tools alongside its usual ones — no special syntax needed, just "read my notes" or "run `tsc --noEmit`". The shipped toolset is grouped into six families:
+
+**Filesystem**
 
 | Tool | Signature | Example use |
 |------|-----------|-------------|
 | `desktop_read_file` | `(path: string, max_bytes?: number)` | "Read my notes.md and summarize." |
 | `desktop_write_file` | `(path: string, content: string, create_dirs?: boolean)` | "Write a quick-start guide to `~/Desktop/quickstart.md`." |
 | `desktop_patch` | `(path: string, patch: string)` | Apply a unified diff. Strict — no fuzzy matching. Interactive approval prompt in `shell`/`chat` mode. |
-| `desktop_terminal` | `(command: string, cwd?: string, timeout?: number)` | "Run `tsc --noEmit` and tell me what's broken." |
 | `desktop_search_files` | `(pattern: string, cwd?: string, max_results?: number, content?: boolean)` | "Find every file mentioning `DesktopToolRouter`." ripgrep with pure-Node fallback; skips `.git` / `node_modules` / `dist` / `.next` / `.cache`. |
+
+**Shell**
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
+| `desktop_terminal` | `(command: string, cwd?: string, timeout?: number)` | "Run `tsc --noEmit` and tell me what's broken." `bash -lc` on POSIX, `cmd /c` on Windows. |
+| `desktop_powershell` | `(script: string, cwd?: string, timeout?: number)` | Runs a PowerShell script piped over stdin (`pwsh` preferred, falls back to `powershell`) — no `cmd.exe` quote-mangling. |
+
+**Process management**
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
+| `desktop_spawn_detached` | `(command: string, cwd?: string)` | Start an unref'd background process; returns its PID and a log path. |
+| `desktop_list_processes` | `()` | Enumerate running processes (`tasklist` / `ps`). |
+| `desktop_kill_process` | `(pid: number)` | Terminate a process by PID. |
+| `desktop_find_pid_by_port` | `(port: number)` | Find which process owns a port (`netstat` / `lsof` / `ss`). |
+
+**Job API** (long-running tasks with persistent logs that survive a daemon restart)
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
+| `desktop_job_start` | `(command: string, cwd?: string)` | Launch a long task; logs stream to `~/.hermes/desktop-jobs/<id>/`. |
+| `desktop_job_status` | `(id: string)` | Check whether a job is running, finished, or failed. |
+| `desktop_job_logs` | `(id: string)` | Tail a job's captured stdout/stderr. |
+| `desktop_job_cancel` | `(id: string)` | Stop a running job (`taskkill /T` on Windows so the whole tree dies). |
+| `desktop_job_list` | `()` | List all known jobs and their states. |
+
+**File transfer**
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
+| `desktop_copy_directory` | `(source: string, dest: string)` | Recursive copy via `fs.cp`. |
+| `desktop_zip` | `(source: string, dest: string)` | Create a zip archive (`tar` → `zip` → PowerShell probe). |
+| `desktop_unzip` | `(source: string, dest: string)` | Extract a zip archive. |
+| `desktop_checksum` | `(path: string, algorithm?: string)` | Streamed `sha256` / `sha1` / `md5` of a file. |
+
+**User-context bridges**
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
 | `desktop_clipboard_read` | `()` | Read the user's system clipboard. Windows / macOS / Linux (Wayland-first). |
 | `desktop_clipboard_write` | `(text: string)` | Write text to the system clipboard. |
 | `desktop_screenshot` | `(display?: number \| string, save_to?: string)` | Capture all monitors (default), primary (`'primary'`), or a specific display (`1` / `2` / ...). Returns base64 + dimensions, or saves to `save_to` and returns the path. |
 | `desktop_open_in_editor` | `(path: string, line?: number, col?: number, wait?: boolean)` | Open a file in the user's editor. Detects `$VISUAL` → `$EDITOR` → `code` / `cursor` / `subl` / `nvim` / `vim` on PATH → platform fallback. Injects `-g path:line:col` for GUI editors. |
 
-All run under a **30-second AbortController** ceiling enforced by the router. `desktop_terminal` accepts a per-call `timeout` (seconds, per the wire spec — converted to ms internally) that's clamped to a 10-minute maximum. `desktop_screenshot` has its own 10 s timeout and 50 MB cap. `desktop_clipboard_*` 5 s timeout and 10 MB cap.
+That's the 23 tools the client advertises by default. A further **computer-use** family (`desktop_computer_status` / `_screenshot` / `_action` / `_grant_request` / `_cancel`) is registered for full local UI control but ships **experimental and off by default** — it advertises only behind an explicit feature flag (`--experimental-computer-use`), on top of the normal tool consent, and host input still fails closed without a task-scoped grant approved from a visible local prompt.
+
+All tools run under a **30-second AbortController** ceiling enforced by the router. `desktop_terminal` / `desktop_powershell` accept a per-call `timeout` (seconds, per the wire spec — converted to ms internally) that's clamped to a 10-minute maximum. `desktop_screenshot` has its own 10 s timeout and 50 MB cap. `desktop_clipboard_*` 5 s timeout and 10 MB cap.
 
 The router heartbeats `desktop.status` every 30 s, advertising the full handler-name list, so the server's `desktop` channel knows which tools your client can service. Servers ping `/desktop/_ping?tool=<name>` to fail fast when a tool isn't advertised.
 
@@ -29,7 +72,7 @@ The router heartbeats `desktop.status` every 30 s, advertising the full handler-
 3. Hermes's Python-side `desktop_tool.py` handlers register with `tools.registry` (same pattern as `android_tool.py`) — the agent sees `desktop_read_file` as just another tool.
 4. When the agent calls a `desktop_*` tool, the Python handler HTTP-POSTs to `localhost:8767/desktop/<tool_name>` on the host.
 5. The relay's `desktop` channel forwards the call over WSS to the connected CLI.
-6. The CLI's `DesktopToolRouter` dispatches to an in-process handler (`fs.ts`, `terminal.ts`, `search.ts`, `clipboard.ts`, `screenshot.ts`, `editor.ts`).
+6. The CLI's `DesktopToolRouter` dispatches to an in-process handler (`fs.ts`, `terminal.ts`, `powershell.ts`, `process.ts`, `jobs.ts`, `transfer.ts`, `search.ts`, `clipboard.ts`, `screenshot.ts`, `editor.ts`).
 7. The handler runs on **your** machine, returns the result, and the response bubbles back: CLI → relay → Python → Hermes → agent.
 8. Typical round-trip: 60–100 ms for a simple command.
 
@@ -120,20 +163,34 @@ If the agent says "desktop_terminal is not available" or calls time out immediat
 ssh bailey@<host> curl -s "http://127.0.0.1:8767/desktop/_ping?tool=desktop_terminal"
 ```
 
-Expected:
+Expected (the default-advertised set — `desktop_computer_*` appears only when the client runs with `--experimental-computer-use`):
 ```json
 {
   "connected": true,
   "advertised_tools": [
-    "desktop_clipboard_read",
-    "desktop_clipboard_write",
-    "desktop_open_in_editor",
-    "desktop_patch",
     "desktop_read_file",
-    "desktop_screenshot",
+    "desktop_write_file",
+    "desktop_patch",
     "desktop_search_files",
     "desktop_terminal",
-    "desktop_write_file"
+    "desktop_powershell",
+    "desktop_spawn_detached",
+    "desktop_list_processes",
+    "desktop_kill_process",
+    "desktop_find_pid_by_port",
+    "desktop_job_start",
+    "desktop_job_status",
+    "desktop_job_logs",
+    "desktop_job_cancel",
+    "desktop_job_list",
+    "desktop_copy_directory",
+    "desktop_zip",
+    "desktop_unzip",
+    "desktop_checksum",
+    "desktop_clipboard_read",
+    "desktop_clipboard_write",
+    "desktop_screenshot",
+    "desktop_open_in_editor"
   ],
   "client_status": { ... },
   "last_seen_at": 1776964298.02,

--- a/user-docs/features/direct-api.md
+++ b/user-docs/features/direct-api.md
@@ -1,14 +1,17 @@
-# Direct API Connection
+# Standard Chat Transport
 
-Hermes-Relay connects directly to the Hermes API Server for chat, bypassing the relay server entirely.
+Hermes-Relay talks to your Hermes server's own surfaces for chat — no Hermes-Relay relay plugin is ever in the chat path. By default it **prefers the dashboard gateway** (`/api/ws`, the same `tui_gateway` transport hermes-desktop and the TUI speak) when your Manage sign-in is ready, because that's the only standard path with **live thinking/reasoning** as it streams. When the gateway isn't available — no dashboard auth yet, an older server, or a forced override — it **falls back to the API server's SSE routes**.
 
 ## How It Works
 
 ```
-Phone (HTTP/SSE) → Hermes API Server (:8642)
+Phone (WS)       → Hermes dashboard (:9119)    [preferred — gateway chat, live thinking]
+Phone (HTTP/SSE) → Hermes API Server (:8642)   [fallback — sessions / runs / completions]
 ```
 
-The app uses the Hermes `/api/sessions` REST API:
+Both paths are **standard upstream Hermes** surfaces. The dashboard gateway `/api/ws` is *not* the Hermes-Relay relay (`:8767`); it's a vanilla dashboard endpoint, reached with a short-lived ticket minted from your Manage dashboard session. The optional Relay plugin is never involved in chat — it only adds terminal, device control, media, and the like.
+
+When it falls back, the app uses the Hermes `/api/sessions` REST API:
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
@@ -32,9 +35,9 @@ The API key field in Settings is technically optional because Hermes can run an 
 
 When provided, the key is stored in Android's `EncryptedSharedPreferences` using AES-256-GCM encryption backed by the Android Keystore.
 
-## SSE Streaming
+## SSE Streaming (fallback path)
 
-Chat responses stream via Server-Sent Events with these Hermes-native event types:
+On the API-server fallback, chat responses stream via Server-Sent Events with these Hermes-native event types. (On the preferred gateway path the same lifecycle arrives over the `/api/ws` WebSocket instead, with live `reasoning.delta`/`thinking.delta` as the model reasons — the API-server SSE surface only surfaces reasoning after the fact via `tool.progress` and the final `run.completed` messages.)
 
 | Event | Description | Key Fields |
 |-------|-------------|------------|
@@ -52,6 +55,6 @@ Chat responses stream via Server-Sent Events with these Hermes-native event type
 | `error` | Error occurred | `message`, `error` |
 | `done` | Stream closed | `session_id`, `run_id`, `state: "final"` |
 
-## Why Direct?
+## Why two paths?
 
-Previous versions routed chat through a WebSocket relay. Direct connection is simpler, has lower latency, and aligns with how every other Hermes frontend works (Open WebUI, ClawPort, etc.).
+Chat always rides standard upstream Hermes — never the Hermes-Relay relay plugin. The gateway `/api/ws` path is preferred because it's the only standard surface with **live** reasoning streaming and full attachment support, matching what hermes-desktop and the Hermes TUI use. The API-server SSE path is the resilient fallback: it needs only the API server (no dashboard sign-in), works on older builds, and aligns with how other Hermes frontends talk to the API. The app probes both and picks the best available on each connect, so you get live thinking when your server can serve it and a working chat either way.

--- a/user-docs/features/index.md
+++ b/user-docs/features/index.md
@@ -8,7 +8,7 @@ A **<span class="track-badge track-badge--sideload">Sideload only</span>** badge
 
 | Feature | Description |
 |---------|-------------|
-| [Direct API Connection](/features/direct-api) | HTTP/SSE streaming to Hermes API Server |
+| [Standard Chat Transport](/features/direct-api) | Gateway `/api/ws` (live thinking) preferred, API-server SSE fallback — never the relay |
 | [Voice Mode](/features/voice) | Real-time voice conversation — you talk, the agent answers aloud via your server's configured TTS/STT providers |
 | [Markdown Rendering](/features/markdown) | Full markdown with syntax-highlighted code blocks |
 | [Reasoning Display](/features/reasoning) | Collapsible extended-thinking blocks |

--- a/user-docs/reference/relay-server.md
+++ b/user-docs/reference/relay-server.md
@@ -1,6 +1,6 @@
 # Relay Server
 
-The relay server is a lightweight Python WSS/HTTP service that enables **terminal** (remote shell), **bridge** (agent-driven phone control), media, sessions, and voice routes in Hermes-Relay. Chat does not use the relay — it connects directly to the Hermes API Server.
+The relay server is a lightweight Python WSS/HTTP service that enables **terminal** (remote shell), **bridge** (agent-driven phone control), media, sessions, and voice routes in Hermes-Relay. Chat never touches the relay — it rides your standard Hermes surfaces, preferring the dashboard gateway (`/api/ws`, live thinking) when Manage auth is ready and falling back to the API server's SSE routes otherwise.
 
 ## Do I Need It?
 


### PR DESCRIPTION
## Summary
Docs refresh across skill docs, the user-docs VitePress site, dev docs, and READMEs — aligned with the current gateway-first chat path and accurate tool/version counts.

## Changes
**Skill docs** — `hermes-relay-doctor`: broken `hermes-relay-doctor` shim command → `hermes relay doctor`. `hermes-relay-desktop-setup`: dead ROADMAP anchor; server `0.6.0`→`1.1.0`, CLI `0.2.0`→`0.3.0-alpha.18`. `hermes-relay-pair`: chat path reframed gateway-first.

**user-docs** — gateway-first chat framing (`features/direct-api.md`, `reference/relay-server.md`, `architecture/index.md`, `README.md`); desktop tool count `9`→`23` (verified vs `handlerSet.ts`, computer-use marked experimental); fixed the unsourced `v0.8.0+` claim → "current upstream".

**Dev docs** — `docs/relay-protocol.md`, `docs/relay-server.md`, `relay_server/SKILL.md`: same correction.

**plugin/dashboard/README.md** — removed the leftover "Hackathon submission" section.

## Note
The `HermesFlow.vue` architecture diagram still lacks a gateway node (prose/tables corrected) — left as a small follow-up (diagram change = design work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
