### PR TITLE
fix(docs-site): keep hero sphere canvas backing store synced to its css box

### DIFF
--- a/user-docs/.vitepress/theme/components/HeroDemo.vue
+++ b/user-docs/.vitepress/theme/components/HeroDemo.vue
@@ -153,17 +153,37 @@ function applyScene(t: number) {
   fadingOut.value = t >= FADE_AT
 }
 
+// Keep the backing store in lockstep with the canvas's CURRENT css box and
+// return the logical (css-px) dimensions to draw against. The canvas size is
+// CSS-driven (88cqw, plus the 900ms boot→chat width tween) so it changes
+// WITHOUT screenEl ever resizing — measuring it live and reallocating only on
+// a real pixel-size change keeps the backing store and the per-frame draw math
+// from ever diverging. That divergence was the "sphere shrinks to ~1/3 and
+// hugs the top-left on mobile" bug: resize() snapshotted one size, drawSphere
+// read another, and a bailed first resize left the 300×150 default store (with
+// no dpr transform) that the truthy-width guard never retried.
+function syncCanvasSize(canvas: HTMLCanvasElement): { w: number; h: number } | null {
+  const rect = canvas.getBoundingClientRect()
+  const cw = rect.width
+  const ch = rect.height
+  if (cw <= 0 || ch <= 0) return null
+  const dpr = window.devicePixelRatio || 1
+  const bw = Math.round(cw * dpr)
+  const bh = Math.round(ch * dpr)
+  if (canvas.width !== bw || canvas.height !== bh) {
+    // Assigning width/height clears the canvas AND resets the transform, so
+    // re-apply the dpr scale right after. We redraw every frame anyway.
+    canvas.width = bw
+    canvas.height = bh
+    const ctx = canvas.getContext('2d')
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  }
+  return { w: cw, h: ch }
+}
+
 function resize() {
   const canvas = canvasEl.value
-  if (!canvas) return
-  const dpr = window.devicePixelRatio || 1
-  const cw = canvas.clientWidth
-  const ch = canvas.clientHeight
-  if (cw <= 0 || ch <= 0) return
-  canvas.width = Math.floor(cw * dpr)
-  canvas.height = Math.floor(ch * dpr)
-  const ctx = canvas.getContext('2d')
-  if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  if (canvas) syncCanvasSize(canvas)
 }
 
 // sceneT loops (drives WHAT the sphere is doing); clockT is monotonic and
@@ -176,10 +196,10 @@ function drawSphere(sceneT: number, clockT: number) {
   if (!canvas) return
   const ctx = canvas.getContext('2d')
   if (!ctx) return
-  if (!canvas.width || !canvas.height) {
-    resize()
-    if (!canvas.width || !canvas.height) return
-  }
+  // Re-sync every frame so a late-resolving layout (mobile container queries)
+  // or the boot→chat width tween can't leave the backing store stale.
+  const dims = syncCanvasSize(canvas)
+  if (!dims) return
 
   retargetTo(sceneStateFor(sceneT), clockT)
   for (const k in tw) (tw as Record<string, Tween>)[k].update(clockT)
@@ -188,8 +208,8 @@ function drawSphere(sceneT: number, clockT: number) {
   tw.intensity.setTarget(sphereState === SphereState.Speaking ? 0.4 : 0, clockT, 0.4)
   const burst = sceneT >= TOOL_AT && sceneT < TOOL_AT + 1.2 ? Math.exp(-(sceneT - TOOL_AT) / 0.35) : 0
 
-  const canvasW = canvas.clientWidth
-  const canvasH = canvas.clientHeight
+  const canvasW = dims.w
+  const canvasH = dims.h
   const cellW = canvasW / COLS
   const cellH = canvasH / ROWS
   const charSize = Math.min(cellW * 1.3, cellH * 1.1)
@@ -300,8 +320,10 @@ onMounted(() => {
       { threshold: 0 }
     )
     intersectionObserver.observe(screenEl.value)
+    // Observe the CANVAS, not screenEl: the canvas resizes on its own during
+    // the 88cqw→80cqw boot→chat tween, which never changes screenEl's box.
     resizeObserver = new ResizeObserver(() => resize())
-    resizeObserver.observe(screenEl.value)
+    if (canvasEl.value) resizeObserver.observe(canvasEl.value)
   }
   rafId = requestAnimationFrame(render)
 })


### PR DESCRIPTION
## What

Fixes the docs-site hero phone-preview morphing sphere rendering at ~1/3 size and hugging the top-left of the phone frame on mobile.

## Root cause

A HiDPI canvas backing-store vs. drawing-coordinate divergence in `HeroDemo.vue`:

- `resize()` snapshotted the canvas size once to set the backing store + `dpr` transform, but `drawSphere()` read `canvas.clientWidth` live every frame. When those disagreed, the grid was drawn into a coordinate space that no longer matched the store — and canvas drawing starts at `(0,0)`, hence the top-left pin.
- Mobile triggered it two ways: (1) the `88cqw` container-query width can resolve a tick after mount, so `resize()` bailed (`cw <= 0`) and left the default `300×150` backing store with no `dpr` transform, which the `if (!canvas.width)` guard saw as truthy and never retried; (2) the `88cqw→80cqw` boot→chat width tween resizes the canvas without resizing `screenEl`, which the `ResizeObserver` was watching.

## Fix (one file)

- Add `syncCanvasSize()` — measures the real box with `getBoundingClientRect()`, reallocates the backing store only on an actual pixel-size change (re-applying the `dpr` transform), and returns the css-px dims to draw against.
- `drawSphere()` calls it **every frame** and draws against that single measurement, so the store and draw math can no longer diverge; a not-ready layout self-heals on the next frame.
- Point the `ResizeObserver` at the canvas (not `screenEl`) so the boot→chat width tween is tracked.

`SphereMark.vue` (the standalone sphere lower on the page) was already immune — it pins `canvas.style.width/height` and reads the same values back — so it's untouched.

## Verification

Verified the component compiles cleanly through Vite (dev server, HTTP 200). Visual confirmation in a real mobile viewport is still pending — browser automation wasn't available in the dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
