### PR TITLE
fix(plugin): avoid signalling gateway PID on Windows

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Syntax check (plugin relay — canonical location)
         run: |
+          python -m py_compile plugin/relay/config.py
           python -m py_compile plugin/relay/server.py
           python -m py_compile plugin/relay/channels/terminal.py
           python -m py_compile plugin/relay/channels/chat.py
@@ -103,4 +104,6 @@ jobs:
             plugin/tests/test_relay_security.py \
             plugin/tests/test_voice_routes.py \
             plugin/tests/test_session_grants.py \
-            plugin/tests/test_native_layout_imports.py
+            plugin/tests/test_native_layout_imports.py \
+            plugin/tests/test_profile_discovery.py \
+            plugin/tests/test_profiles_updated_broadcast.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **Relay trust boundaries are enforced across privileged interfaces.** Pairing policy is host-authorized, Android bridge and terminal dispatch require active grants, ordinary sessions can only reduce their own policy, remote profile config is restricted to a public schema, and voice callers cannot redirect host provider credentials.
+- **Starting Relay no longer terminates a running Hermes gateway on Windows.** Profile discovery now checks gateway PIDs through non-signalling process APIs, including during periodic rescans.
 
 ## [1.4.8] - 2026-07-18
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,14 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-18 — Non-signalling Windows gateway PID probes
+
+Relay profile discovery now prefers Hermes' supported psutil liveness check and
+falls back to native Windows process handles when psutil is unavailable. The
+POSIX signal-zero probe is restricted to POSIX hosts, preventing relay startup
+and periodic profile rescans from signalling or terminating the gateway named
+by `gateway.pid`. Regression coverage uses disposable child processes instead
+of pointing PID fixtures at the test runner.
+
 ## 2026-07-18 — Android privacy-policy URL hotfix
 
 The canonical Android privacy policy moved to a stable public page on

--- a/plugin/relay/config.py
+++ b/plugin/relay/config.py
@@ -16,6 +16,11 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+try:
+    import psutil as _psutil  # type: ignore[import-not-found]
+except ImportError:  # Hermes normally provides psutil; standalone installs may not.
+    _psutil = None
+
 # Characters used for pairing codes. Full A-Z + 0-9 alphabet (36 chars) so
 # codes the phone generates with AuthManager.PAIRING_CODE_CHARS always
 # validate cleanly. The earlier "no ambiguous 0/O/1/I" restriction only
@@ -705,22 +710,73 @@ def _extract_description_from_soul(soul_text: str) -> str:
     return ""
 
 
-def _pid_is_alive(pid: int) -> bool:
-    """Return True if ``pid`` refers to a live process on this host.
+def _windows_pid_is_alive(pid: int) -> bool:
+    """Probe a Windows PID through a non-signalling process handle."""
+    try:
+        import ctypes
 
-    Uses the POSIX ``os.kill(pid, 0)`` "probe" pattern — signal 0 performs
-    the permission/existence check without delivering a real signal. On
-    Windows, ``os.kill`` with signal 0 on CPython is implemented via
-    ``OpenProcess`` and returns success for live PIDs, ``OSError`` with
-    ``EINVAL``/``ESRCH``/``EPERM``-ish errno for dead or inaccessible
-    ones. We treat any ``OSError`` as "not running" — we prefer
-    false-negatives here (the gateway will simply be flagged offline) to
-    false-positives that would claim a dead daemon is live.
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = [ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32]
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+        kernel32.WaitForSingleObject.restype = ctypes.c_uint32
+        kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+        kernel32.CloseHandle.restype = ctypes.c_int
+
+        process_query_limited_information = 0x1000
+        synchronize = 0x00100000
+        wait_timeout = 0x00000102
+        error_invalid_parameter = 87
+        error_access_denied = 5
+
+        handle = kernel32.OpenProcess(
+            process_query_limited_information | synchronize,
+            False,
+            pid,
+        )
+        if not handle:
+            error = ctypes.get_last_error()
+            if error == error_access_denied:
+                return True
+            if error == error_invalid_parameter:
+                return False
+            return False
+        try:
+            return kernel32.WaitForSingleObject(handle, 0) == wait_timeout
+        finally:
+            kernel32.CloseHandle(handle)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return whether ``pid`` identifies a live process without signalling it.
+
+    Hermes normally supplies :mod:`psutil`, whose PID probe uses native process
+    APIs on Windows. Standalone Relay installs may not include psutil, so the
+    fallback uses ``OpenProcess``/``WaitForSingleObject`` on Windows and keeps
+    the signal-0 probe strictly on POSIX. Windows must never call
+    ``os.kill(pid, 0)``: CPython can route signal 0 through console-control or
+    process-termination behavior instead of treating it as a no-op.
     """
     if pid <= 0:
         return False
