### PR TITLE
fix(docs): add temporary legacy redirects

### DIFF
--- a/.github/workflows/legacy-docs-redirect.yml
+++ b/.github/workflows/legacy-docs-redirect.yml
@@ -1,0 +1,81 @@
+name: Deploy legacy docs redirects
+
+on:
+  pull_request:
+    paths:
+      - "legacy-pages-redirect/**"
+      - ".github/workflows/legacy-docs-redirect.yml"
+  push:
+    branches: [main]
+    paths:
+      - "legacy-pages-redirect/**"
+      - ".github/workflows/legacy-docs-redirect.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: legacy-docs-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build redirect artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build redirect-only site
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_file="legacy-pages-redirect/redirect.html"
+          output_dir="legacy-pages-redirect/_site"
+          rm -rf "$output_dir"
+          mkdir -p \
+            "$output_dir/guide/getting-started" \
+            "$output_dir/reference/relay-server" \
+            "$output_dir/architecture"
+          for target in \
+            index.html \
+            404.html \
+            guide/getting-started.html \
+            guide/getting-started/index.html \
+            reference/relay-server.html \
+            reference/relay-server/index.html \
+            architecture/connection-security.html; do
+            cp "$source_file" "$output_dir/$target"
+          done
+          touch "$output_dir/.nojekyll"
+          test "$(find "$output_dir" -type f | wc -l)" -eq 8
+          if grep -R -E '<title>VitePress|<div id="app">' "$output_dir"; then
+            echo "Full documentation content must not be deployed by this workflow." >&2
+            exit 1
+          fi
+
+      - name: Configure Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v6
+
+      - name: Upload redirect artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: legacy-pages-redirect/_site
+
+  deploy:
+    name: Deploy redirect shim
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,13 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-16 — Temporary redirect shim for pre-migration Android builds
+
+Restored GitHub Pages only as a redirect-only compatibility endpoint for app
+versions that still open `https://codename-11.github.io/hermes-relay/`. The
+shim preserves known paths, query strings, and fragments while forwarding to
+`https://hermes-relay.dev/docs/`; it does not publish the VitePress site.
+Removal criteria and the operator review date are tracked in `TODO.md`.
+
 ## 2026-07-15 — Retire GitHub Pages and move docs to hermes-relay.dev
 
 Disabled and removed the GitHub Pages deployment path, changed the repository

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,36 @@ For shipped work, see `DEVLOG.md`. For architectural decisions, see `docs/decisi
 
 ---
 
+## Active — Remove temporary GitHub Pages docs redirects
+
+PR #210 moved current source and production documentation to
+`https://hermes-relay.dev/docs/`, but Android 1.4.0 and earlier releases still
+contain hardcoded `https://codename-11.github.io/hermes-relay/` links. GitHub
+Pages therefore serves a redirect-only compatibility shim from
+`legacy-pages-redirect/`; it must never regain full documentation content.
+
+Retire the shim only after the first Android release containing merge commit
+`52df3adbf6d61d0ddbfb69671546f7c4953f956a` has been available for at least
+90 days **and** at least two Android releases containing the corrected links
+have shipped. If either condition is unmet at review time, retain it and set a
+new review date.
+
+Removal checklist:
+
+- Remove `.github/workflows/legacy-docs-redirect.yml` and
+  `legacy-pages-redirect/` through a reviewed PR.
+- Delete/disable the repository Pages site after that PR merges.
+- Verify `https://codename-11.github.io/hermes-relay/` no longer serves the
+  shim and `https://hermes-relay.dev/docs/` plus representative deep links
+  still return HTTP 200.
+- Update `DEVLOG.md` and the canonical Obsidian Hermes-Relay project note.
+
+A one-shot operator reminder is scheduled for **2026-10-15 at 09:00 ET** to
+review these gates; it is a review trigger, not authorization for automatic
+removal.
+
+---
+
 ## Multi-profile Phone/Threads routing — deferred (2026-07-12)
 
 Android profile hot-swap and concurrent Gateway turns are separate from proactive

--- a/legacy-pages-redirect/README.md
+++ b/legacy-pages-redirect/README.md
@@ -1,0 +1,16 @@
+# Legacy documentation redirect
+
+This directory is a temporary compatibility shim for Android releases that
+hardcoded `https://codename-11.github.io/hermes-relay/` before PR #210.
+Documentation is hosted only at `https://hermes-relay.dev/docs/`; GitHub Pages
+serves redirect HTML and no documentation content.
+
+The deployment workflow copies `redirect.html` to the project root, the Pages
+404 fallback, and the exact deep-link paths embedded in released clients. The
+JavaScript preserves the path, query string, and fragment while moving the
+request under `/docs/`. The meta refresh and visible link provide a no-script
+fallback to the guide root.
+
+Removal is tracked in the repository root `TODO.md`. Do not delete this shim
+solely because the first fixed release has shipped; honor the documented
+compatibility window for older Play and sideload installations.

--- a/legacy-pages-redirect/redirect.html
+++ b/legacy-pages-redirect/redirect.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta http-equiv="refresh" content="2;url=https://hermes-relay.dev/docs/" />
+    <link rel="canonical" href="https://hermes-relay.dev/docs/" />
+    <title>Hermes Relay documentation moved</title>
+  </head>
+  <body>
+    <main>
+      <h1>Hermes Relay documentation moved</h1>
+      <p>
+        Redirecting to
+        <a id="destination" href="https://hermes-relay.dev/docs/">hermes-relay.dev/docs</a>.
+      </p>
+    </main>
+    <script>
+      (() => {
+        const legacyBase = "/hermes-relay";
+        const pathname = window.location.pathname;
+        const suffix = pathname === legacyBase || pathname === `${legacyBase}/`
+          ? "/"
+          : pathname.startsWith(`${legacyBase}/`)
+            ? pathname.slice(legacyBase.length)
+            : "/";
+        const destination = new URL("https://hermes-relay.dev/docs/");
+        destination.pathname = `/docs/${suffix.replace(/^\/+/, "")}`;
+        destination.search = window.location.search;
+        destination.hash = window.location.hash;
+        document.getElementById("destination").href = destination.href;
+        window.location.replace(destination.href);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Restore GitHub Pages only as a redirect-only compatibility shim for Android releases with hardcoded legacy docs links.
- Preserve known app paths, query strings, and fragments while forwarding to `https://hermes-relay.dev/docs/`.
- Track retirement in `TODO.md`: at least 90 days after the first corrected Android release and at least two corrected releases shipped.
- Record the one-shot October 15 operator review reminder; it reports readiness and does not remove anything automatically.

## Safety
- The artifact contains redirect HTML only; the workflow rejects VitePress app markers.
- Pull requests build and validate the artifact but cannot configure, upload, or deploy Pages.
- Pages deployment occurs only after merge to `main` or manual dispatch.

## Test Plan
- [x] Validate root, known released-client paths, and unknown deep-link mapping in a Node VM.
- [x] Verify query-string and fragment preservation.
- [x] Build the exact eight-file Pages artifact locally.
- [x] Verify the artifact contains no VitePress app content.
- [x] Run `git diff --check`.
- [ ] Confirm redirect build CI passes.
- [ ] After merge, enable workflow-based Pages and verify live legacy URLs redirect to the corresponding production docs routes.