### PR TITLE
fix(ci): raise Gradle heap to 4g for release bundling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.suppressUnsupportedCompileSdk=36
 kotlin.code.style=official


### PR DESCRIPTION
Re-cut blocker for android-v1.2.0: the release workflow OOMed in `packageSideloadReleaseBundle` at -Xmx2048m. Bumps to 4g. Only new content vs main is gradle.properties; no app code change. Admin-merging since the real validation is the release re-run.