+
+    if _psutil is not None:
+        try:
+            return bool(_psutil.pid_exists(pid))
+        except Exception:
+            pass
+
+    if os.name == "nt":
+        return _windows_pid_is_alive(pid)
+
     try:
-        os.kill(pid, 0)
+        os.kill(pid, 0)  # windows-footgun: ok — POSIX-only branch
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
     except OSError:
         return False
     except Exception:  # pragma: no cover — defensive
@@ -821,11 +877,10 @@ def _probe_gateway_running(profile_home: Path) -> bool:
       ``hermes`` or ``gateway``. A PID pointing at (say) ``init`` or
       ``sshd`` reports ``False``.
 
-    On platforms without ``/proc`` (Windows/macOS dev hosts) these
-    secondary checks degrade to "don't penalize" — the primary
-    ``os.kill(pid, 0)`` probe still runs. Returns ``False`` on any
-    filesystem or parse error — the feature is advisory, not
-    load-bearing.
+    On platforms without ``/proc`` (Windows/macOS dev hosts) these secondary
+    checks degrade to "don't penalize"; the primary cross-platform process
+    probe still runs without signalling the target. Returns ``False`` on any
+    filesystem or parse error — the feature is advisory, not load-bearing.
     """
     pid_file = profile_home / "gateway.pid"
     try:
@@ -857,7 +912,7 @@ def _probe_gateway_running(profile_home: Path) -> bool:
         return False
 
     # Start-time cross-check (Linux only — no /proc means None and we
-    # skip this gate, trusting os.kill alone).
+    # skip this gate, trusting the cross-platform liveness probe alone).
     if claimed_start_time is not None:
         actual_start_time = _read_proc_start_time(pid)
         if actual_start_time is not None and actual_start_time != claimed_start_time:

--- a/plugin/tests/test_profile_discovery.py
+++ b/plugin/tests/test_profile_discovery.py
@@ -86,18 +86,6 @@ class ProfileDiscoveryTests(unittest.TestCase):
         self.profiles_dir = self.hermes_dir / "profiles"
         self.profiles_dir.mkdir(parents=True, exist_ok=True)
 
-        # `_probe_gateway_running` cross-checks /proc/<pid>/comm + /proc/<pid>/cmdline
-        # for "hermes" or "gateway" to defend against PID reuse. The test process
-        # is `python3` and won't match — patch the comm/cmdline check to True so
-        # the gateway-running probe degrades to "PID exists + start_time matches"
-        # for these tests. Both predicates remain enforced in production code.
-        self._comm_patcher = patch(
-            "plugin.relay.config._pid_matches_hermes",
-            return_value=True,
-        )
-        self._comm_patcher.start()
-        self.addCleanup(self._comm_patcher.stop)
-
     def _start_live_process(self) -> subprocess.Popen[bytes]:
         """Start a disposable process for PID liveness tests."""
         process = subprocess.Popen(

--- a/plugin/tests/test_profile_discovery.py
+++ b/plugin/tests/test_profile_discovery.py
@@ -9,13 +9,72 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from plugin.relay.config import _load_profiles, _read_proc_start_time
+from plugin.relay.config import _load_profiles, _pid_is_alive, _read_proc_start_time
+
+
+class PidLivenessProbeTests(unittest.TestCase):
+    def _start_live_process(self) -> subprocess.Popen[bytes]:
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)", "hermes-gateway"]
+        )
+
+        def stop_process() -> None:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+
+        self.addCleanup(stop_process)
+        return process
+
+    def test_windows_fallback_never_calls_os_kill(self) -> None:
+        with (
+            patch("plugin.relay.config._psutil", None),
+            patch("plugin.relay.config.os.name", "nt"),
+            patch(
+                "plugin.relay.config._windows_pid_is_alive", return_value=True
+            ) as windows_probe,
+            patch("plugin.relay.config.os.kill") as kill,
+        ):
+            self.assertTrue(_pid_is_alive(1234))
+
+        windows_probe.assert_called_once_with(1234)
+        kill.assert_not_called()
+
+    def test_psutil_probe_is_preferred_without_signalling(self) -> None:
+        psutil = MagicMock()
+        psutil.pid_exists.return_value = True
+        with (
+            patch("plugin.relay.config._psutil", psutil),
+            patch("plugin.relay.config.os.kill") as kill,
+        ):
+            self.assertTrue(_pid_is_alive(4321))
+
+        psutil.pid_exists.assert_called_once_with(4321)
+        kill.assert_not_called()
+
+    @unittest.skipUnless(os.name == "nt", "native Windows fallback test")
+    def test_windows_native_fallback_preserves_live_process(self) -> None:
+        process = self._start_live_process()
+        with (
+            patch("plugin.relay.config._psutil", None),
+            patch("plugin.relay.config.os.kill") as kill,
+        ):
+            self.assertTrue(_pid_is_alive(process.pid))
+
+        kill.assert_not_called()
+        self.assertIsNone(process.poll(), "native PID probe terminated the child")
 
 
 class ProfileDiscoveryTests(unittest.TestCase):
@@ -39,11 +98,27 @@ class ProfileDiscoveryTests(unittest.TestCase):
         self._comm_patcher.start()
         self.addCleanup(self._comm_patcher.stop)
 
-    def _real_start_time(self) -> int | None:
-        """Return the live test process's /proc start_time (clock ticks since
-        boot). On non-Linux hosts this is None and the probe degrades to
-        os.kill-alone — which still passes for os.getpid()."""
-        return _read_proc_start_time(os.getpid())
+    def _start_live_process(self) -> subprocess.Popen[bytes]:
+        """Start a disposable process for PID liveness tests."""
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)", "hermes-gateway"]
+        )
+
+        def stop_process() -> None:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+
+        self.addCleanup(stop_process)
+        return process
+
+    def _real_start_time(self, pid: int) -> int | None:
+        """Return a live child process's Linux ``/proc`` start time."""
+        return _read_proc_start_time(pid)
 
     # ── helpers ─────────────────────────────────────────────────────────
 
