### PR TITLE
fix(website): serve VitePress clean URLs

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -6,6 +6,8 @@ Restored GitHub Pages only as a redirect-only compatibility endpoint for app
 versions that still open `https://codename-11.github.io/hermes-relay/`. The
 shim preserves known paths, query strings, and fragments while forwarding to
 `https://hermes-relay.dev/docs/`; it does not publish the VitePress site.
+The production Nginx configuration resolves VitePress clean URLs to their
+`.html` artifacts so both legacy and corrected in-app links reach real pages.
 Removal criteria and the operator review date are tracked in `TODO.md`.
 
 ## 2026-07-15 — Retire GitHub Pages and move docs to hermes-relay.dev

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -21,6 +21,7 @@ COPY preview preview
 RUN cd user-docs && npm run build
 
 FROM nginx:1.28-alpine
+COPY website/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=website-build /src/website/dist/ /usr/share/nginx/html/
 COPY --from=docs-build /src/user-docs/.vitepress/dist/ /usr/share/nginx/html/docs/
 EXPOSE 80

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        # VitePress emits .html files while its public links omit the extension.
+        try_files $uri $uri.html $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary
- Add an explicit Nginx site configuration that resolves VitePress clean URLs to generated `.html` files.
- Preserve existing root, directory, and static-asset routing.
- Document why both legacy redirect targets and corrected in-app links require this fallback.

## Context
The live browser verification for PR #211 exposed that `/docs/guide/getting-started` redirected correctly but Nginx returned 404 because VitePress emitted `getting-started.html`. Released Android links and current source intentionally use the clean URL.

## Test Plan
- [x] Build the exact staged production Docker image from a clean worktree.
- [x] Run `nginx -t`.
- [x] Verify HTTP 200 for `/`, `/docs/`, extensionless guide/reference routes, explicit `.html`, and JSON assets.
- [x] Run `git diff --check`.