### PR TITLE
fix(play): publish required contact email

### DIFF
--- a/app/src/googlePlay/play/contact-email.txt
+++ b/app/src/googlePlay/play/contact-email.txt
@@ -1,0 +1,1 @@
+info@axiom-labs.dev


### PR DESCRIPTION
## Summary

- publish `info@axiom-labs.dev` as the Google Play developer contact email
- store it in Gradle Play Publisher's canonical global metadata path

## Root cause

The Android 1.4.2 bundle upload and production draft succeeded. The separate static-listing workflow uploaded its text and screenshots into a Play edit, but Google rejected the final edit commit because the app had no contact email configured.

## Validation

- `python scripts/screenshots.py validate`
- `git diff --check`

After this reaches `main`, the path-scoped listing workflow will republish the metadata through the existing Play service account.