@@ -305,20 +380,21 @@ class ProfileDiscoveryTests(unittest.TestCase):
     def test_gateway_running_true_when_pid_file_points_at_live_process(
         self,
     ) -> None:
-        """A profile whose ``gateway.pid`` points at this test process
-        reports ``gateway_running=True``. We use the test runner's own
-        PID — guaranteed to be alive while the assertion runs."""
+        """Profile discovery probes a child PID without terminating it."""
         self._write_root_config()
         pdir = self._write_profile(
             "live",
             config_body="model:\n  default: x\n",
             soul=None,
         )
-        (pdir / "gateway.pid").write_text(str(os.getpid()), encoding="utf-8")
+        process = self._start_live_process()
+        (pdir / "gateway.pid").write_text(str(process.pid), encoding="utf-8")
 
+        self.assertTrue(_pid_is_alive(process.pid))
         out = self._load()
         entry = next(p for p in out if p["name"] == "live")
         self.assertTrue(entry["gateway_running"])
+        self.assertIsNone(process.poll(), "liveness probe terminated the child")
 
     def test_gateway_running_false_when_pid_file_absent(self) -> None:
         self._write_root_config()
@@ -361,14 +437,15 @@ class ProfileDiscoveryTests(unittest.TestCase):
             config_body="model:\n  default: x\n",
             soul=None,
         )
+        process = self._start_live_process()
         # Probe compares pid-file's start_time against /proc/<pid>/stat field 22
         # to defend against PID reuse. Use the live test pid's actual start_time
         # so the probe ratifies the file as fresh. On non-Linux hosts
         # _real_start_time() is None and the probe skips this check entirely.
