### PR TITLE
fix(android): smooth streamed reply finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **Long streamed replies stay anchored through final rendering and history reconciliation.** Android follows the final Markdown re-layout and preserves stable visible-row identity when persisted server message IDs replace live IDs, without pulling readers away from history they intentionally scrolled up to view.
+- **Long streamed replies finish without a visible transcript reload.** Uninterrupted Gateway turns keep their live transcript, while reconnect gaps still reconcile missed events; bottom-following is anchored in the final Markdown remeasure without disturbing readers who intentionally scrolled up.
 - **Relay trust boundaries are enforced across privileged interfaces.** Pairing policy is host-authorized, Android bridge and terminal dispatch require active grants, ordinary sessions can only reduce their own policy, remote profile config is restricted to a public schema, and voice callers cannot redirect host provider credentials.
 
 ## [Android 1.4.6] - 2026-07-15

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,27 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-17 — Smooth streamed-reply finalization
+
+Uninterrupted Gateway turns now treat their structured live assistant, reasoning,
+and tool events as the authoritative completion state instead of immediately
+republishing the transcript through a full history read. A turn that successfully
+rejoins after a socket gap carries an explicit reconciliation signal because events
+emitted while disconnected cannot be replayed. Successful Sessions SSE turns and
+all detached-turn, profile-aware resume, error, and missing-data recovery paths
+retain their authoritative history reconciliation.
+
+The final renderer remains one full CommonMark document so document-global
+references, indentation, and nested containers retain exact semantics.
+Bottom-following readers are instead anchored to the trailing spacer in the same
+Compose remeasure through `requestScrollToItem`; message-count and stable-row-key
+guards prevent a session or tail replacement from being treated as an ordinary
+stream completion. Readers who intentionally scrolled up remain under the existing
+user-scroll gate.
+
+Focused Gateway reconnect, completion-policy, and scroll-snapshot regressions
+passed. Full Android lint and the sideload debug assembly also completed
+successfully; existing unrelated compiler and packaging warnings remain unchanged.
+
 ## 2026-07-17 — Stable chat rows across post-turn history reconciliation
 
 Android chat now separates the stable Compose identity of a visible message row

--- a/TODO.md
+++ b/TODO.md
@@ -645,13 +645,12 @@ every bubble) + grouping breaks on a >5min gap (`GROUP_GAP_MS`) so a resumed
 conversation gets its own beat; long-press haptic on the action menu; streaming dots
 gated to pre-first-token. Deferred:
 
-- **Streaming↔final render parity — conservative 1.4.1 slice implemented; live
-  reflow check remains.** Blank-terminated, unambiguous top-level prose/headings use
-  the final Markdown renderer during generation while the active tail stays raw.
-  Lists, quotes, tables, HTML, and fences intentionally remain lightweight until the
-  final parse because partial CommonMark containers can re-parent earlier blocks.
-  Verify that the chosen boundary removes the common heading/prose pop without
-  introducing partial-fence or list flicker.
+- **Streaming↔final render parity — live reflow check remains.** Blank-terminated,
+  unambiguous top-level prose/headings use the final Markdown renderer during
+  generation while the active tail stays lightweight. Completion intentionally
+  parses one full CommonMark document so global link references, indentation, and
+  nested containers remain correct; the viewport now anchors that same remeasure.
+  Verify lists, tables, quotes, HTML, nested fences, and reference links on-device.
 - **Bubble body 14sp → 15sp/21.** 14sp is the smallest body of the five reference
   apps. Bump markdown paragraph/text/list + the two plain `Text` sites
   (`MessageBubble.kt` user/system) together; keep ~1.4 leading so the ~272dp measure
@@ -673,13 +672,12 @@ gated to pre-first-token. Deferred:
   kebab). Needs on-device confirmation of the current conflict first.
 - **Drop the no-op tap ripple on bubbles.** The 1.4.1 jump-to-bottom unread badge is
   code-complete; `combinedClickable(onClick={})` still ripples on a normal bubble tap.
