### PR TITLE
feat(app): surface Demo mode on every first-run dead-end + tighten App-access copy

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
@@ -1588,6 +1588,11 @@ fun RelayApp() {
                                 launchSingleTop = true
                             }
                         },
+                        // Empty-chat "needs connection" card also offers the offline
+                        // demo, so a skipped / never-connected first run can explore
+                        // without leaving Chat. Safe here — this state only shows when
+                        // nothing is configured, so there's no placeholder in flight.
+                        onTryDemo = enterDemo,
                         onNavigateToManage = {
                             navController.navigate(Screen.Manage.route) {
                                 popUpTo(navController.graph.findStartDestination().id) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/onboarding/OnboardingScreen.kt
@@ -136,9 +136,9 @@ fun OnboardingScreen(
                 title = { Text("Skip setup?") },
                 text = {
                     Text(
-                        "You can configure your Hermes connection later in Settings → Connections. " +
-                            "Without a connection, Chat and Manage won't load. Relay pairing can " +
-                            "be added later for power tools."
+                        "No problem — you can explore the demo to see how Hermes-Relay works, " +
+                            "and connect your own Hermes server anytime from Settings → Connections. " +
+                            "Relay pairing for power tools can be added later too."
                     )
                 },
                 confirmButton = {
@@ -146,7 +146,7 @@ fun OnboardingScreen(
                         showSkipConfirm = false
                         onComplete()
                     }) {
-                        Text("Skip anyway")
+                        Text("Skip for now")
                     }
                 },
                 dismissButton = {

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -380,6 +380,9 @@ fun ChatScreen(
     // don't wire navigation.
     onNavigateToConnections: () -> Unit = {},
     onNavigateToConnect: () -> Unit = onNavigateToConnections,
+    // Offline demo entry, surfaced on the empty-chat "needs connection" card so a
+    // skipped / never-connected first run can explore without a server. null hides it.
+    onTryDemo: (() -> Unit)? = null,
     onNavigateToManage: () -> Unit = {},
     onNavigateToBridge: () -> Unit = {},
     onNavigateToTerminal: () -> Unit = {},
@@ -1852,7 +1855,7 @@ fun ChatScreen(
                                             verticalArrangement = Arrangement.spacedBy(10.dp),
                                         ) {
                                             Text(
-                                                text = "Chat needs a Hermes API connection.",
+                                                text = "Connect your Hermes server to start chatting — or explore a quick demo first. You can connect anytime.",
                                                 style = MaterialTheme.typography.bodyMedium,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
@@ -1861,6 +1864,14 @@ fun ChatScreen(
                                                 modifier = Modifier.fillMaxWidth(),
                                             ) {
                                                 Text("Connect Hermes")
+                                            }
+                                            if (onTryDemo != null) {
+                                                TextButton(
+                                                    onClick = onTryDemo,
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                ) {
+                                                    Text("Try the demo")
+                                                }
                                             }
                                         }
                                     }

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -132,23 +132,29 @@ Submission-time declarations the Play Console requires — keep in sync with the
 
 ### App access
 
-Hermes-Relay is a client for a **user-run Hermes server**, so a fresh install with no server configured has no content of its own — which is what a reviewer hits first. **All functionality is reachable offline via Demo mode**, so no test server or credentials are required to review the app.
+Hermes-Relay is a client for a **user-run Hermes server**. A fresh install with no server configured has no content of its own — which is what a reviewer hits first, and what triggered the v1.2.4 *App access* rejection. The core experience is reviewable **offline via Demo mode**, with **no test server, account, or credentials required**.
 
-Fill **App content → App access** as *All functionality is available without special access* (no login required), and provide these instructions:
+In **App content → App access**, choose **"All or some functionality is restricted"** — full chat, Manage, and voice require the user to connect their own Hermes server, and choosing "restricted" is what exposes the instructions field that tells the reviewer how to get in. Add **one** access entry with **no username/password**, just these instructions:
 
 ```
-This app is a client for a Hermes agent server the user runs themselves, so a
-fresh install has no content until you connect one. To review the app without a
-server:
+Hermes-Relay is a client for a Hermes agent server the user runs themselves,
+so a fresh install has no content until a server is connected. To review the
+app with no server and no account:
 
-  Open the app → on the setup / Connect screen, tap "Try the demo".
+  1. Launch the app — you land on the welcome / setup screen.
+  2. Tap "Try the demo". It is on the first Connect screen, and also on the
+     empty Chat screen if you tap Skip.
 
-This opens an offline demo of the real Chat UI with a sample conversation
-(streaming-style reply, Markdown, a tool-progress card, and a rich card). It
-needs no login, no account, and no network — it works in airplane mode. A
-"Demo mode — sample data, not connected" banner is shown throughout, with a
-Connect action that opens the real setup wizard.
+This opens an offline demo of the real Chat UI — a sample conversation with a
+streaming-style reply, Markdown, a tool-progress card, and a rich card. No
+login, account, or network is needed; it runs in airplane mode. A "Demo mode —
+sample data, not connected" banner shows throughout, with a Connect action that
+opens the real setup wizard.
 ```
+
+**Reviewer note** — paste into the resubmission / appeal message to pre-empt the same rejection:
+
+> Hermes-Relay is a client for a self-hosted Hermes agent server (like an SSH or self-hosted-app client), so it has no content until the user connects their own. We added an offline **"Try the demo"** mode — tap it on the first screen — so the full chat experience is reviewable with no server, account, or network.
 
 ### Foreground service permissions
 


### PR DESCRIPTION
Follow-up polish to the offline Demo mode (#137), so a Play reviewer (or any new user) reaches it from **every** first-run path — not just the Connect surfaces.

## Changes
- **Empty-chat "needs connection" card** now offers **"Try the demo"** under "Connect Hermes" (new optional `onTryDemo` param), and reads warmer: *"Connect your Hermes server to start chatting — or explore a quick demo first. You can connect anytime."* This closes the **skip → empty Chat** dead-end, which previously only offered "Connect Hermes".
- **RelayApp** wires that card's `onTryDemo` to the existing `enterDemo` lambda (safe: the card only shows when nothing is configured).
- **Onboarding "Skip setup?" dialog** reframed from the alarming *"Chat and Manage won't load"* to *"explore the demo… connect anytime from Settings → Connections"*; confirm button → **"Skip for now"**.
- **docs/play-store-listing.md** App-access guidance tightened: recommend **"All or some functionality is restricted"** (the only option that exposes Play Console's reviewer-instructions field — picking "all available" leaves the reviewer no hint to tap the demo), name the exact screens, and add a paste-ready **reviewer note** for resubmission.

## Verification
`:app:assembleSideloadDebug` green; installed + walked on-device (fresh `pm clear`): onboarding Skip dialog → empty Chat "Try the demo" → offline demo loads. Part of the **v1.2.5** bundle (with the #131 crash fix and Demo mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)