### PR TITLE
feat(plugin): env prompts, native install, /relay slash commands, session-start hook

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
-# Hermes-Relay — canonical one-line installer.
+# Hermes-Relay — canonical one-line installer (full relay path).
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Codename-11/hermes-relay/main/install.sh | bash
+#
+# Two ways to install:
+#   - FULL RELAY (this script): sets up the WSS relay server, systemd user
+#     unit, editable pip install, shell shims, skills dir, and the optional
+#     compatibility bootstrap — everything needed for terminal, bridge/phone
+#     control, relay voice, desktop tooling, and remote access.
+#   - TOOLS-ONLY (native): `hermes plugins install Codename-11/hermes-relay/plugin`
+#     uses hermes-agent's built-in plugin installer to discover + enable the
+#     android_*/desktop_* tools and prompt for optional voice-provider keys
+#     (declared in plugin/plugin.yaml `requires_env`). The `/plugin` subdir is
+#     required because the manifest lives there, not at the repo root. This path
+#     does NOT install the relay server, systemd unit, pip-editable, shims, or
+#     bootstrap — use it when you only want the agent-side tools.
 #
 # Installs:
 #   1. The hermes-relay repo to ~/.hermes/hermes-relay (editable, git-backed)
@@ -135,7 +148,7 @@ while [ $# -gt 0 ]; do
             shift 2
             ;;
         -h|--help)
-            sed -n '3,70p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '3,97p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -45,6 +45,26 @@ def register(ctx):
             check_fn=_make_desktop_check(tool_name),
         )
 
+    # Register the in-session `/relay` slash command (status/devices/pair) and
+    # the `on_session_start` lifecycle hook. Both are self-guarded internally,
+    # and wrapped here too so a missing register_command/register_hook on an
+    # older hermes-agent build cannot block tool/CLI registration below.
+    try:
+        from .slash import register_slash_commands
+
+        register_slash_commands(ctx)
+    except Exception:
+        # Slash commands are additive; never let them break plugin load.
+        pass
+
+    try:
+        from .hooks import register_hooks
+
+        register_hooks(ctx)
+    except Exception:
+        # The lifecycle hook is best-effort; never block plugin load.
+        pass
+
     # Register plugin-native CLI sub-commands: hermes pair + hermes relay.
     # Wrapped in try/except so the plugin still works on older hermes-agent
     # versions that do not expose register_cli_command.

--- a/plugin/after-install.md
+++ b/plugin/after-install.md
@@ -10,6 +10,32 @@ Use `hermes pair` to create a QR pairing payload. Use `hermes relay start` to ru
 the relay foreground server, or use the legacy installer if you still need the
 systemd user service and shell shims.
 