-        st_value = self._real_start_time()
+        st_value = self._real_start_time(process.pid)
         st_field = (', "start_time": ' + str(st_value)) if st_value is not None else ""
         payload = (
-            '{"pid": ' + str(os.getpid()) +
+            '{"pid": ' + str(process.pid) +
             ', "kind": "hermes-gateway", "argv": ["main.py"]'
             + st_field + '}'
         )
@@ -377,6 +454,7 @@ class ProfileDiscoveryTests(unittest.TestCase):
         out = self._load()
         entry = next(p for p in out if p["name"] == "json-pid")
         self.assertTrue(entry["gateway_running"])
+        self.assertIsNone(process.poll(), "JSON PID probe terminated the child")
 
     def test_gateway_running_false_for_stale_pid(self) -> None:
         """A ``gateway.pid`` file containing a PID that doesn't exist

--- a/plugin/tests/test_profiles_updated_broadcast.py
+++ b/plugin/tests/test_profiles_updated_broadcast.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -28,6 +30,7 @@ from plugin.relay.config import RelayConfig
 from plugin.relay.server import (
     _broadcast_profiles_updated,
     _notify_profiles_changed,
+    _profile_rescan_loop,
     create_app,
 )
 
@@ -185,6 +188,47 @@ class NotifyProfilesChangedTests(unittest.IsolatedAsyncioTestCase):
         mock_bcast.assert_awaited()
         names = [p["name"] for p in server.config.profiles]
         self.assertIn("fresh", names)
+
+    async def test_periodic_rescan_does_not_terminate_gateway_pid(self) -> None:
+        """The recurring discovery path leaves a live gateway process intact."""
+        server = self._build_server()
+        pdir = self._write_profile("live")
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)", "hermes-gateway"]
+        )
+        self.addAsyncCleanup(self._stop_process, process)
+        (pdir / "gateway.pid").write_text(str(process.pid), encoding="utf-8")
+
+        with (
+            patch("plugin.relay.server._PROFILE_RESCAN_INTERVAL_SECONDS", 0.01),
+            patch(
+                "plugin.relay.server._broadcast_profiles_updated",
+                new_callable=AsyncMock,
+            ) as mock_bcast,
+            patch("plugin.relay.config._pid_matches_hermes", return_value=True),
+        ):
+            task = asyncio.create_task(_profile_rescan_loop({"server": server}))
+            try:
+                for _ in range(50):
+                    if mock_bcast.await_count:
+                        break
+                    await asyncio.sleep(0.01)
+            finally:
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+        mock_bcast.assert_awaited()
+        self.assertIsNone(process.poll(), "periodic rescan terminated the child")
+
+    async def _stop_process(self, process: subprocess.Popen[bytes]) -> None:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                await asyncio.to_thread(process.wait, 5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                await asyncio.to_thread(process.wait, 5)
 
 
 class PutEndpointBroadcastIntegrationTests(AioHTTPTestCase):


### PR DESCRIPTION
## Summary
- replace Relay's Windows-unsafe `os.kill(pid, 0)` gateway liveness check with the upstream-style non-signalling approach
- prefer Hermes-provided `psutil.pid_exists`, fall back to Win32 `OpenProcess`/`WaitForSingleObject`, and retain signal 0 only on POSIX
- replace self-PID fixtures with disposable child processes and cover direct discovery plus periodic profile rescans
- include the focused profile regression suites in Plugin CI

## Root cause
Relay profile discovery runs during `RelayConfig.from_env()` startup and during the periodic rescan. On Windows, `os.kill(pid, 0)` is not a safe existence probe and can terminate or interrupt the gateway referenced by `gateway.pid`. A separate virtual environment only masked that call path; shared venvs were not the root cause.

## Verification
- `python -m pytest plugin/tests/test_relay_security.py plugin/tests/test_voice_routes.py plugin/tests/test_session_grants.py plugin/tests/test_native_layout_imports.py plugin/tests/test_profile_discovery.py plugin/tests/test_profiles_updated_broadcast.py` (110 passed, 3 skipped)
- Plugin Python syntax compilation
- `python scripts/check-plugin-version-sync.py`
- `node .github/scripts/classify-ci-paths.test.cjs`
- `git diff --check`

Closes #223