### PR TITLE
Add upstream-impact Relay guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Server-backed session cleanup plumbing.** The dashboard client now supports single-session export, the upstream `/api/sessions/prune` route with a mandatory dry-run preview before destructive apply, plus soft archive/restore helpers and an `archived` session-list filter for the Manage surface.
 - **Voice settings: edit your server's voice engine.** Voice settings now has a **Server voice config** section that reads and writes the host's text-to-speech and speech-to-text settings — provider, voice, model, language, and per-provider options — over the dashboard, the same config the official desktop app edits. It includes an **ElevenLabs voice picker** that lists the voices available on your server's ElevenLabs key (and tells you when no key is set). Works on the no-plugin (Standard) path; sign in to Manage to use it.
 - **Desktop CLI: `hermes-relay audit`.** Shows what the remote agent has actually run on this machine through the desktop tools — tool, status, and a short detail per call — read from a local log, no network or auth. Answers "what did the agent just do?" at a glance.
 - **Desktop CLI: `hermes-relay relay`.** Inspect the relay server itself: `relay info` (version, uptime, sessions — on the relay host), `relay security` (runtime auth toggles), `relay context` (audit the system-prompt context the relay injects into the agent, which works from a remote machine with your session), and `relay queue` (list — or `--clear` / `--cancel <id>` — the messages your agent queued for an offline phone; on the relay host).
@@ -43,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Doctor catches dashboard URLs pointed at the wrong Hermes surface.** `hermes relay doctor` now distinguishes the dashboard/Manage surface from an API-server/headless backend URL and tells operators to use `hermes dashboard` when a configured dashboard URL is actually pointing at `hermes serve` / the API server.
 - **Back button on Manage and Bridge now works.** The back arrow on the Manage ("Hermes management") and Bridge screens did nothing — it tried to jump to Chat in a way that silently no-op'd. Back now reliably returns to the screen you opened it from.
 - **Dropped relay connections from a status-report race.** The phone's periodic device-status report could occasionally be sent to the relay *before* the connection had finished authenticating, which made the relay reject the whole connection and forced a reconnect. The app now holds every message until the connection is authenticated, so the handshake always completes first.
 - **Fewer needless connection re-checks when switching apps.** Returning to the app after a quick glance at another app no longer triggers a full connection re-probe (and the brief "checking…" flash) when the connection was already healthy — it only re-checks after a longer absence or if something actually looks off.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,29 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-06 — Upstream-impact guardrails: dashboard surface + session cleanup