+## Two install paths
+
+**Tools-only (this path — `hermes plugins install`):** discovers + enables the
+`android_*` / `desktop_*` tools, prompts for any optional voice-provider keys,
+and registers the plugin with the gateway. The plugin's `plugin.yaml` lives in
+the repo's `plugin/` subdir, so install with the subdir identifier:
+
+```bash
+hermes plugins install Codename-11/hermes-relay/plugin
+```
+
+This is the right path if you only want the agent-side tools and will run the
+WSS relay yourself (or don't need it). It does **not** set up the relay server,
+a systemd unit, the `pip install -e`, the shell shims, or the legacy
+compatibility bootstrap.
+
+**Full relay (`install.sh` curl one-liner):** everything above **plus** the
+relay server, systemd user unit, editable pip install, `hermes-pair` /
+`hermes-relay` / `hermes-relay-tailscale` shims, the skills dir, and the
+optional compatibility bootstrap. Use this for terminal, bridge/phone control,
+relay voice, desktop tooling, and remote access:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Codename-11/hermes-relay/main/install.sh | bash
+```
+
 The optional legacy compatibility hook is managed separately:
 
 ```bash

--- a/plugin/hooks.py
+++ b/plugin/hooks.py
@@ -1,0 +1,125 @@
+"""Lifecycle hooks for the hermes-relay plugin.
+
+Registered via ``ctx.register_hook(...)``. There is exactly one hook here:
+``on_session_start``, which performs a single fast, fully-guarded loopback
+probe of the relay's ``/health`` endpoint and caches the result.
+
+IMPORTANT — runs in the gateway process
+---------------------------------------
+``on_session_start`` is fired *synchronously* inside the agent core
+(``agent/conversation_loop.py``) on the first turn of every new session.
+The host already wraps each callback in its own ``try/except``, but this
+handler MUST independently stay cheap and non-throwing:
+
+  * No blocking work, no heavy I/O — only a single ``GET /health`` with a
+    tight (0.5s) timeout against loopback.
+  * Everything wrapped in ``try/except``; any failure is swallowed and
+    logged at DEBUG so it can NEVER slow down or crash a session.
+  * No network calls off-host — loopback only (127.0.0.1).
+
+The cached snapshot is intentionally lightweight: it lets other code (or a
+future context contribution) know whether the relay was reachable at
+session start without re-probing. We deliberately do NOT inject context
+into the turn here — keeping the hook a pure, side-effect-light observer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Last relay-health snapshot taken at session start. Read-only for the rest
+# of the process; updated only by the hook below. Shape:
+#   {"reachable": bool, "checked_at": float, "version": str|None,
+#    "clients": int|None, "sessions": int|None, "error": str|None}
+_LAST_HEALTH: Optional[Dict[str, Any]] = None
+
+# Tight timeout — this runs in the gateway hot path. A relay that doesn't
+# answer within half a second is treated as "not reachable" and we move on.
+_HEALTH_TIMEOUT_S = 0.5
+
+
+def _relay_port() -> int:
+    """Resolve the loopback relay port (``$RELAY_PORT`` or 8767 default)."""
+    import os
+
+    raw = (os.environ.get("RELAY_PORT") or "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            return 8767
+    return 8767
+
+
+def get_last_health() -> Optional[Dict[str, Any]]:
+    """Return the most recent session-start health snapshot, if any."""
+    return _LAST_HEALTH
+
+
+def on_session_start(**kwargs: Any) -> None:
+    """Cheap, non-throwing relay-availability probe at session start.
+
+    Accepts ``**kwargs`` only — the host passes ``session_id``, ``model``,
+    ``platform``, and a framework-injected ``telemetry_schema_version`` (and
+    may add more later). We read none of them; ``**kwargs`` keeps this
+    forward-compatible and prevents a signature mismatch from ever raising.
+
+    Returns ``None`` (no context injection) so this stays a pure observer.
+    """
+    global _LAST_HEALTH
+    port = _relay_port()
+    url = f"http://127.0.0.1:{port}/health"
+    snapshot: Dict[str, Any] = {
+        "reachable": False,
+        "checked_at": time.time(),
+        "version": None,
+        "clients": None,
+        "sessions": None,
+        "error": None,
+    }
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=_HEALTH_TIMEOUT_S) as resp:
+            body = resp.read().decode("utf-8")
+        data = json.loads(body)
+        if isinstance(data, dict):
+            snapshot["reachable"] = True
+            snapshot["version"] = data.get("version")
+            snapshot["clients"] = data.get("clients")
+            snapshot["sessions"] = data.get("sessions")
+            logger.debug(
+                "hermes-relay reachable at session start "
+                "(v%s, clients=%s, sessions=%s)",
+                snapshot["version"], snapshot["clients"], snapshot["sessions"],
+            )
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+        # Relay not running / not reachable / bad body — all expected and
+        # benign. Record it and move on; never propagate.
+        snapshot["error"] = str(exc)
+        logger.debug("hermes-relay not reachable at session start: %s", exc)
+    except Exception as exc:  # noqa: BLE001 — belt-and-suspenders, never throw
+        snapshot["error"] = str(exc)
+        logger.debug("on_session_start relay probe failed: %s", exc)
+
+    _LAST_HEALTH = snapshot
+    return None
+
+
+def register_hooks(ctx) -> None:
+    """Register the ``on_session_start`` hook with the plugin host.
+
+    Guarded so an older hermes-agent build without ``register_hook`` cannot
+    break tool/CLI/slash registration in :func:`plugin.register`.
+    """
+    try:
+        ctx.register_hook("on_session_start", on_session_start)
+    except (AttributeError, TypeError) as exc:
+        logger.debug("register_hook unavailable; skipping on_session_start: %s", exc)

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -3,7 +3,24 @@ manifest_version: 1
 version: 1.1.0
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
-requires_env: []
+# All three are OPTIONAL — only needed if you use the relay's extra /
+# provider-native voice engines. The standard (no-plugin) chat, Manage, and
+# dashboard voice path needs none of these. `hermes plugins install` prompts
+# for each; skip any you don't use (press Enter) and set it later in
+# ~/.hermes/.env. Keys are also accepted under VOICE_TOOLS_*_KEY aliases.
+requires_env:
+  - name: XAI_API_KEY
+    description: "Optional — xAI/Grok voice (TTS + realtime). Leave blank unless using Grok relay voice."
+    url: "https://console.x.ai/"
+    secret: true
+  - name: OPENAI_API_KEY
+    description: "Optional — OpenAI voice (TTS + realtime). Leave blank unless using OpenAI relay voice."
+    url: "https://platform.openai.com/api-keys"
+    secret: true
+  - name: ELEVENLABS_API_KEY
+    description: "Optional — ElevenLabs TTS. Leave blank unless using ElevenLabs relay voice."
+    url: "https://elevenlabs.io/app/settings/api-keys"
+    secret: true
 provides_tools:
   - android_ping
   - android_read_screen

--- a/plugin/slash.py
+++ b/plugin/slash.py
@@ -1,0 +1,239 @@
+"""In-session ``/relay`` slash command for the hermes-relay plugin.
+
+Registered via ``ctx.register_command("relay", handler)`` so it is usable
+mid-conversation from any platform (CLI, Telegram, Discord, TUI, …). The
+host calls the handler with a single ``raw_args: str`` and expects a
+``str | None`` reply suitable for a chat message.
+
+Subcommands (parsed out of ``raw_args`` by :func:`relay_slash_handler`):
+
+    /relay status       Relay reachability + connected-phone summary
+    /relay devices      Paired-device list (loopback ``GET /sessions``)
+    /relay pair         Mint a fresh 6-char pairing code on the running relay
+    /relay help         This help text
+
+All of the real work is delegated to the existing relay logic
+(:mod:`plugin.status`, :mod:`plugin.pair`, and the relay's loopback HTTP
+surface) so this module stays a thin chat-facing veneer. Every handler is
+fully ``try/except``-guarded: a failure returns a friendly one-line message,
+never an exception into the host dispatch loop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+def _relay_port() -> int:
+    """Resolve the loopback relay port (``$RELAY_PORT`` or the 8767 default)."""
+    raw = (os.environ.get("RELAY_PORT") or "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            logger.debug("Ignoring invalid RELAY_PORT=%r; using 8767", raw)
+    return 8767
+
+
+def _fmt_age(seconds: Optional[float]) -> str:
+    """Render a seconds-ago value as a compact human string."""
+    if not isinstance(seconds, (int, float)) or seconds < 0:
+        return "?"
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s ago"
+    if s < 3600:
+        return f"{s // 60}m ago"
+    if s < 86400:
+        return f"{s // 3600}h ago"
+    return f"{s // 86400}d ago"
+
+
+# ── /relay status ─────────────────────────────────────────────────────────────
+
+
+def _cmd_status() -> str:
+    """Concise relay-reachability + phone-connection summary for chat."""
+    # Reuse the canonical read-only fetcher from the status CLI so the
+    # chat reply and `hermes-status` agree on parsing/exit semantics.
+    from .status import (
+        EXIT_NO_PHONE,
+        EXIT_OK,
+        EXIT_RELAY_UNREACHABLE,
+        fetch_status,
+    )
+
+    port = _relay_port()
+    code, data, err = fetch_status(port, timeout_s=2.0)
+
+    if code == EXIT_RELAY_UNREACHABLE:
+        return (
+            f"Relay unreachable on 127.0.0.1:{port} "
+            f"({err or 'not running'}). Start it with "
+            "`systemctl --user start hermes-relay`."
+        )
+
+    data = data or {}
+    if code == EXIT_NO_PHONE or not data.get("phone_connected"):
+        reason = data.get("error") or "no phone connected"
+        return f"Relay is up on :{port}, but no phone is connected ({reason})."
+
+    # Connected — surface the device line + a couple of quick facts.
+    parts = ["Relay up — phone connected."]
+    device = data.get("device") if isinstance(data.get("device"), dict) else {}
+    name = device.get("name")
+    battery = device.get("battery_percent")
+    last_seen = data.get("last_seen_seconds_ago")
+    if name:
+        parts.append(f"Device: {name}.")
+    if isinstance(battery, (int, float)):
+        parts.append(f"Battery: {int(battery)}%.")
+    if isinstance(last_seen, (int, float)):
+        parts.append(f"Last seen {_fmt_age(last_seen)}.")
+    return " ".join(parts)
+
+
+# ── /relay devices ────────────────────────────────────────────────────────────
+
+
+def _cmd_devices() -> str:
+    """List paired devices via the relay's loopback ``GET /sessions``.
+
+    Loopback callers without a bearer get the full list (see
+    ``handle_sessions_list`` in the relay server); the response only ever
+    carries token *prefixes*, never full tokens.
+    """
+    port = _relay_port()
+    url = f"http://127.0.0.1:{port}/sessions"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=2.0) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+        return (
+            f"Could not list devices — relay unreachable on 127.0.0.1:{port} "
+            f"({exc})."
+        )
+
+    sessions = payload.get("sessions") if isinstance(payload, dict) else None
+    if not isinstance(sessions, list) or not sessions:
+        return "No paired devices. Run `/relay pair` to mint a pairing code."
+
+    lines = [f"Paired devices ({len(sessions)}):"]
+    for s in sessions:
+        if not isinstance(s, dict):
+            continue
+        name = s.get("device_name") or "unknown device"
+        prefix = s.get("token_prefix") or "????????"
+        surface = s.get("client_surface") or ""
+        last = _fmt_age(_seconds_since(s.get("last_seen")))
+        suffix = f" [{surface}]" if surface else ""
+        lines.append(f"  • {name}{suffix} — {prefix}… (seen {last})")
+    return "\n".join(lines)
+
+
+def _seconds_since(epoch_ts: Any) -> Optional[float]:
+    """Convert an absolute epoch ``last_seen`` to seconds-ago (best effort)."""
+    if not isinstance(epoch_ts, (int, float)):
+        return None
+    import time
+
+    delta = time.time() - float(epoch_ts)
+    return delta if delta >= 0 else 0.0
+
+
+# ── /relay pair ───────────────────────────────────────────────────────────────
+
+
+def _cmd_pair() -> str:
+    """Mint a fresh pairing code on the running relay (loopback only).
+
+    Uses the exact same path as ``hermes pair --register-code``: generate a
+    6-char code locally, then pre-register it with the relay via the
+    loopback-only ``POST /pairing/register`` endpoint. The phone claims the
+    code to complete pairing.
+    """
+    from .pair import _generate_relay_code, register_relay_code
+
+    port = _relay_port()
+    code = _generate_relay_code()
+    ok = register_relay_code(port, code, timeout_s=2.0)
+    if not ok:
+        return (
+            f"Could not mint a pairing code — relay not reachable on "
+            f"127.0.0.1:{port}, or pairing registration failed. Is "
+            "`hermes-relay` running on this host?"
+        )
+    return (
+        f"Pairing code: {code}\n"
+        "Enter it in the Hermes-Relay app (Pair → enter code) within the "
+        "pairing window. For a scannable QR, run `hermes pair` in a terminal "
+        "on the relay host."
+    )
+
+
+# ── Help + dispatch ───────────────────────────────────────────────────────────
+
+_HELP = (
+    "/relay — Hermes-Relay control\n"
+    "  status   Relay reachability + connected-phone summary\n"
+    "  devices  List paired devices\n"
+    "  pair     Mint a fresh 6-char pairing code\n"
+    "  help     Show this help"
+)
+
+
+def relay_slash_handler(raw_args: str) -> str:
+    """Dispatch ``/relay <subcommand>`` to the matching handler.
+
+    Signature matches the upstream ``register_command`` contract:
+    ``fn(raw_args: str) -> str | None``. Always returns a string; never
+    raises — each subcommand is independently guarded so a transient relay
+    failure becomes a friendly chat reply instead of a host-loop exception.
+    """
+    argv = (raw_args or "").strip().split()
+    sub = argv[0].lower() if argv else "status"
+
+    try:
+        if sub in ("help", "-h", "--help", "?"):
+            return _HELP
+        if sub == "status":
+            return _cmd_status()
+        if sub == "devices":
+            return _cmd_devices()
+        if sub == "pair":
+            return _cmd_pair()
+        return f"Unknown subcommand '{sub}'.\n\n{_HELP}"
+    except Exception as exc:  # noqa: BLE001 — never throw into host dispatch
+        logger.warning("/relay %s failed: %s", sub, exc, exc_info=True)
+        return f"`/relay {sub}` failed: {exc}"
+
+
+def register_slash_commands(ctx) -> None:
+    """Register the ``/relay`` slash command with the plugin host.
+
+    Guarded so older hermes-agent builds without ``register_command`` (or a
+    transient registration failure) cannot break tool/CLI registration in
+    :func:`plugin.register`.
+    """
+    try:
+        ctx.register_command(
+            "relay",
+            handler=relay_slash_handler,
+            description="Hermes-Relay status, paired devices, and pairing.",
+            args_hint="status|devices|pair",
+        )
+    except (AttributeError, TypeError) as exc:
+        # Older hermes-agent without register_command, or a signature
+        # mismatch — degrade silently; the `hermes relay` CLI still works.
+        logger.debug("register_command unavailable; skipping /relay: %s", exc)


### PR DESCRIPTION
## Summary
Four upstream plugin surfaces adopted to cut manual setup/config (plugin `1.1.0`). Contracts verified against `upstream/main`.

## Changes
- **`requires_env` rich form** (`plugin.yaml`) — declares the optional voice-provider keys (`XAI_API_KEY`, `OPENAI_API_KEY`, `ELEVENLABS_API_KEY`, each `secret`, with "get yours" URLs) so `hermes plugins install` prompts for them (masked) instead of hand-editing `.env`. The standard no-plugin path needs none.
- **Native install path** (`install.sh` header + `after-install.md`) — documents/supports `hermes plugins install Codename-11/hermes-relay/plugin` for tools-only users (manifest lives in the `/plugin` subdir). Additive — curl `install.sh` behavior unchanged.
- **`/relay` slash commands** (`plugin/slash.py`) — `relay status · devices · pair · help`, usable mid-conversation from any platform; reuses existing relay logic; each subcommand guarded.
- **`on_session_start` hook** (`plugin/hooks.py`) — a minimal observer: one 0.5s-timeout guarded `/health` ping, returns `None`; documented to stay cheap + non-throwing (runs in the gateway).

## Verification
`py_compile` (init/slash/hooks) passes · `plugin.yaml` parses · `bash -n install.sh` clean · upstream contract verified.

(The 5th enhancement — the dashboard relay-status slot — folds into dashboard PR #76 since it shares the bundle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
