### PR TITLE
release(android): android-v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **Android: Demo mode.** A "Try the demo" option on the setup / Connect screen opens an offline preview of the real Chat UI — a sample conversation with Markdown, a tool-progress card, and a rich card — with zero setup and zero network (works in airplane mode). A persistent "Demo mode — sample data, not connected" banner offers a one-tap Connect that opens the real setup wizard; other tabs show a friendly "connect your Hermes server" empty state. Lets a first-run user (or a Play reviewer with no server) see what the app does before connecting.
 - **Desktop CLI: `hermes-relay audit`.** Shows what the remote agent has actually run on this machine through the desktop tools — tool, status, and a short detail per call — read from a local log, no network or auth. Answers "what did the agent just do?" at a glance.
 - **Desktop CLI: `hermes-relay relay`.** Inspect the relay server itself: `relay info` (version, uptime, sessions — on the relay host), `relay security` (runtime auth toggles), and `relay context` (audit the system-prompt context the relay injects into the agent, which works from a remote machine with your session).
 - **Desktop CLI: background daemon.** `hermes-relay daemon start` runs the headless tool router in the background (no console window, survives closing the terminal), with `daemon stop` and `daemon status` to manage it. `daemon status` reports state, uptime, relay, and advertised-tool count; bare `daemon` still runs in the foreground. Logs go to `~/.hermes/daemon.log`.
@@ -20,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Desktop CLI: visual + ergonomics refresh.** A single color theme across the CLI, aligned tables for `devices`/`sessions`, status dots for on/off states, and progress spinners for slow operations (the multi-endpoint pairing probe and the gateway connect) so nothing looks hung. Errors now suggest the fix (e.g. re-pair on auth failure).
 - **Desktop CLI: smoother pairing.** The multi-endpoint probe shows per-endpoint progress and latency; a near-expiry session warns before it fails and prints the exact re-pair command; and a bare `ws://host` (no port) defaults to `:8767`.
 - **Desktop CLI: voice + consent transparency.** `voice` now surfaces enhanced-voice capabilities (Gemini tone tags / persona, xAI speech tags); the desktop-tool consent prompt is clear that it persists per relay and points at `hermes-relay audit`; and computer-use's observe → grant → act flow is documented in `--help`.
+
+## [1.2.5] - 2026-06-27
+
+### Added
+
+- **Demo mode.** A "Try the demo" option on the setup / Connect screen — and on the empty chat screen if you skip setup — opens an offline preview of the real Chat UI: a sample conversation with Markdown, a tool-progress card, and a rich card, with zero setup and zero network (works in airplane mode). A persistent "Demo mode — sample data, not connected" banner offers a one-tap Connect that opens the real setup wizard; other tabs show a friendly "connect your Hermes server" empty state. Lets a first-run user — or a Play reviewer with no server — see what the app does before connecting.
 
 ### Fixed
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,9 @@
 # Hermes-Relay — Dev Log
 
