### PR TITLE
fix(dev-loop): brief filter matches Claude-app comments; bump github-script; tidy deep-dive

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label from title prefix + keyword area
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
         with:
@@ -258,7 +258,8 @@ jobs:
             2. INVESTIGATE: trace the relevant code paths. Identify the specific files/functions involved.
                Distinguish what you VERIFIED in the code from what remains a hypothesis.
             3. POST one comment (`gh issue comment ${{ github.event.issue.number }} --body "..."`) with these
-               sections, in Markdown:
+               sections, in Markdown. The `##`/`**bold**` headings below ARE the section separators — do NOT add
+               horizontal rules (`---`) between sections or directly under the H2; keep it clean and scannable:
 
                ## 🔬 Deep-dive analysis
                **Root-cause hypothesis** — your best explanation with the supporting code evidence. Label your

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,16 @@
 # Hermes-Relay — Dev Log
 
+## 2026-06-28 — Dev-loop polish after the live smoke test
+
+**Why.** End-to-end testing the triage workflow on `main` (issue #150 through open → `triage:deep` → reply, plus a dispatch against #146) surfaced three things to tidy.
+
+**What.**
+- **`start-issue.sh` brief filter fix.** Triage/deep-dive/follow-up comments are posted by the **Claude GitHub App** (author `claude`), not `github-actions` — so the brief generator's `author.login=="github-actions"` filter would have produced an empty "Automated triage notes" section. Switched to an identity-proof match on the comment signatures (`automated triage` / `Deep-dive analysis` / `automated follow-up`), with the bot logins as a fallback.
+- **`actions/github-script@v7` → `@v8`.** Clears the Node 20 deprecation annotation (v8 targets Node 24).
+- **Deep-dive formatting.** Prompt now tells the deep-dive to use its `##`/bold headings as the section separators and not to add horizontal rules (`---`) between sections — the first run rendered a rule under every heading, which read heavy.
+
+**Verification.** Smoke test confirmed all four jobs behave as designed: auto-label + opinionated triage (3 real likely-files), label-gated deep-dive (root cause + fix + surface-aware verification + worktree quick-start), and follow-up gating (skips bot + owner comments; response path is external-reporter-only by design). The workflow tweaks here activate on the next `dev → main` merge; the script fix is live from `dev`.
+
 ## 2026-06-28 — Opinionated issue triage + deep-dive + follow-up loop + issue→worktree dev-loop
 
 **Why.** `claude-triage.yml` was a deliberately conservative classifier — label, dedupe, and one hedged note, with no root-cause opinion and no fix suggestion by design. To shorten the issue→fix loop, triage should also diagnose and hand off a starting branch/worktree, and do it surface-aware: plugin/CLI fixes can be CI-proven, while Android UI/behavior stays a manual on-device gate. Modeled on the MeshMonitor (`Yeraze/meshmonitor`) multi-job triage, ported to our `claude-code-action@v1` interface (`prompt` + `claude_args`, not the older `@beta` `direct_prompt`/`model`/`use_sticky_comment` shape), with the existing untrusted-input hardening kept.

--- a/scripts/start-issue.sh
+++ b/scripts/start-issue.sh
@@ -169,8 +169,11 @@ BRIEF="${WTDIR}/ISSUE-BRIEF.md"
   echo
   echo "## Automated triage / deep-dive notes"
   echo
+  # Triage/deep-dive/follow-up comments are posted by the Claude GitHub App
+  # (author "claude"), NOT "github-actions" — so match on our comment signatures
+  # (identity-proof), with the known bot logins as a fallback.
   BOTNOTES="$(gh issue view "$N" --json comments \
-    --jq '.comments[] | select(.author.login=="github-actions" or .author.login=="github-actions[bot]") | "_" + .createdAt + "_\n\n" + .body + "\n\n---\n"')"
+    --jq '.comments[] | select(((.body // "") | test("automated triage|Deep-dive analysis|automated follow-up")) or ((.author.login // "") | test("^(claude|github-actions)"))) | "_" + .createdAt + "_\n\n" + .body + "\n\n---\n"')"
   if [ -n "$BOTNOTES" ]; then
     printf '%s\n' "$BOTNOTES"
   else


### PR DESCRIPTION
Follow-ups from the live triage smoke test (#150 end-to-end + a dispatch against #146). All three are small.

## Changes
- **`start-issue.sh` brief filter (the real bug).** The brief's "Automated triage notes" section filtered on author `github-actions`, but triage/deep-dive/follow-up comments are posted by the **Claude GitHub App** (author `claude`) — so the section came up **empty**, defeating the local bridge. Switched to an identity-proof match on the comment signatures (`automated triage` / `Deep-dive analysis` / `automated follow-up`), with the bot logins as a fallback. **Verified against #150:** the new filter returns the 2 bot notes and excludes owner comments.
- **`actions/github-script@v7` → `@v8`.** Clears the Node 20 deprecation annotation (v8 targets Node 24). Only one usage in the repo (auto-label job).
- **Deep-dive formatting.** Prompt now tells the deep-dive to use its `##`/bold headings as section separators and not add horizontal rules (`---`) — the first run rendered a rule under every heading, which read heavy.

## Activation note
The two `claude-triage.yml` tweaks (github-script bump, deep-dive formatting) run the **default-branch** copy, so they activate on the next `dev → main` merge. The `start-issue.sh` fix is live from `dev` immediately (local script).

## Smoke-test outcome (for context)
All four jobs behaved as designed: auto-label + opinionated triage (3 real likely-files), label-gated deep-dive (root cause + fix + surface-aware verification + worktree quick-start), and follow-up gating (skips bot + owner comments; response path is external-reporter-only by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)