### PR TITLE
fix(docs): pin search-insights for deterministic npm ci

### DIFF
--- a/user-docs/package-lock.json
+++ b/user-docs/package-lock.json
@@ -9,6 +9,7 @@
         "@vue-flow/core": "^1.48.2"
       },
       "devDependencies": {
+        "search-insights": "^2.17.3",
         "vitepress": "^1.6.4"
       }
     },
@@ -2332,6 +2333,13 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "2.5.0",

--- a/user-docs/package.json
+++ b/user-docs/package.json
@@ -8,7 +8,8 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "search-insights": "^2.17.3"
   },
   "dependencies": {
     "@vue-flow/core": "^1.48.2"


### PR DESCRIPTION
Real fix for the Deploy Docs failure (the Node-24 bump alone was insufficient). Pins the optional docsearch peer dep so npm ci agrees across npm versions. Validated locally with a clean npm ci.