+## 2026-06-27 — Released android-v1.2.5
+
+Bundles the day's Android work: the #131/#132 non-address-URL crash guard, the offline Demo / Explore mode, and the demo-reachability + App-access polish. Bumped `appVersionName` 1.2.4 → 1.2.5 and `appVersionCode` 18 → 19. Promoted the Android items into a `## [1.2.5]` CHANGELOG block; the Desktop CLI items stay in `[Unreleased]` for a future `cli-v*` release. Refreshed `RELEASE_NOTES.md`, the in-app `whats_new.txt` + `changelog.json`, and the Play `what's-new`. Released via a `dev → main` merge and the `android-v1.2.5` tag; `release-android.yml` builds the signed APK/AAB + GitHub Release. Play upload and the App-access "Try the demo" declaration are owner-driven.
+
 ## 2026-06-27 — Add in-app Demo / Explore mode (offline, for Play review + first-run UX)
 
 **Why.** Google Play rejected v1.2.4 under "App access": a reviewer opened the app, had no Hermes server to point it at, hit the empty Connect/setup wall, and bounced. The app is a client for a user-run Hermes server, so there is no content without a connection — and there was no offline path. This adds an in-app Demo mode so anyone (a reviewer or a first-run user) can see the app work with zero setup and zero network; Play Console "App access" can then declare that all functionality is reachable via "Try the demo" (no login). It doubles as a first-run UX win.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,22 +1,22 @@
-# Hermes-Relay-Android v1.2.4
+# Hermes-Relay-Android v1.2.5
 
-**Release Date:** June 25, 2026
-**Since v1.2.3:** A second connection-stability fix plus a new way to see whether your connection is encrypted. A transient blip on the dashboard session check — a pooled connection aborting or timing out over Tailscale — could still hard-close the app even after the v1.2.3 fix; that path is now handled cleanly. And the app now shows, at a glance, whether each transport is encrypted.
+**Release Date:** June 27, 2026
+**Since v1.2.4:** A crash fix and a new way to explore the app before connecting. A non-URL value entered in a server address field — a UI label, or a line copied from the docs — could force-close the app on the Manage / sign-in screen; that's now caught with an inline error. And a new offline **Try the demo** mode lets anyone preview the chat experience with no server, account, or network.
 
-v1.2.4 is recommended for anyone connecting over Tailscale or public TLS. Plain-LAN connections were never affected by the crash.
+v1.2.5 is recommended for everyone.
 
 ---
 
 ## Download
 
-v1.2.4 ships in two Android build flavors. APK and AAB filenames are version-tagged:
+v1.2.5 ships in two Android build flavors. APK and AAB filenames are version-tagged:
 
 | Flavor | File | Who it's for |
 |---|---|---|
-| Google Play | `hermes-relay-1.2.4-googlePlay-release.aab` | Upload this Android App Bundle to Play Console. It has no AccessibilityService, screen reading, screenshots, gestures, SMS/calls, contacts/location, overlays, or unattended phone control. |
-| sideload | `hermes-relay-1.2.4-sideload-release.apk` | Direct-install APK for full Device Control. Installs as `com.axiomlabs.hermesrelay.sideload`. |
-| googlePlay APK | `hermes-relay-1.2.4-googlePlay-release.apk` | Parity/testing artifact. |
-| sideload AAB | `hermes-relay-1.2.4-sideload-release.aab` | Parity/testing artifact. |
+| Google Play | `hermes-relay-1.2.5-googlePlay-release.aab` | Upload this Android App Bundle to Play Console. It has no AccessibilityService, screen reading, screenshots, gestures, SMS/calls, contacts/location, overlays, or unattended phone control. |
+| sideload | `hermes-relay-1.2.5-sideload-release.apk` | Direct-install APK for full Device Control. Installs as `com.axiomlabs.hermesrelay.sideload`. |
+| googlePlay APK | `hermes-relay-1.2.5-googlePlay-release.apk` | Parity/testing artifact. |
+| sideload AAB | `hermes-relay-1.2.5-sideload-release.aab` | Parity/testing artifact. |
 
 Verify integrity with `SHA256SUMS.txt` from the same release. See the [Sideload guide](https://codename-11.github.io/hermes-relay/guide/getting-started.html#sideload-apk) for APK install steps.
 
@@ -25,14 +25,13 @@ Verify integrity with `SHA256SUMS.txt` from the same release. See the [Sideload 
 ## Highlights
 
 ### Fixed
-- **No more crash when the dashboard connection drops mid-check.** A transient network failure on the dashboard session check — for example a pooled connection aborting or timing out over Tailscale — could still force-close the app: the check returned a result type but re-threw the network error instead of reporting it, and it surfaced on the main thread. The check now reports the failure cleanly and the connection probe degrades gracefully, so a flaky link can no longer crash the app. (#129)
+- **No more crash when a non-address is entered as a server URL.** Typing or pasting non-URL text — for example a UI label, or a line copied from the docs — into the API server or Dashboard URL field could force-close the app on the Manage / sign-in screen: the value was handed to the networking layer as a host, which rejected it with an uncaught error on the main thread. The setup fields now reject anything that isn't a valid host or `http(s)://` URL with an inline error, and the dashboard and voice request paths treat a malformed address as "unreachable" instead of ever crashing. (#131, #132)
 
 ### Added
