### PR TITLE
fix(play): publish required contact email

### DIFF
--- a/app/src/googlePlay/play/contact-email.txt
+++ b/app/src/googlePlay/play/contact-email.txt
@@ -1,0 +1,1 @@
+info@axiom-labs.dev


### PR DESCRIPTION
Promotes the validated Play contact-email metadata from dev to main. This enables the path-scoped Play listing workflow to commit app details, text, and screenshots through the existing service account. Root cause: the 1.4.2 artifact draft uploaded successfully, but Google rejected the separate listing edit because its required contact email was blank. Source PR: #185.