### PR TITLE
fix(website): add Coolify root-context build

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,17 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-15 — Coolify root-context website deployment hotfix
+
+Added a repository-owned multi-stage Dockerfile for the Astro marketing site
+and corrected its Coolify instructions. Production builds now keep the
+repository root as Docker context, run the existing `build:production` gate
+from `website/`, and serve the generated static output with Nginx. This keeps
+the site's canonical screenshot comparison against `docs/media/` intact while
+avoiding Nixpacks' incorrect Android/Gradle provider selection at monorepo root.
+
+Verification: local website checks, production build, link validation, Docker
+image build, and Nginx-served smoke checks passed before deployment.
+
 ## 2026-07-15 — Android 1.4.6 and Plugin 1.4.2 release preparation
 
 The profile-continuity and profile-image work was prepared as a two-surface

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine AS build
+WORKDIR /src
+
+COPY website/package.json website/package-lock.json website/
+RUN cd website && npm ci
+
+# Build from the repository root because the website verifies its screenshots
+# against the canonical sources under docs/media/.
+COPY . .
+RUN cd website && npm run build:production
+
+FROM nginx:1.28-alpine
+COPY --from=build /src/website/dist/ /usr/share/nginx/html/
+EXPOSE 80

--- a/website/README.md
+++ b/website/README.md
@@ -59,19 +59,24 @@ canonical fallback; do not hand-edit the WebP variants.
 
 ## Coolify
 
-Deploy this directory as a static Nixpacks application:
+Deploy the website with its repository-owned Dockerfile. The build context must
+remain the repository root because the production asset check compares website
+copies against canonical screenshots under `docs/media/`.
 
-- Base directory: `/website`
-- Build command: detected from `nixpacks.toml` (`npm run build:production`)
-- Publish directory: `/dist`
-- Static site: enabled
+- Build pack: Dockerfile
+- Base directory: `/`
+- Dockerfile location: `/website/Dockerfile`
+- Exposed port: `80`
+- Health check: `GET /` expecting `200`
 - Domain: `https://hermes-relay.dev`
 - Optional environment override: `PUBLIC_SITE_URL=https://<preview-domain>`
-- Node: pinned to the supported Node 22 line through `package.json`
 - Force HTTPS: enabled
 
-The environment value is consumed at build time; the output remains a static
-Nginx-served site. No custom Dockerfile or Node runtime is required.
+The Dockerfile builds with Node 22, runs `npm run build:production` from the
+website workspace, and serves the resulting static `/website/dist` tree with
+Nginx. Do not isolate `/website` as the Coolify base directory: doing so omits
+the canonical screenshot sources and correctly causes the asset-integrity gate
+to fail.
 
 Assign `https://hermes-relay.dev` in Coolify and redeploy. If
 `PUBLIC_SITE_URL` is supplied for a preview environment, the production build


### PR DESCRIPTION
## Summary
- Add a repository-owned multi-stage Dockerfile for the Astro marketing site.
- Keep the repository root as build context so canonical screenshot validation can read `docs/media/`.
- Update the Coolify deployment instructions to use the Dockerfile and serve the static build with Nginx.

## Test Plan
- [x] `npm run check`
- [x] `npm run build:production`
- [x] `npm run links:check`
- [x] Build `website/Dockerfile` from repository-root context and smoke-test the resulting Nginx container.