### PR TITLE
docs(changelog): voice-mode enhancements [Unreleased] entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Enhanced voice control (Gemini & xAI).** When the relay uses a Gemini or xAI voice provider, Voice Settings can now steer it: pick a Gemini voice and model and turn on expressive tone tags (with optional natural-language voice direction), or set an xAI voice with expressive speech tags. Expressive tags also apply to xAI on the streaming voice-output renderer. Standard (no-plugin) voice stays configured server-side.
+- **Voice render-path visibility.** Voice Settings shows which path is rendering speech (streaming vs. basic), and Diagnostics records it each session, making voice issues easier to troubleshoot.
+
+### Changed
+
+- **Voice replies are formatted for listening.** In voice mode the assistant is now guided to answer in short, conversational sentences without markdown, emoji, or raw URLs — without changing what is stored in chat history.
+
+### Fixed
+
+- **Realtime voice no longer drops the conversation mid-session with some providers.** A normal end-of-turn signal was being rejected on certain voice providers, ending the session every turn.
+- **Relay voice synthesis no longer leaves temporary audio files behind** on the server.
+- **Clearer voice errors and an oversize-recording guard.** Standard voice now rejects an over-long recording before uploading it and shows a helpful message for audio the server can't read, instead of a generic HTTP error.
+
 ## [1.1.0] - 2026-06-16
 
 ### Added


### PR DESCRIPTION
Adds the public-facing `CHANGELOG.md` `[Unreleased]` entry for the voice-mode enhancements merged in #83 (enhanced voice control for Gemini & xAI, render-path visibility, spoken-output formatting, realtime/synthesis fixes). Keep-a-Changelog grouping; docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)