-- **See whether your connection is encrypted.** The chat status chip, the connection card, and the route picker now show your encryption state at a glance — 🔒 **Encrypted · TLS**, 🛡️ **Encrypted · Tailscale** (both secure), 🛡️ **Mixed routes**, or ⚠️ **Not encrypted** — and tapping it opens a per-transport breakdown (chat, API, relay tools). A Tailscale or WireGuard route is now correctly shown as encrypted rather than implied insecure. A new ["Is my connection secure?"](https://codename-11.github.io/hermes-relay/architecture/connection-security.html) docs page explains the difference between TLS and overlay (WireGuard) encryption.
+- **Try the demo.** A new "Try the demo" option on the setup / Connect screen — and on the empty chat screen if you skip setup — opens an offline preview of the real Chat UI: a sample conversation with Markdown, a tool-progress card, and a rich card, with zero setup and zero network (it works in airplane mode). A "Demo mode — sample data, not connected" banner offers a one-tap Connect into the real setup wizard. Lets a first-run user — or anyone curious — see what the app does before connecting a server.
 
 ---
 
 ## Upgrade notes
 - This is an app-side release on **both** flavors — no Device Control or server changes needed.
-- If you connect over Tailscale or HTTPS, update and reconnect.
-- `appVersionCode` is **18**.
+- `appVersionCode` is **19**.

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,4 +1,4 @@
-v1.2.4 — Stability + connection security.
+v1.2.5 — Stability + Try the demo.
 
-• Fixed a crash that could close the app when the dashboard connection dropped mid-check (e.g. a brief Tailscale blip) — it now fails gracefully instead of force-closing.
-• New: see whether your connection is encrypted at a glance (TLS or Tailscale) from the chat chip, connection card, and route picker, with a per-transport breakdown on tap.
+• Fixed a crash that could close the app when a non-URL value (like a label or a line copied from the docs) was entered in a server address field — it now shows an inline error instead.
+• New: Try the demo — explore an offline preview of the chat experience with no server or setup, right from the first screen.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -1,6 +1,25 @@
 {
   "versions": [
     {
+      "version": "1.2.5",
+      "title": "Stability + Try the demo",
+      "date": "2026-06-27",
+      "sections": [
+        {
+          "header": "Stability",
+          "bullets": [
+            "Fixed a crash that could close the app when a non-URL value — a UI label, or a line copied from the docs — was entered in the API server or Dashboard URL field. The setup fields now reject anything that isn't a valid host or http(s) URL with an inline error, and the dashboard and voice request paths treat a bad address as unreachable instead of crashing."
+          ]
+        },
+        {
+          "header": "Try the demo",
+          "bullets": [
+            "A new \"Try the demo\" option on the setup screen — and on the empty chat screen if you skip setup — opens an offline preview of the real chat experience: a sample conversation with Markdown, a tool-progress card, and a rich card, with no server, account, or network. A banner shows it's a demo, with a one-tap Connect to set up for real."
+          ]
+        }
+      ]
+    },
+    {
       "version": "1.2.4",
       "title": "Stability + connection security",
       "date": "2026-06-25",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,11 +1,11 @@
-v1.2.4 - Stability + connection security
+v1.2.5 - Stability + Try the demo
 
 Stability
-* Fixed a crash that could close the app when the dashboard connection
-  dropped mid-check (e.g. a brief Tailscale blip). The check now fails
-  gracefully instead of force-closing.
+* Fixed a crash that could close the app when a non-URL value — like a
+  label or a line copied from the docs — was entered in a server address
+  field. It now shows an inline error instead of force-closing.
 
 New
-* See whether your connection is encrypted at a glance — the chat chip,
-  connection card, and route picker now show TLS or Tailscale encryption,
-  with a per-transport breakdown on tap.
+* Try the demo — explore an offline preview of the chat experience with
+  no server, account, or network, right from the welcome screen (and the
+  empty chat screen if you skip setup).

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -85,10 +85,10 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.2.4 — Stability + connection security.
+v1.2.5 — Stability + Try the demo.
 
-• Fixed a crash that could close the app when the dashboard connection dropped mid-check (e.g. a brief Tailscale blip) — it now fails gracefully instead of force-closing.
-• New: see whether your connection is encrypted at a glance (TLS or Tailscale) from the chat chip, connection card, and route picker, with a per-transport breakdown on tap.
+• Fixed a crash that could close the app when a non-URL value (like a label or a line copied from the docs) was entered in a server address field — it now shows an inline error instead.
+• New: Try the demo — explore an offline preview of the chat experience with no server or setup, right from the first screen.
 ```
 
 ## Category

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.2.4"
-appVersionCode = "18"
+appVersionName = "1.2.5"
+appVersionCode = "19"
 agp = "9.2.1"
 kotlin = "2.4.0"
 compose-bom = "2026.06.00"


### PR DESCRIPTION
Version bump + release notes for **android-v1.2.5**. Bundles the three changes already merged to `dev` today:

- **#136** — #131/#132 non-address-URL crash guard (shared `ServerAddress` validation + `resolveUrl()` request guards)
- **#137** — offline **Demo mode** ("Try the demo")
- **#138** — demo reachable from every first-run dead-end + tightened App-access copy

## This PR
- `appVersionName` **1.2.4 → 1.2.5**, `appVersionCode` **18 → 19**
- CHANGELOG: promote the **Android** items into `## [1.2.5]`; the **Desktop CLI** items stay in `[Unreleased]` for a future `cli-v*` release
- Refresh `RELEASE_NOTES.md`, in-app `whats_new.txt` + `changelog.json`, the Play `what's-new`, and the listing release-notes block

After this lands on `dev`, the release merges `dev → main` and tags `android-v1.2.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)