+
+**Why.** The upstream-impact watch flagged two Relay-adjacent changes: `hermes serve`
+now represents the headless backend path while `hermes dashboard` remains the Manage/UI
+surface, and newer upstream session APIs expose safer server-side cleanup primitives.
+Relay needed concrete compatibility seams so Android and operators do not treat those
+surfaces interchangeably or delete sessions client-side without a server preview.
+
+**What.**
+- `hermes relay doctor` now probes the configured dashboard URL for both
+  `/api/status` and `/v1/capabilities`, classifies whether it is the dashboard/Manage
+  surface or an API-server/headless URL, and prints an actionable `hermes dashboard`
+  fix when it is not the Manage surface. It also probes `/api/sessions/prune` with
+  `HEAD` only so diagnostics can report server-backed cleanup support without ever
+  running a prune.
+- `DashboardApiClient` gained single-session export, soft archive/restore helpers, an
+  optional `archived` list filter, and `previewSessionPrune` / `pruneSessions` wrappers
+  around upstream `/api/sessions/prune`. The destructive apply requires a
+  caller-supplied preview and short-circuits when the preview matched nothing.
+- Session cleanup docs now record the export, archive, and prune contract; dashboard
+  docs call out `hermes dashboard` vs. headless `hermes serve`.
+
+**Verification.** `python -m unittest plugin.tests.test_doctor`; `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :app:testSideloadDebugUnitTest --tests com.hermesandroid.relay.network.upstream.DashboardApiClientTest`.
+
 ## 2026-07-01 — Realtime voice: live background-run chip (progress, phases, cancel)
 
 **Why.** With timer-driven spoken progress off by default (see the robustness batch

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
@@ -7,6 +7,9 @@ import com.hermesandroid.relay.network.upstream.models.MessageItem
 import com.hermesandroid.relay.network.upstream.models.MessageListResponse
 import com.hermesandroid.relay.network.upstream.models.SessionItem
 import com.hermesandroid.relay.network.upstream.models.SessionListResponse
+import com.hermesandroid.relay.network.upstream.models.SessionPruneFilters
+import com.hermesandroid.relay.network.upstream.models.SessionPrunePreview
+import com.hermesandroid.relay.network.upstream.models.SessionPruneResult
 import com.hermesandroid.relay.auth.SecureStoreCache
 import com.hermesandroid.relay.auth.SessionTokenStore
 import com.hermesandroid.relay.auth.buildRawTokenStore
@@ -508,7 +511,11 @@ class DashboardApiClient(
      * ordering where the host honors it. Android still sorts by decoded
      * `last_active` locally because older hosts return started-time order.
      */
-    suspend fun listSessions(profile: String? = null, limit: Int = 200): Result<List<SessionItem>> =
+    suspend fun listSessions(
+        profile: String? = null,
+        limit: Int = 200,
+        archived: String? = null,
+    ): Result<List<SessionItem>> =
         withContext(Dispatchers.IO) {
             val query = buildList {
                 add("limit=${limit.coerceIn(1, 200)}")
@@ -516,6 +523,10 @@ class DashboardApiClient(
                 add("min_messages=1")
                 val name = profile?.trim().orEmpty()
                 if (name.isNotBlank()) add("profile=${pathSegment(name)}")
+                // Upstream `archived` filter: exclude (default) | only | include.
+                // Omitted unless requested so older hosts see an unchanged request.
+                val archivedMode = archived?.trim().orEmpty()
+                if (archivedMode.isNotBlank()) add("archived=${pathSegment(archivedMode)}")
             }.joinToString(prefix = "?", separator = "&")
             getJson("/api/sessions$query").mapCatching { root ->
                 val parsed = json.decodeFromJsonElement(SessionListResponse.serializer(), root)
@@ -556,17 +567,96 @@ class DashboardApiClient(
         deleteJsonObject("/api/sessions/${pathSegment(sessionId)}${profileQuery(profile)}")
 
     /**
+     * Export one session as server-owned JSON metadata + messages. This is the
+     * safe "archive a copy before cleanup" primitive for clients that want to
+     * offer download/share before a destructive delete or prune. Profile scoping
+     * matches [deleteSession].
+     */
+    suspend fun exportSession(sessionId: String, profile: String? = null): Result<JsonObject> =
+        getJsonObject("/api/sessions/${pathSegment(sessionId)}/export${profileQuery(profile)}")
+
+    /**
      * Rename a session scoped to a profile via the dashboard
-     * `PATCH /api/sessions/{id}?profile=` surface — the write twin of
-     * [deleteSession]. A non-default profile's sessions live in that profile's
-     * own `state.db`, so the unscoped api_server rename would patch the wrong
-     * DB and the new title would never appear in the profile-scoped list.
+     * `PATCH /api/sessions/{id}` surface — the write twin of [deleteSession].
+     * A non-default profile's sessions live in that profile's own `state.db`,
+     * so the unscoped api_server rename would patch the wrong DB and the new
+     * title would never appear in the profile-scoped list. Current upstream
+     * reads `profile` from the PATCH body (`SessionRename`); the query param
+     * rides along for builds that scoped by query.
      */
     suspend fun renameSession(sessionId: String, title: String, profile: String? = null): Result<JsonObject> =
         patchJsonObject(
             "/api/sessions/${pathSegment(sessionId)}${profileQuery(profile)}",
-            buildJsonObject { put("title", title) },
+            buildJsonObject {
+                put("title", title)
+                profile?.trim()?.takeIf { it.isNotBlank() }?.let { put("profile", it) }
+            },
         )
+
+    /**
+     * Soft-archive or restore a session via the same dashboard
+     * `PATCH /api/sessions/{id}` surface (`{archived: true|false}`). Archived
+     * sessions drop out of the default list and are excluded from a prune
+     * unless [SessionPruneFilters.includeArchived] is set; list them back with
+     * [listSessions] `archived = "only"`. Profile scoping matches
+     * [renameSession]: body for current upstream, query for older builds.
+     */
+    suspend fun setSessionArchived(
+        sessionId: String,
+        archived: Boolean,
+        profile: String? = null,
+    ): Result<JsonObject> =
+        patchJsonObject(
+            "/api/sessions/${pathSegment(sessionId)}${profileQuery(profile)}",
+            buildJsonObject {
+                put("archived", archived)
+                profile?.trim()?.takeIf { it.isNotBlank() }?.let { put("profile", it) }
+            },
+        )
+
+    /**
+     * Dry-run a server-backed bulk session cleanup via the dashboard
+     * `POST /api/sessions/prune` (`dry_run: true`). Returns what WOULD be
+     * deleted — matched count, started-at span, and the candidate rows —
+     * without deleting anything. This is the required first step of the
+     * prune flow: show the preview, then pass it to [pruneSessions].
+     */
+    suspend fun previewSessionPrune(filters: SessionPruneFilters): Result<SessionPrunePreview> =
+        postJsonObject("/api/sessions/prune", filters.toPrunePayload(dryRun = true))
+            .mapCatching { root ->
+                json.decodeFromJsonElement(SessionPrunePreview.serializer(), root)
+            }
+
+    /**
+     * Apply a server-backed bulk session cleanup (`POST /api/sessions/prune`,
+     * `dry_run: false`). Destructive — [confirmedPreview] is required so no
+     * caller can reach this without first running [previewSessionPrune] with
+     * the same [filters] and showing the user its count/span. A preview that
+     * matched nothing short-circuits without touching the server: sessions
+     * that aged into the filter after the preview are not covered by what the
+     * user confirmed.
+     */
+    suspend fun pruneSessions(
+        filters: SessionPruneFilters,
+        confirmedPreview: SessionPrunePreview,
+    ): Result<SessionPruneResult> {
+        if (confirmedPreview.matched <= 0) {
+            return Result.success(SessionPruneResult(ok = true, removed = 0))
+        }
+        return postJsonObject("/api/sessions/prune", filters.toPrunePayload(dryRun = false))
+            .mapCatching { root ->
+                json.decodeFromJsonElement(SessionPruneResult.serializer(), root)
+            }
+    }
+
+    private fun SessionPruneFilters.toPrunePayload(dryRun: Boolean): JsonObject =
+        buildJsonObject {
+            olderThanDays?.let { put("older_than_days", it) }
+            source?.trim()?.takeIf { it.isNotBlank() }?.let { put("source", it) }
+            profile?.trim()?.takeIf { it.isNotBlank() }?.let { put("profile", it) }
+            if (includeArchived) put("include_archived", true)
+            put("dry_run", dryRun)
+        }
 
     private fun parseProfiles(root: JsonObject): List<Profile> {
         fun decode(element: JsonElement, nameOverride: String?): Profile? = runCatching {

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/models/SessionModels.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/models/SessionModels.kt
@@ -179,6 +179,58 @@ data class RenameSessionRequest(
     val title: String
 )
 
+// --- Server-backed bulk cleanup (dashboard POST /api/sessions/prune) ---
+
+/**
+ * Client-side subset of upstream's `SessionPrune` body. Nulls are omitted from
+ * the request; a fully-bare filter set is a "bare prune", where upstream
+ * applies its own implicit ended-more-than-90-days-ago cutoff.
+ */
+data class SessionPruneFilters(
+    val olderThanDays: Double? = null,
+    val source: String? = null,
+    val profile: String? = null,
+    val includeArchived: Boolean = false,
+)
+
+/** One row of the dry-run preview (`sessions` in the prune response). */
+@Serializable
+data class SessionPruneCandidate(
+    @Serializable(with = FlexibleIdNonNullSerializer::class)
+    val id: String = "",
+    val source: String? = null,
+    val title: String? = null,
+    val model: String? = null,
+    @SerialName("started_at")
+    @Serializable(with = FlexibleTimestampSerializer::class)
+    val startedAt: Double? = null,
+    @SerialName("message_count") val messageCount: Int? = null,
+)
+
+/**
+ * Dry-run response: what a prune WOULD delete — count, started-at span, and
+ * the candidate rows — without deleting anything. Upstream orders candidates
+ * oldest-first.
+ */
+@Serializable
+data class SessionPrunePreview(
+    val matched: Int = 0,
+    @SerialName("oldest_started_at")
+    @Serializable(with = FlexibleTimestampSerializer::class)
+    val oldestStartedAt: Double? = null,
+    @SerialName("newest_started_at")
+    @Serializable(with = FlexibleTimestampSerializer::class)
+    val newestStartedAt: Double? = null,
+    val sessions: List<SessionPruneCandidate> = emptyList(),
+)
+
+/** Apply response — how many sessions the server actually removed. */
+@Serializable
+data class SessionPruneResult(
+    val ok: Boolean = true,
+    val removed: Int = 0,
+)
+
 // --- Messages ---
 
 @Serializable

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
@@ -1,5 +1,7 @@
 package com.hermesandroid.relay.network.upstream
 
+import com.hermesandroid.relay.network.upstream.models.SessionPruneFilters
+import com.hermesandroid.relay.network.upstream.models.SessionPrunePreview
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.Json
@@ -701,6 +703,213 @@ class DashboardApiClientTest {
 
         assertEquals("/api/config", server.takeRequest().path)
         assertEquals("/api/config/schema", server.takeRequest().path)
+    }
+
+    @Test
+    fun previewSessionPrune_postsDryRunAndParsesPreview() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {"ok":true,"removed":0,"matched":2,
+                     "oldest_started_at":1000.5,"newest_started_at":2000.5,
+                     "sessions":[
+                       {"id":"sess-old","source":"phone","title":"Old plan","model":"claude-opus-4-8","started_at":1000.5,"message_count":3},
+                       {"id":"sess-new","source":"phone","started_at":2000.5,"message_count":1}
+                     ]}
+                    """.trimIndent(),
+                ),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        val preview = client.previewSessionPrune(
+            SessionPruneFilters(olderThanDays = 30.0, source = "phone", profile = "mizu"),
+        ).getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/sessions/prune", request.path)
+        val body = request.body.readUtf8()
+        // The preview MUST be a dry run — this call may never delete.
+        assertTrue(body.contains(""""dry_run":true"""))
+        assertTrue(body.contains(""""older_than_days":30.0"""))
+        assertTrue(body.contains(""""source":"phone""""))
+        assertTrue(body.contains(""""profile":"mizu""""))
+        assertEquals(2, preview.matched)
+        assertEquals(1000.5, preview.oldestStartedAt!!, 0.001)
+        assertEquals(2000.5, preview.newestStartedAt!!, 0.001)
+        assertEquals("sess-old", preview.sessions[0].id)
+        assertEquals(3, preview.sessions[0].messageCount)
+        assertEquals("Old plan", preview.sessions[0].title)
+    }
+
+    @Test
+    fun previewSessionPrune_bareFiltersOmitOptionalFields() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"ok":true,"removed":0,"matched":0,"sessions":[]}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        client.previewSessionPrune(SessionPruneFilters()).getOrThrow()
+
+        val body = server.takeRequest().body.readUtf8()
+        // A bare prune sends only dry_run; upstream then applies its own
+        // implicit ended-more-than-90-days-ago cutoff.
+        assertTrue(body.contains(""""dry_run":true"""))
+        assertFalse(body.contains("older_than_days"))
+        assertFalse(body.contains("source"))
+        assertFalse(body.contains("profile"))
+        assertFalse(body.contains("include_archived"))
+    }
+
+    @Test
+    fun pruneSessions_appliesWithDryRunFalseAndParsesRemoved() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"ok":true,"removed":2}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        val filters = SessionPruneFilters(olderThanDays = 30.0, source = "phone")
+        val preview = SessionPrunePreview(matched = 2)
+        val result = client.pruneSessions(filters, confirmedPreview = preview).getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/sessions/prune", request.path)
+        val body = request.body.readUtf8()
+        assertTrue(body.contains(""""dry_run":false"""))
+        assertTrue(body.contains(""""older_than_days":30.0"""))
+        assertEquals(2, result.removed)
+    }
+
+    @Test
+    fun pruneSessions_skipsServerCallWhenPreviewMatchedNothing() = runTest {
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        val result = client.pruneSessions(
+            SessionPruneFilters(olderThanDays = 30.0),
+            confirmedPreview = SessionPrunePreview(matched = 0),
+        ).getOrThrow()
+
+        // Nothing matched at preview time → nothing to delete. The client must
+        // not fire the destructive POST at all (sessions that aged in after
+        // the preview are not covered by what the user confirmed).
+        assertEquals(0, server.requestCount)
+        assertEquals(0, result.removed)
+    }
+
+    @Test
+    fun exportSession_getsServerOwnedArchiveJsonScopedToProfile() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"id":"sess-old","messages":[]}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        val exported = client.exportSession("sess-old", profile = "mizu").getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/sessions/sess-old/export", request.requestUrl!!.encodedPath)
+        assertEquals("mizu", request.requestUrl!!.queryParameter("profile"))
+        assertEquals("sess-old", exported["id"].toString().trim('"'))
+    }
+
+    @Test
+    fun setSessionArchived_patchesArchivedScopedToProfile() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"ok":true,"title":"Old plan","archived":true}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        client.setSessionArchived("sess-old", archived = true, profile = "mizu").getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("PATCH", request.method)
+        // Current upstream reads profile from the PATCH body (SessionRename
+        // model); the query param rides along for builds that scoped by query.
+        assertEquals("/api/sessions/sess-old", request.requestUrl!!.encodedPath)
+        assertEquals("mizu", request.requestUrl!!.queryParameter("profile"))
+        val body = request.body.readUtf8()
+        assertTrue(body.contains(""""archived":true"""))
+        assertTrue(body.contains(""""profile":"mizu""""))
+    }
+
+    @Test
+    fun setSessionArchived_omitsProfileForDefaultSelection() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"ok":true,"title":"","archived":false}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        client.setSessionArchived("sess-old", archived = false, profile = null).getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals(null, request.requestUrl!!.queryParameter("profile"))
+        val body = request.body.readUtf8()
+        assertTrue(body.contains(""""archived":false"""))
+        assertFalse(body.contains("profile"))
+    }
+
+    @Test
+    fun renameSession_carriesProfileInBodyAndQuery() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"ok":true,"title":"New title"}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        client.renameSession("sess-a", title = "New title", profile = "mizu").getOrThrow()
+
+        val request = server.takeRequest()
+        assertEquals("PATCH", request.method)
+        assertEquals("/api/sessions/sess-a", request.requestUrl!!.encodedPath)
+        assertEquals("mizu", request.requestUrl!!.queryParameter("profile"))
+        val body = request.body.readUtf8()
+        assertTrue(body.contains(""""title":"New title""""))
+        // Current upstream reads profile from the PATCH body, not the query.
+        assertTrue(body.contains(""""profile":"mizu""""))
+    }
+
+    @Test
+    fun listSessions_passesArchivedFilterThrough() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"sessions":[],"total":0,"limit":50,"offset":0}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        client.listSessions(archived = "only").getOrThrow()
+
+        val url = server.takeRequest().requestUrl!!
+        assertEquals("only", url.queryParameter("archived"))
+    }
+
+    @Test
+    fun listSessions_omitsArchivedParamByDefault() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"sessions":[],"total":0,"limit":50,"offset":0}"""),
+        )
+
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+        client.listSessions().getOrThrow()
+
+        // Default stays upstream's default (exclude) with no param, so older
+        // hosts that predate the archived filter see an unchanged request.
+        assertEquals(null, server.takeRequest().requestUrl!!.queryParameter("archived"))
     }
 
     @Test

--- a/docs/upstream-surface-matrix.md
+++ b/docs/upstream-surface-matrix.md
@@ -22,7 +22,7 @@ Verified upstream source snapshot:
 | `/v1/capabilities` | Upstream API server | No | Capability probe | Source of truth for API-server features; current upstream advertises no audio API. |
 | `/v1/chat/completions` | Upstream API server | No | Chat fallback | OpenAI-compatible streaming. Tool events may degrade to inline annotations. |
 | `/v1/runs`, `/v1/runs/{id}/events` | Upstream API server | No | Chat fallback | Structured run events and stop/approval support. |
-| `/api/sessions/*` | Upstream API server | No | Session CRUD and SSE chat | Native upstream session list/create/read/update/delete/messages/fork/chat/chat-stream. Bootstrap is old-build fallback only. |
+| `/api/sessions/*` | Upstream API server/dashboard | No | Session CRUD, SSE chat, export, archive, and bulk cleanup | Native upstream session list/create/read/update/delete/messages/fork/chat/chat-stream. Newer hosts also expose single-session JSON export via `GET /api/sessions/{id}/export`, soft archive via `PATCH /api/sessions/{id}`, and guarded bulk cleanup via `POST /api/sessions/prune`; Android must dry-run prune first and show the matched count/span before destructive apply. Bootstrap is old-build fallback only. |
 | `/v1/skills`, `/v1/toolsets` | Upstream API server | No | Discovery | Read-only API-server skill/toolset inventory. |
 | Dashboard `/api/status`, `/api/auth/me` | Upstream dashboard | No | Manage auth | Dashboard cookie/session path; separate from API bearer. |
 | Dashboard `/api/auth/ws-ticket`, `/api/ws` | Upstream dashboard/tui_gateway | No | Preferred chat transport | Vanilla Hermes gateway chat path with live reasoning/thinking events. |

--- a/plugin/doctor.py
+++ b/plugin/doctor.py
@@ -138,6 +138,58 @@ def http_probe(
         }
 
 
+_MANAGE_SURFACE_FIX = (
+    "Manage, dashboard voice, and gateway chat need the dashboard/Manage "
+    "surface. Start it with `hermes dashboard` (default port 9119) and point "
+    "the dashboard URL at it; `hermes serve` is the headless backend command "
+    "and is not the Manage surface."
+)
+
+
+def classify_manage_surface(
+    status_probe: dict[str, Any],
+    capabilities_probe: dict[str, Any],
+) -> dict[str, Any]:
+    """Classify what the configured dashboard URL is actually serving.
+
+    ``status_probe`` is ``GET /api/status`` on the dashboard base (the
+    dashboard/Manage liveness marker); ``capabilities_probe`` is
+    ``GET /v1/capabilities`` on the same base, which only the API server
+    answers. The classification catches the two common misconfigurations:
+    pointing the dashboard slot at the API server, and pointing it at a host
+    where no dashboard is running at all.
+    """
+    if status_probe.get("ok"):
+        return {
+            "kind": "dashboard",
+            "summary": "dashboard URL answers the dashboard/Manage surface",
+            "recommendation": None,
+        }
+    if capabilities_probe.get("ok"):
+        return {
+            "kind": "api-server",
+            "summary": (
+                "dashboard URL answers like the Hermes API server, "
+                "not the dashboard/Manage surface"
+            ),
+            "recommendation": _MANAGE_SURFACE_FIX,
+        }
+    if status_probe.get("status") is None and capabilities_probe.get("status") is None:
+        return {
+            "kind": "unreachable",
+            "summary": "no dashboard/Manage surface reachable at the dashboard URL",
+            "recommendation": _MANAGE_SURFACE_FIX,
+        }
+    return {
+        "kind": "unknown",
+        "summary": (
+            "dashboard URL is reachable but did not answer like the "
+            "dashboard/Manage surface"
+        ),
+        "recommendation": _MANAGE_SURFACE_FIX,
+    }
+
+
 def _site_dirs(site_dirs: Iterable[Path] | None = None) -> list[Path]:
     if site_dirs is not None:
         return [Path(p) for p in site_dirs]
@@ -222,6 +274,22 @@ def collect_doctor_report(
         method="POST",
         timeout=timeout,
     )
+    # Same base as the dashboard URL on purpose: only the API server answers
+    # /v1/capabilities, so a hit here means the dashboard slot points at the
+    # API server instead of the dashboard/Manage surface.
+    dashboard_capabilities = probe(
+        _url(dashboard_base, "/v1/capabilities"),
+        method="GET",
+        timeout=timeout,
+    )
+    # HEAD, never POST: /api/sessions/prune deletes sessions. A POST-only
+    # FastAPI route answers HEAD with 405 when present and 404 when absent.
+    dashboard_sessions_prune = probe(
+        _url(dashboard_base, "/api/sessions/prune"),
+        method="HEAD",
+        timeout=timeout,
+    )
+    manage_surface = classify_manage_surface(dashboard_status, dashboard_capabilities)
     relay_info = probe(
         f"http://127.0.0.1:{int(port)}/relay/info",
         method="GET",
@@ -259,6 +327,23 @@ def collect_doctor_report(
         "dashboard /api/status reachable"
         if dashboard_status.get("ok")
         else "dashboard not reachable from this host",
+    )
+    _check(
+        checks,
+        "dashboard-manage-surface",
+        "ok" if manage_surface["kind"] == "dashboard" else "warn",
+        manage_surface["summary"],
+    )
+    _check(
+        checks,
+        "dashboard-session-prune",
+        "ok" if dashboard_sessions_prune.get("exists") else "warn",
+        "server-backed session cleanup route (/api/sessions/prune) exists"
+        if dashboard_sessions_prune.get("exists")
+        else (
+            "server-backed session cleanup route (/api/sessions/prune) was not "
+            "detected; bulk cleanup degrades to per-session deletes"
+        ),
     )
     _check(
         checks,
@@ -308,6 +393,9 @@ def collect_doctor_report(
                 "status": dashboard_status,
                 "audio_transcribe": dashboard_audio,
                 "ws_ticket": dashboard_ws_ticket,
+                "capabilities": dashboard_capabilities,
+                "sessions_prune": dashboard_sessions_prune,
+                "manage_surface": manage_surface,
             },
         },
         "relay": {
@@ -368,6 +456,12 @@ def render_doctor_text(report: dict[str, Any]) -> str:
     for check in report.get("checks", []):
         status = str(check.get("status", "unknown")).upper()
         lines.append(f"  [{status}] {check.get('id')}: {check.get('summary')}")
+
+    manage_surface = standard.get("dashboard", {}).get("manage_surface", {})
+    recommendation = manage_surface.get("recommendation")
+    if recommendation:
+        lines.append("")
+        lines.append(f"Fix: {recommendation}")
 
     lines.append("")
     lines.append(

--- a/plugin/tests/test_doctor.py
+++ b/plugin/tests/test_doctor.py
@@ -19,6 +19,24 @@ def _fake_probe(url: str, *, method: str = "GET", timeout: float = 2.0):
     }
 
 
+def _probe_map(responses):
+    """Probe stub keyed by exact URL; unknown URLs read as unreachable."""
+
+    def probe(url: str, *, method: str = "GET", timeout: float = 2.0):
+        base = {
+            "ok": False,
+            "exists": False,
+            "status": None,
+            "method": method,
+            "url": url,
+            "error": "unreachable",
+        }
+        override = responses.get(url, {})
+        return {**base, **override}
+
+    return probe
+
+
 class DoctorTests(unittest.TestCase):
     def test_collect_doctor_report_uses_standard_route_probes(self) -> None:
         with mock.patch("importlib.util.find_spec", return_value=None):
@@ -85,6 +103,108 @@ class DoctorTests(unittest.TestCase):
         self.assertIn("Hermes-Relay doctor", rendered)
         self.assertIn("[OK] plugin-root", rendered)
         self.assertIn("vanilla upstream Hermes", rendered)
+
+    def test_classify_manage_surface_ok_for_reachable_dashboard(self) -> None:
+        surface = doctor.classify_manage_surface(
+            {"ok": True, "exists": True, "status": 200},
+            {"ok": False, "exists": False, "status": None},
+        )
+
+        self.assertEqual(surface["kind"], "dashboard")
+        self.assertIsNone(surface["recommendation"])
+
+    def test_classify_manage_surface_flags_api_server_url(self) -> None:
+        surface = doctor.classify_manage_surface(
+            {"ok": False, "exists": False, "status": 404},
+            {"ok": True, "exists": True, "status": 200},
+        )
+
+        self.assertEqual(surface["kind"], "api-server")
+        self.assertIn("hermes dashboard", surface["recommendation"])
+        self.assertIn("hermes serve", surface["recommendation"])
+
+    def test_classify_manage_surface_unreachable_recommends_dashboard(self) -> None:
+        surface = doctor.classify_manage_surface(
+            {"ok": False, "exists": False, "status": None},
+            {"ok": False, "exists": False, "status": None},
+        )
+
+        self.assertEqual(surface["kind"], "unreachable")
+        self.assertIn("hermes dashboard", surface["recommendation"])
+
+    def test_doctor_warns_when_dashboard_url_answers_like_api_server(self) -> None:
+        probe = _probe_map(
+            {
+                "http://dash.example:8642/api/status": {"status": 404, "exists": False},
+                "http://dash.example:8642/v1/capabilities": {
+                    "ok": True,
+                    "exists": True,
+                    "status": 200,
+                },
+            }
+        )
+        with mock.patch("importlib.util.find_spec", return_value=None):
+            report = doctor.collect_doctor_report(
+                api_url="http://api.example:8642",
+                dashboard_url="http://dash.example:8642",
+                relay_port=9999,
+                probe=probe,
+                site_dirs=[],
+            )
+
+        surface = report["standard"]["dashboard"]["manage_surface"]
+        self.assertEqual(surface["kind"], "api-server")
+        check = next(
+            c for c in report["checks"] if c["id"] == "dashboard-manage-surface"
+        )
+        self.assertEqual(check["status"], "warn")
+
+        rendered = doctor.render_doctor_text(report)
+        self.assertIn("hermes dashboard", rendered)
+        self.assertIn("hermes serve", rendered)
+
+    def test_doctor_reports_session_prune_route(self) -> None:
+        with mock.patch("importlib.util.find_spec", return_value=None):
+            report = doctor.collect_doctor_report(
+                api_url="http://api.example:8642",
+                dashboard_url="http://dash.example:9119",
+                relay_port=9999,
+                probe=_fake_probe,
+                site_dirs=[],
+            )
+
+        prune = report["standard"]["dashboard"]["sessions_prune"]
+        self.assertEqual(prune["url"], "http://dash.example:9119/api/sessions/prune")
+        # Route probing must never POST — a real POST would run the prune.
+        self.assertEqual(prune["method"], "HEAD")
+        check = next(
+            c for c in report["checks"] if c["id"] == "dashboard-session-prune"
+        )
+        self.assertEqual(check["status"], "ok")
+
+    def test_doctor_warns_when_session_prune_route_missing(self) -> None:
+        probe = _probe_map(
+            {
+                "http://dash.example:9119/api/status": {
+                    "ok": True,
+                    "exists": True,
+                    "status": 200,
+                },
+            }
+        )
+        with mock.patch("importlib.util.find_spec", return_value=None):
+            report = doctor.collect_doctor_report(
+                api_url="http://api.example:8642",
+                dashboard_url="http://dash.example:9119",
+                relay_port=9999,
+                probe=probe,
+                site_dirs=[],
+            )
+
+        check = next(
+            c for c in report["checks"] if c["id"] == "dashboard-session-prune"
+        )
+        self.assertEqual(check["status"], "warn")
 
     def test_relay_cli_registers_doctor_command(self) -> None:
         parser = argparse.ArgumentParser()

--- a/user-docs/features/dashboard.md
+++ b/user-docs/features/dashboard.md
@@ -24,6 +24,8 @@ Nothing. The dashboard plugin renders in your browser against the Hermes server 
 
 Open the hermes-agent dashboard in your browser (default: `http://localhost:<dashboard_port>`). The **Relay** tab sits between Skills and whatever you have next in your nav order — click it and you land on the four-tab shell.
 
+Use the real dashboard/Manage surface for this URL: start it with `hermes dashboard` and point Android's Dashboard URL at that service (default `:9119`). `hermes serve` is a headless backend/API command; it is useful for programmatic clients, but it does not serve the Manage UI that Android uses for Skills, Models, Keys, Profiles, voice auth, or dashboard plugins. `hermes relay doctor` warns when the Dashboard URL looks like an API-server/headless URL instead of the dashboard surface.
+
 The plugin's header shows the relay version, overall health (green / red dot), and an **Auto-refresh** toggle that persists to `localStorage`. Turn auto-refresh off if you're reading a specific activity row and don't want it to scroll out from under you.
 
 ## Android Manage Surface

--- a/user-docs/guide/sessions.md
+++ b/user-docs/guide/sessions.md
@@ -27,6 +27,14 @@ Tap the edit icon next to a session in the drawer. Enter a new title and tap **R
 
 Tap the delete icon next to a session. Confirm in the dialog. This permanently deletes the session and its message history on the server.
 
+## Archive and Bulk Cleanup
+
+Newer Hermes servers expose two safer server-side cleanup primitives that Relay uses from the dashboard/Manage client layer:
+
+- **Export** — `GET /api/sessions/{id}/export` returns one session's metadata and messages as server-owned JSON, which clients can offer as a save/share step before destructive cleanup.
+- **Archive / restore** — a soft session state via `PATCH /api/sessions/{id}`. Archived sessions are hidden from the default drawer list but can be listed explicitly by clients that offer an archive view.
+- **Bulk cleanup** — `POST /api/sessions/prune`. Destructive cleanup must run as a dry-run first, showing the matched session count plus oldest/newest matched timestamps before applying. If the server does not expose this route, bulk cleanup should fall back to explicit per-session deletes rather than guessing locally.
+
 ## Session Persistence
 
 Your last active session is saved and automatically resumed when you reopen the app.


### PR DESCRIPTION
## Summary
- add `hermes relay doctor` guardrails that distinguish the dashboard/Manage surface from API-server/headless `hermes serve` URLs and report `/api/sessions/prune` availability without running a destructive request
- add Android dashboard-client plumbing for upstream session export, soft archive/restore, archived list filtering, and guarded bulk cleanup via dry-run-first `/api/sessions/prune`
- document the dashboard-vs-serve split and the server-backed session cleanup/export contract in user/dev docs, changelog, and DEVLOG

## Verification
- `python -m unittest plugin.tests.test_doctor`
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :app:testSideloadDebugUnitTest --tests com.hermesandroid.relay.network.upstream.DashboardApiClientTest`
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :app:lintSideloadDebug`

## Notes
This covers both upstream-impact follow-ups from the cron review: the dashboard/`serve` surface split and server-backed session cleanup/archive plumbing.