-- **Sessions-transport `animateItem` flash.** Stream-complete rebuilds the list with
-  new ids → every visible bubble replays its enter animation (gateway transport,
-  stable id, is unaffected). Reuse the streaming bubble's id for the final message.
-- **Viewport re-pin on the `isStreaming` true→false height growth** (gateway
-  transport): `ChatScreen` early-returns on `onlyStreamingFlagChanged`; issue one
-  `withFrameNanos{}` + instant `scrollToItem(last)` when the flag flips and the user
-  isn't scrolled away. Largely neutralized once render parity removes the height delta.
+- **Sessions per-turn reconciliation.** Current upstream includes assistant/tool
+  rows in `run.completed.messages`, but Android still uses a full profile-aware
+  history read for successful Sessions turns so older servers and persisted message
+  boundaries remain safe. Replace it only with a bounded partial-turn merge that
+  preserves the prior transcript and client-only fields, with a full-history fallback
+  when the completion payload is absent or incomplete.
 - **Full 15-role `Typography` + metadata contrast.** Type.kt declares only 7 roles at
   0 tracking; the rest inherit M3 defaults with 0.1–0.5sp tracking (ChatScreen uses
   several) — declare all 15 for one coherent scale. Separately, floor muted-metadata

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
@@ -2103,9 +2103,19 @@ class GatewayChatClient(
 
         private val rejoinAttempts = java.util.concurrent.atomic.AtomicInteger(0)
 
-        /** True if this socket loss should be answered with a rejoin attempt. */
-        fun beginRejoin(): Boolean =
-            !ended && rejoinAttempts.incrementAndGet() <= MAX_TURN_REJOINS
+        @Volatile
+        private var reconcileRequired = false
+
+        /**
+         * True if this socket loss should be answered with a rejoin attempt.
+         * Mark reconciliation before reconnecting so a terminal event arriving
+         * immediately after `gateway.ready` cannot race ahead of the signal.
+         */
+        fun beginRejoin(): Boolean {
+            val shouldRejoin = !ended && rejoinAttempts.incrementAndGet() <= MAX_TURN_REJOINS
+            if (shouldRejoin) reconcileRequired = true
+            return shouldRejoin
+        }
 
         private var watchdog: Job? = null
 
@@ -2132,6 +2142,12 @@ class GatewayChatClient(
             // Ask requests block with no further events, so they arm with
             // their own (longer) duration via watchdogTimeoutFor.
             armWatchdog(watchdogTimeoutFor(type))
+            // Queue this immediately before the terminal callbacks. Both are
+            // marshalled through the same dispatcher, preserving callback order
+            // even when the WebSocket reader and reconnect coroutine differ.
+            if (type == "message.complete" && reconcileRequired) {
+                callbacks.onReconcileRequired()
+            }
             mapper.onEvent(type, payload)
             if (mapper.turnEnded) {
                 disarmWatchdog()
@@ -2305,6 +2321,7 @@ class GatewayChatClient(
         onToolCallFailed = { a, b -> callbackDispatcher { callbacks.onToolCallFailed(a, b) } },
         onToolOutputRisk = { v -> callbackDispatcher { callbacks.onToolOutputRisk(v) } },
         onTurnComplete = { callbackDispatcher { callbacks.onTurnComplete() } },
+        onReconcileRequired = { callbackDispatcher { callbacks.onReconcileRequired() } },
         onComplete = { callbackDispatcher { callbacks.onComplete() } },
         onUsage = { v -> callbackDispatcher { callbacks.onUsage(v) } },
         onError = { v -> callbackDispatcher { callbacks.onError(v) } },

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayModels.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayModels.kt
@@ -335,6 +335,12 @@ class GatewayTurnCallbacks(
     /** Attach deterministic output-risk metadata to the matching tool card. */
     val onToolOutputRisk: (GatewayToolOutputRisk) -> Unit = { _ -> },
     val onTurnComplete: () -> Unit,
+    /**
+     * Fired before [onComplete] when this turn rejoined after a socket gap.
+     * Events emitted while the socket was unavailable are not replayed, so
+     * the caller must reconcile the durable transcript after completion.
+     */
+    val onReconcileRequired: () -> Unit,
     val onComplete: () -> Unit,
     val onUsage: (UsageInfo?) -> Unit,
     val onError: (String) -> Unit,

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -242,6 +242,7 @@ private const val GROUP_GAP_MS = 5 * 60_000L
 internal data class ChatScrollSnapshot(
     val messageCount: Int,
     val lastMessageId: String?,
+    val lastMessageUiKey: String?,
     val lastContentLength: Int,
     val lastThinkingLength: Int,
     val lastToolCallCount: Int,
@@ -249,7 +250,10 @@ internal data class ChatScrollSnapshot(
 )
 
 internal fun ChatScrollSnapshot.isCompletionAfter(previous: ChatScrollSnapshot?): Boolean =
-    previous?.isStreaming == true && !isStreaming
+    previous?.isStreaming == true &&
+        !isStreaming &&
+        previous.messageCount == messageCount &&
+        previous.lastMessageUiKey == lastMessageUiKey
 
 private fun LazyListState.isAtConversationBottom(slopPx: Int): Boolean {
     val layout = layoutInfo
@@ -1216,11 +1220,12 @@ fun ChatScreen(
     //      pins the bottom of the item to the bottom of the viewport.
     //   3. There was no userScrolledAway gate, so any delta would yank a
     //      user reading history back to the bottom.
-    //   4. The stream-complete transition needs an INSTANT multi-frame settle:
-    //      the renderer replaces its lightweight streaming tail with the final
-    //      Markdown tree, which can remeasure a long bubble substantially.
-    //      Animating that settle produces a visible jiggle; skipping it leaves
-    //      the viewport anchored far above the new bottom.
+    //   4. The stream-complete transition must anchor the SAME remeasure that
+    //      replaces streaming blocks with the final full-document CommonMark
+    //      tree. Waiting a frame and then scrolling exposes one bad top-anchored
+    //      frame before the correction. Completion therefore uses
+    //      requestScrollToItem(), which applies on the next remeasure instead of
+    //      launching the deferred settle helper.
     //   5. Sessions endpoint reloads the entire message list on stream
     //      complete via loadMessageHistory(), and the resulting animateItem()
     //      placement animations on every bubble fought with our concurrent
@@ -1247,6 +1252,7 @@ fun ChatScreen(
             ChatScrollSnapshot(
                 messageCount = messages.size,
                 lastMessageId = last?.id,
+                lastMessageUiKey = last?.uiKey,
                 lastContentLength = last?.content?.length ?: 0,
                 lastThinkingLength = last?.thinkingContent?.length ?: 0,
                 lastToolCallCount = last?.toolCalls?.size ?: 0,
@@ -1261,14 +1267,16 @@ fun ChatScreen(
                 if (messages.isEmpty()) return@collectLatest
                 if (userScrolledAway) return@collectLatest
 
-                // Finalization swaps StreamingMarkdownContent from its stable
-                // prefix + lightweight active-tail tree to one full Markdown
-                // tree. A long reply can therefore remeasure substantially even
-                // though no text changed. LazyColumn preserves the tall item's
-                // top-relative offset, which moves the viewport away from the
-                // bottom unless we settle again after that re-layout.
+                // Finalization swaps the streaming partitions for one complete
+                // CommonMark document (required for global references and nested
+                // containers), which can change height. Request the trailing
+                // spacer at the bottom for the SAME next remeasure so no
+                // incorrect top-anchored frame is displayed before a follow-up
+                // scroll.
+                // The uiKey/count guard in isCompletionAfter prevents a session
+                // or tail replacement from masquerading as this transition.
                 if (snapshot.isCompletionAfter(prev)) {
-                    scrollConversationToBottom(animated = false)
+                    listState.requestScrollToItem(snapshot.messageCount + 1, Int.MAX_VALUE)
                     return@collectLatest
                 }
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
@@ -120,6 +120,21 @@ data class ContextWindowUsage(
         get() = if (maxTokens > 0) (usedTokens.toFloat() / maxTokens).coerceIn(0f, 1f) else 0f
 }
 
+/**
+ * A successful Sessions SSE turn still needs the server-authoritative transcript
+ * because that transport does not stream every persisted message boundary.
+ * Gateway turns already deliver the assistant, reasoning, and tool lifecycle
+ * directly; reloading their full transcript only republishes a healthy live turn.
+ * A successful socket rejoin is the exception because events emitted during the
+ * gap cannot be replayed.
+ */
+internal fun shouldReloadHistoryAfterSuccessfulTurn(
+    actualTransport: String,
+    gatewayReconcileRequired: Boolean,
+): Boolean =
+    actualTransport == "sessions" ||
+        (actualTransport == "gateway" && gatewayReconcileRequired)
+
 class ChatViewModel : ViewModel() {
 
     private var apiClient: HermesApiClient? = null
@@ -1254,6 +1269,9 @@ class ChatViewModel : ViewModel() {
             onTurnComplete = {
                 if (acceptsEvent()) handler.onTurnComplete(messageId)
             },
+            // Server-initiated turns already take the bounded durable-history
+            // reconcile below on every completion.
+            onReconcileRequired = { },
             onComplete = {
                 val canWriteTranscript = acceptsEvent()
                 val expectedText = handler.messages.value
@@ -3339,7 +3357,8 @@ class ChatViewModel : ViewModel() {
      * message among role==USER messages (excluding phone-local traces the
      * server never saw), truncates the local list from it, and dispatches a
      * gateway turn carrying `truncate_before_user_ordinal`. Local/server
-     * divergence self-heals via the post-turn history reload.
+     * divergence self-heals through the gateway's authoritative truncate and
+     * live turn events; recovery paths still perform a full history reconcile.
      *
      * @return false when the edit could not be dispatched (turn in flight,
      *   non-gateway endpoint, missing client, ordinal failure) — the caller
@@ -4036,6 +4055,8 @@ class ChatViewModel : ViewModel() {
                     scheduleCheckpointWrite(immediate = true)
                 }
             },
+            // Recovered turns already reload their authoritative history below.
+            onReconcileRequired = { },
             onComplete = {
                 if (owns()) {
                     finalizeTurnSideEffects(handler, messageId)
@@ -5414,6 +5435,7 @@ class ChatViewModel : ViewModel() {
         // stream answer recovery (issue #166) on "sessions": the other
         // endpoints keep their existing error behavior.
         var dispatchedSseEndpoint: String? = null
+        var gatewayHistoryReconcileRequired = false
 
         val assistantTimestamp = System.currentTimeMillis()
         beginTurnCheckpoint(
@@ -5440,7 +5462,7 @@ class ChatViewModel : ViewModel() {
                 // interfaceContextPrompt today, so it marks this turn as spoken.
                 // Tag the reply with a "Voice" chip (parity with "Realtime
                 // Agent"); ChatHandler.loadMessageHistory preserves it across
-                // the post-turn history reload.
+                // history and recovery reconciliation.
                 badges = if (interfaceContextPrompt != null) listOf("Voice") else emptyList(),
             )
         )
@@ -5487,6 +5509,8 @@ class ChatViewModel : ViewModel() {
             // wins — stop the poller before finalizing so the turn can't
             // finish twice.
             cancelAnswerRecovery(settleUi = false)
+            val completedTransport = dispatchedSseEndpoint
+                ?: if (activeStreamIsGateway) "gateway" else streamingEndpoint
             finalizeTurnSideEffects(handler, currentMessageId)
             AppAnalytics.onStreamComplete(lastInputTokens, lastOutputTokens)
 
@@ -5504,15 +5528,13 @@ class ChatViewModel : ViewModel() {
                 refreshReasoningSettings()
             }
 
-            // Sessions endpoint doesn't emit structured tool events during streaming —
-            // tool calls are only available as JSON on the stored messages. Reload the
-            // server-authoritative history to get proper message boundaries + tool_calls.
-            // Gateway turns reconcile the same way: live tool events are gated by the
-            // server's display.tool_progress config, so a turn that ran tools silently
-            // (config off, or events lost in a mid-turn rejoin gap) still gets its tool
-            // cards + persisted reasoning right after the turn — not on the next app
-            // restart. By message.complete the server has persisted the turn, so the
-            // REST read is authoritative.
+            // Sessions SSE does not stream every persisted message boundary, so it
+            // still needs the server-authoritative transcript after success. A healthy
+            // Gateway turn is already authoritative in memory through its structured
+            // assistant/reasoning/tool events; reloading the full transcript here would
+            // republish the entire visible list and cause a completion flash. A Gateway
+            // socket rejoin explicitly flags this completion for the same profile-aware
+            // history reconcile because events emitted during the gap may be missing.
             val sid = handler.currentSessionId.value
             // A turn that ended in an error (gateway ❌ lifecycle → "Error" badge)
             // has NO assistant message persisted server-side, so reconciling the
@@ -5523,9 +5545,13 @@ class ChatViewModel : ViewModel() {
             val turnErrored = handler.messages.value
                 .lastOrNull { it.id == currentMessageId }
                 ?.badges?.contains("Error") == true
-            if (sid != null && (streamingEndpoint == "sessions" || streamingEndpoint == "gateway")) {
+            if (sid != null && (completedTransport == "sessions" || completedTransport == "gateway")) {
                 viewModelScope.launch {
-                    if (!turnErrored) {
+                    if (!turnErrored && shouldReloadHistoryAfterSuccessfulTurn(
+                            completedTransport,
+                            gatewayHistoryReconcileRequired,
+                        )
+                    ) {
                         // Profile-aware read: a gateway turn on a non-default profile
                         // persists into THAT profile's own state.db, so the bare
                         // api_server `/api/sessions/{id}/messages` 404s → emptyList()
@@ -5947,6 +5973,9 @@ class ChatViewModel : ViewModel() {
                             scheduleCheckpointWrite(immediate = true)
                         },
                         onTurnComplete = onTurnCompleteCb,
+                        onReconcileRequired = {
+                            gatewayHistoryReconcileRequired = true
+                        },
                         onComplete = onCompleteCb,
                         onUsage = onUsageCb,
                         onError = onErrorCb,

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
@@ -382,6 +382,7 @@ class GatewayChatClientTest {
         val toolGenerating = ConcurrentLinkedQueue<String>()
         val subagentEvents = ConcurrentLinkedQueue<GatewaySubagentEvent>()
         val usages = ConcurrentLinkedQueue<UsageInfo>()
+        val reconcileRequests = AtomicInteger(0)
         val completeLatch = CountDownLatch(1)
         val preflightFailures = ConcurrentLinkedQueue<String>()
 
@@ -394,6 +395,7 @@ class GatewayChatClientTest {
             onToolCallDone = { id, result -> toolDone += id to result },
             onToolCallFailed = { _, _ -> },
             onTurnComplete = { },
+            onReconcileRequired = { reconcileRequests.incrementAndGet() },
             onComplete = { completeLatch.countDown() },
             onUsage = { it?.let(usages::add) },
             onError = { errors += it; completeLatch.countDown() },
@@ -503,6 +505,7 @@ class GatewayChatClientTest {
         assertEquals(listOf("Hi!"), r.textDeltas.toList())
         assertEquals(listOf("20260612_120000_abc123"), r.sessionIds.toList())
         assertEquals(5, r.usages.firstOrNull()?.resolvedInputTokens)
+        assertEquals(0, r.reconcileRequests.get())
         assertTrue(r.errors.isEmpty())
         assertTrue(r.preflightFailures.isEmpty())
     }
@@ -978,6 +981,7 @@ class GatewayChatClientTest {
 
         assertTrue("turn never completed after rejoin", r.completeLatch.await(10, TimeUnit.SECONDS))
         assertEquals(listOf("after rejoin"), r.textDeltas.toList())
+        assertEquals(1, r.reconcileRequests.get())
         assertTrue("rejoined turn must not error, got ${r.errors}", r.errors.isEmpty())
         // The fix's core invariant: a mid-turn rejoin must NEVER session.resume.
         assertTrue(

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapperTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapperTest.kt
@@ -32,6 +32,7 @@ class GatewayEventMapperTest {
         val sessionIds = mutableListOf<String>()
         var starts = 0
         var turnCompletes = 0
+        var reconcileRequests = 0
         var completes = 0
         var usage: UsageInfo? = null
         var usageCalls = 0
@@ -47,6 +48,7 @@ class GatewayEventMapperTest {
             onToolCallFailed = { id, err -> toolFails += id to err },
             onToolOutputRisk = { toolOutputRisks += it },
             onTurnComplete = { turnCompletes++ },
+            onReconcileRequired = { reconcileRequests++ },
             onComplete = { completes++ },
             onUsage = { usage = it; usageCalls++ },
             onError = { errors += it },

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/ChatScrollSnapshotTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/ChatScrollSnapshotTest.kt
@@ -7,11 +7,27 @@ import org.junit.Test
 
 class ChatScrollSnapshotTest {
     @Test
-    fun `stream completion requires a bottom settle even when content is unchanged`() {
+    fun `same-tail stream completion requests an atomic bottom anchor`() {
         val streaming = snapshot(isStreaming = true)
         val complete = snapshot(isStreaming = false)
 
         assertTrue(complete.isCompletionAfter(streaming))
+    }
+
+    @Test
+    fun `tail replacement is not mistaken for stream completion`() {
+        val streaming = snapshot(isStreaming = true)
+        val replaced = snapshot(isStreaming = false, lastMessageUiKey = "replacement-tail")
+
+        assertFalse(replaced.isCompletionAfter(streaming))
+    }
+
+    @Test
+    fun `message list rebuild is not mistaken for stream completion`() {
+        val streaming = snapshot(isStreaming = true)
+        val rebuilt = snapshot(isStreaming = false, messageCount = 10)
+
+        assertFalse(rebuilt.isCompletionAfter(streaming))
     }
 
     @Test
@@ -41,9 +57,12 @@ class ChatScrollSnapshotTest {
     private fun snapshot(
         contentLength: Int = 12_000,
         isStreaming: Boolean,
+        messageCount: Int = 8,
+        lastMessageUiKey: String = "assistant-ui-key",
     ) = ChatScrollSnapshot(
-        messageCount = 8,
+        messageCount = messageCount,
         lastMessageId = "assistant-live-id",
+        lastMessageUiKey = lastMessageUiKey,
         lastContentLength = contentLength,
         lastThinkingLength = 1_200,
         lastToolCallCount = 2,

--- a/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/ChatTurnCompletionPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/ChatTurnCompletionPolicyTest.kt
@@ -1,0 +1,28 @@
+package com.hermesandroid.relay.viewmodel
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatTurnCompletionPolicyTest {
+    @Test
+    fun `successful Sessions turns reload persisted message boundaries`() {
+        assertTrue(shouldReloadHistoryAfterSuccessfulTurn("sessions", gatewayReconcileRequired = false))
+    }
+
+    @Test
+    fun `healthy uninterrupted Gateway turns keep their live transcript`() {
+        assertFalse(shouldReloadHistoryAfterSuccessfulTurn("gateway", gatewayReconcileRequired = false))
+    }
+
+    @Test
+    fun `Gateway turns with a socket gap reload potentially missed events`() {
+        assertTrue(shouldReloadHistoryAfterSuccessfulTurn("gateway", gatewayReconcileRequired = true))
+    }
+
+    @Test
+    fun `stateless structured transports do not reload session history`() {
+        assertFalse(shouldReloadHistoryAfterSuccessfulTurn("runs", gatewayReconcileRequired = false))
+        assertFalse(shouldReloadHistoryAfterSuccessfulTurn("completions", gatewayReconcileRequired = false))
+    }
+}


### PR DESCRIPTION
## Summary

- keep uninterrupted Gateway completions on their structured live transcript instead of republishing full history
- retain profile-aware history reconciliation for Sessions, Gateway socket-gap rejoins, detached turns, and recovery paths
- anchor the full final CommonMark remeasure atomically while preserving readers who intentionally scrolled away
- guard completion handling by stable message identity and add transport/scroll regressions

## Verification

- `testSideloadDebugUnitTest` focused Gateway reconnect, completion-policy, and scroll tests — passed
- `lint assembleSideloadDebug` — passed (135 tasks)
- `git diff --check` — passed

## Remaining verification

- On-device visual smoothness remains the final experiential check after merge; no device behavior is claimed by the local build alone.