### PR TITLE
fix(website): restore production docs build context

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,15 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-16 — Fix production docs asset context
+
+Updated the production docs Docker stage to build from the same full repository
+checkout used by CI rather than a hand-maintained file allowlist. This supplies
+the canonical screenshot manifest, localization registry and validators, route
+contract source, version metadata, and preview renderer without creating
+Docker-only `ENOENT` failures when those build inputs grow. Both Node build
+stages now install Python 3 so the localized website and docs validators run
+inside the production image build as they do in CI.
+
 ## 2026-07-16 — Localized marketing site
 
 The Astro product site now publishes German, Spanish, Japanese, Brazilian

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22-alpine AS website-build
 WORKDIR /src
+RUN apk add --no-cache python3
 
 COPY website/package.json website/package-lock.json website/
 RUN cd website && npm ci
@@ -11,15 +12,12 @@ RUN cd website && npm run build:production
 
 FROM node:24-alpine AS docs-build
 WORKDIR /src
+RUN apk add --no-cache python3
 
 COPY user-docs/package.json user-docs/package-lock.json user-docs/
 RUN cd user-docs && npm ci
 
-COPY user-docs user-docs
-COPY assets/screenshots/02_chat.png assets/screenshots/02_chat.png
-COPY plugin/relay/server.py plugin/relay/server.py
-COPY gradle gradle
-COPY preview preview
+COPY . .
 RUN cd user-docs && npm run build
 
 FROM nginx:1.28-alpine


### PR DESCRIPTION
## Summary
- install Python 3 in both Node build stages for localization validators
- build VitePress from the same full repository context used by CI
- remove the brittle docs-stage file allowlist that omitted new localization assets and validators

## Root cause
PR #214 introduced docs asset sync and Python locale validation. CI used a full checkout, while `website/Dockerfile` copied only selected root dependencies. Coolify therefore failed first on `assets/screenshots/07_connections.png`, then on the absent Python validator environment.

## Validation
- `git diff --check`
- full root-context `docker build -f website/Dockerfile`
- both locale validators passed inside Docker
- VitePress route-contract validation passed inside Docker
- Nginx configuration test passed
- HTTP 200 for all six marketing locales, five docs locales, and `/docs/connections-demo.png`

## Deployment
Coolify auto-deploy watch paths and the authenticated GitHub push webhook are now configured. Merging this PR should automatically queue the production deployment.