### PR TITLE
feat(android): show diffusion animation during image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Android shows a diffusion animation while Hermes generates an image.** Active `image_generate` tool calls render a theme-aware placeholder in chat until the result arrives; no special server protocol is required.
+
 ### Fixed
 
 - **Relay trust boundaries are enforced across privileged interfaces.** Pairing policy is host-authorized, Android bridge and terminal dispatch require active grants, ordinary sessions can only reduce their own policy, remote profile config is restricted to a public schema, and voice callers cannot redirect host provider credentials.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,14 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-20 — Image generation placeholder during turns
+
+Android chat now specializes the generic tool lifecycle for active
+`image_generate` calls. While the tool is pending, the message shows a
+theme-aware procedural diffusion canvas with a polite live-region announcement
+instead of a generic tool card. The completed tool result still replaces the
+placeholder through the existing tool completion path. Coverage includes pure
+JVM selection/denoise tests and a Compose accessibility snapshot test.
+
 ## 2026-07-19 — Android 1.4.9 release preparation
 
 Android advanced to 1.4.9 with versionCode 32 after the dashboard-primary

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholder.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholder.kt
@@ -1,0 +1,173 @@
+package com.hermesandroid.relay.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.hermesandroid.relay.R
+import com.hermesandroid.relay.data.ToolCall
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.sin
+
+private const val IMAGE_GENERATION_TOOL = "image_generate"
+private const val GRID_COLUMNS = 42
+private const val GRID_ROWS = 24
+
+internal fun ToolCall.showsImageGenerationPlaceholder(): Boolean =
+    !isComplete && name.trim().lowercase() == IMAGE_GENERATION_TOOL
+
+/**
+ * Theme-aware latent diffusion preview for an active Hermes image-generation
+ * tool. It specializes the generic tool lifecycle already emitted by vanilla
+ * Hermes; no Relay-only protocol or server patch is required.
+ */
+@Composable
+fun ImageGenerationPlaceholder(
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(R.string.image_generation_rendering)
+    val transition = rememberInfiniteTransition(label = "imageGenerationDiffusion")
+    val phase by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 4_800, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "imageGenerationDiffusionPhase",
+    )
+    val background = MaterialTheme.colorScheme.surfaceVariant
+    val foreground = MaterialTheme.colorScheme.onSurfaceVariant
+    val primary = MaterialTheme.colorScheme.primary
+    val tertiary = MaterialTheme.colorScheme.tertiary
+
+    Box(
+        modifier = modifier
+            .widthIn(max = 360.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(background)
+            .semantics {
+                contentDescription = description
+                liveRegion = LiveRegionMode.Polite
+            },
+    ) {
+        DiffusionCanvas(
+            phase = phase,
+            background = background,
+            foreground = foreground,
+            primary = primary,
+            tertiary = tertiary,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f),
+        )
+    }
+}
+
+@Composable
+private fun DiffusionCanvas(
+    phase: Float,
+    background: Color,
+    foreground: Color,
+    primary: Color,
+    tertiary: Color,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(modifier = modifier) {
+        drawRect(background)
+        val cellWidth = size.width / GRID_COLUMNS
+        val cellHeight = size.height / GRID_ROWS
+        val denoise = diffusionDenoise(phase)
+        val time = phase * 9f
+
+        repeat(GRID_ROWS) { row ->
+            repeat(GRID_COLUMNS) { column ->
+                val signal = diffusionSignal(column, row, time, denoise)
+                if (signal < 0.2f) return@repeat
+
+                val x = column * cellWidth + cellWidth * 0.5f
+                val y = row * cellHeight + cellHeight * 0.5f
+                val radius = (cellWidth.coerceAtMost(cellHeight) * (0.14f + signal * 0.24f))
+                    .coerceAtLeast(0.7.dp.toPx())
+                val warmMix = ((signal - 0.35f) / 0.65f).coerceIn(0f, 1f)
+                val base = lerpColor(foreground, primary, warmMix)
+                val color = lerpColor(base, tertiary, hash01(column + 17, row - 11) * 0.32f)
+
+                drawRoundRect(
+                    color = color.copy(alpha = (0.08f + signal * 0.76f).coerceAtMost(0.84f)),
+                    topLeft = Offset(x - radius, y - radius),
+                    size = Size(radius * 2f, radius * 2f),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(radius * 0.45f),
+                )
+            }
+        }
+    }
+}
+
+internal fun diffusionDenoise(phase: Float): Float {
+    val normalized = phase - floor(phase)
+    return if (normalized < 0.82f) {
+        smoothstep(0.02f, 0.82f, normalized)
+    } else {
+        1f - smoothstep(0.82f, 1f, normalized)
+    }
+}
+
+internal fun diffusionSignal(column: Int, row: Int, time: Float, denoise: Float): Float {
+    val nx = (column + 0.5f) / GRID_COLUMNS - 0.52f
+    val ny = (row + 0.5f) / GRID_ROWS - 0.5f
+    val radius = kotlin.math.sqrt(nx * nx * 1.35f + ny * ny)
+    val bloom = (1f - radius * 2.35f).coerceIn(0f, 1f)
+    val ring = (1f - abs(radius - (0.23f + sin(time * 0.44f) * 0.025f)) * 15f)
+        .coerceIn(0f, 1f)
+    val latent = (bloom * 0.75f + ring * 0.5f).coerceIn(0f, 1f)
+    val staticNoise = hash01(column + floor(time * 3f).toInt() * 19, row - floor(time * 3f).toInt() * 11)
+    val livingNoise = hash01(column + floor(time * 7f).toInt(), row + floor(time * 5f).toInt())
+    return (
+        staticNoise * (1f - denoise) +
+            latent * denoise +
+            (livingNoise - 0.5f) * (0.42f - denoise * 0.2f)
+        ).coerceIn(0f, 1f)
+}
+
+private fun hash01(x: Int, y: Int): Float {
+    val value = sin(x * 127.1 + y * 311.7) * 43_758.5453
+    return (value - floor(value)).toFloat()
+}
+
+private fun smoothstep(edge0: Float, edge1: Float, value: Float): Float {
+    val t = ((value - edge0) / (edge1 - edge0)).coerceIn(0f, 1f)
+    return t * t * (3f - 2f * t)
+}
+
+private fun lerpColor(from: Color, to: Color, amount: Float): Color = Color(
+    red = from.red + (to.red - from.red) * amount,
+    green = from.green + (to.green - from.green) * amount,
+    blue = from.blue + (to.blue - from.blue) * amount,
+    alpha = from.alpha + (to.alpha - from.alpha) * amount,
+)

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -175,6 +175,7 @@ import com.hermesandroid.relay.ui.components.CompactToolCall
 import com.hermesandroid.relay.ui.components.ContextMeterBar
 import com.hermesandroid.relay.ui.components.GatewayBackgroundProcessSheet
 import com.hermesandroid.relay.ui.components.GatewayBackgroundProcessStrip
+import com.hermesandroid.relay.ui.components.ImageGenerationPlaceholder
 import com.hermesandroid.relay.ui.components.InjectedContextSheet
 import com.hermesandroid.relay.ui.components.InlineAutocomplete
 import com.hermesandroid.relay.ui.components.loadedContentTransform
@@ -197,6 +198,7 @@ import com.hermesandroid.relay.ui.components.SessionDrawerContent
 import com.hermesandroid.relay.ui.components.SlashCommand
 import com.hermesandroid.relay.ui.components.SubagentLane
 import com.hermesandroid.relay.ui.components.ToolProgressCard
+import com.hermesandroid.relay.ui.components.showsImageGenerationPlaceholder
 import com.hermesandroid.relay.ui.components.VoiceModeOverlay
 import com.hermesandroid.relay.ui.LocalSnackbarHost
 import com.hermesandroid.relay.ui.showHumanError
@@ -2339,12 +2341,16 @@ fun ChatScreen(
                                 val laneGroups = message.toolCalls.groupBy { it.taskIndex }
                                 laneGroups[null]?.forEach { toolCall ->
                                     Spacer(modifier = Modifier.height(4.dp))
-                                    when (toolDisplay) {
-                                        "compact" -> CompactToolCall(toolCall = toolCall)
-                                        else -> ToolProgressCard(
-                                            toolCall = toolCall,
-                                            messageTimestamp = message.timestamp,
-                                        )
+                                    if (toolCall.showsImageGenerationPlaceholder()) {
+                                        ImageGenerationPlaceholder()
+                                    } else {
+                                        when (toolDisplay) {
+                                            "compact" -> CompactToolCall(toolCall = toolCall)
+                                            else -> ToolProgressCard(
+                                                toolCall = toolCall,
+                                                messageTimestamp = message.timestamp,
+                                            )
+                                        }
                                     }
                                 }
                                 laneGroups.keys.filterNotNull().sorted().forEach { taskIndex ->

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -2343,6 +2343,7 @@
     <string name="tool_progress_status_completed">concluída</string>
     <string name="tool_progress_status_failed">falhou</string>
     <string name="tool_progress_status_running">em execução</string>
+    <string name="image_generation_rendering">Gerando imagem</string>
     <string name="tool_progress_cd_collapse">Recolher</string>
     <string name="tool_progress_cd_expand">Expandir</string>
     <!-- AgentIconRow -->

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -2452,6 +2452,7 @@
     <string name="tool_progress_status_completed">已完成</string>
     <string name="tool_progress_status_failed">失败</string>
     <string name="tool_progress_status_running">运行中</string>
+    <string name="image_generation_rendering">正在生成图像</string>
     <string name="tool_progress_cd_collapse">折叠</string>
     <string name="tool_progress_cd_expand">展开</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2455,6 +2455,7 @@
     <string name="tool_progress_status_completed">abgeschlossen</string>
     <string name="tool_progress_status_failed">fehlgeschlagen</string>
     <string name="tool_progress_status_running">läuft</string>
+    <string name="image_generation_rendering">Bild wird erstellt</string>
     <string name="tool_progress_cd_collapse">Einklappen</string>
     <string name="tool_progress_cd_expand">Ausklappen</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2229,6 +2229,7 @@
     <string name="tool_progress_status_completed">terminado</string>
     <string name="tool_progress_status_failed">fallido</string>
     <string name="tool_progress_status_running">correr</string>
+    <string name="image_generation_rendering">Generando imagen</string>
     <string name="tool_progress_cd_collapse">Colapsar</string>
     <string name="tool_progress_cd_expand">Expandir</string>
     <string name="agent_icon_title">Icono de agente</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2466,6 +2466,7 @@
     <string name="tool_progress_status_completed">完成した</string>
     <string name="tool_progress_status_failed">失敗した</string>
     <string name="tool_progress_status_running">走っている</string>
+    <string name="image_generation_rendering">画像を生成中</string>
     <string name="tool_progress_cd_collapse">崩壊</string>
     <string name="tool_progress_cd_expand">拡大する</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2549,6 +2549,7 @@
     <string name="tool_progress_status_completed">completed</string>
     <string name="tool_progress_status_failed">failed</string>
     <string name="tool_progress_status_running">running</string>
+    <string name="image_generation_rendering">Rendering image</string>
     <string name="tool_progress_cd_collapse">Collapse</string>
     <string name="tool_progress_cd_expand">Expand</string>
 

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholderTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholderTest.kt
@@ -1,0 +1,45 @@
+package com.hermesandroid.relay.ui.components
+
+import com.hermesandroid.relay.data.ToolCall
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageGenerationPlaceholderTest {
+
+    @Test
+    fun `active image generation uses diffusion placeholder`() {
+        val active = ToolCall(
+            id = "image-1",
+            name = " image_generate ",
+            args = null,
+            result = null,
+            success = null,
+        )
+
+        assertTrue(active.showsImageGenerationPlaceholder())
+        assertFalse(active.copy(isComplete = true, success = true).showsImageGenerationPlaceholder())
+        assertFalse(active.copy(name = "video_generate").showsImageGenerationPlaceholder())
+    }
+
+    @Test
+    fun `diffusion field changes across the animation cycle`() {
+        val noisy = diffusionSignal(column = 12, row = 8, time = 0.25f, denoise = diffusionDenoise(0.08f))
+        val resolved = diffusionSignal(column = 12, row = 8, time = 3.5f, denoise = diffusionDenoise(0.62f))
+
+        assertTrue(noisy in 0f..1f)
+        assertTrue(resolved in 0f..1f)
+        assertNotEquals(noisy, resolved)
+    }
+
+    @Test
+    fun `denoise cycle resolves then resets`() {
+        val early = diffusionDenoise(0.05f)
+        val resolved = diffusionDenoise(0.82f)
+        val reset = diffusionDenoise(0.99f)
+
+        assertTrue(early < resolved)
+        assertTrue(reset < resolved)
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholderUiTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholderUiTest.kt
@@ -1,0 +1,39 @@
+package com.hermesandroid.relay.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h720dp-xhdpi")
+class ImageGenerationPlaceholderUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `placeholder announces rendering image status`() {
+        compose.mainClock.autoAdvance = false
+        compose.setContent {
+            MaterialTheme {
+                ImageGenerationPlaceholder(Modifier.padding(16.dp))
+            }
+        }
+
+        compose.mainClock.advanceTimeBy(2_400)
+        compose.onNodeWithContentDescription("Rendering image").assertExists()
+        compose.onRoot().captureRoboImage("build/verification-shots/image-generation-placeholder.png")
+    }
+}

--- a/docs/localization-status.json
+++ b/docs/localization-status.json
@@ -13,7 +13,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "deed0aca5d3332d94a1ce517e1861112359802d334e926471ff0344fd0eef086",
+        "main": "b846b87b984403a1ec8aadb37ea550a7a0255a82c295649d24ee90cdab9a5d40",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -48,7 +48,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "deed0aca5d3332d94a1ce517e1861112359802d334e926471ff0344fd0eef086",
+        "main": "b846b87b984403a1ec8aadb37ea550a7a0255a82c295649d24ee90cdab9a5d40",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -72,7 +72,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "deed0aca5d3332d94a1ce517e1861112359802d334e926471ff0344fd0eef086",
+        "main": "b846b87b984403a1ec8aadb37ea550a7a0255a82c295649d24ee90cdab9a5d40",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -96,7 +96,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "deed0aca5d3332d94a1ce517e1861112359802d334e926471ff0344fd0eef086",
+        "main": "b846b87b984403a1ec8aadb37ea550a7a0255a82c295649d24ee90cdab9a5d40",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -120,7 +120,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "deed0aca5d3332d94a1ce517e1861112359802d334e926471ff0344fd0eef086",
+        "main": "b846b87b984403a1ec8aadb37ea550a7a0255a82c295649d24ee90cdab9a5d40",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {


### PR DESCRIPTION
## Summary
- Specialize pending `image_generate` tool parts in Android chat with a theme-aware procedural diffusion placeholder
- Keep the change client-only against vanilla Hermes tool lifecycle events (no server/protocol fork)
- Add accessibility live-region announcement plus unit/UI coverage

## Mechanism
Upstream Desktop paints a diffusion canvas while an `image_generate` tool part is pending, then replaces it with the decoded result. Android already receives the same generic tool lifecycle over Gateway/Sessions/Runs, so support is Compose-side only.

## Test plan
- [x] `./gradlew :app:testSideloadDebugUnitTest --tests ImageGenerationPlaceholderTest --tests ImageGenerationPlaceholderUiTest`
- [ ] CI Android lint/unit checks on this PR
- [ ] Optional on-device: trigger `image_generate` and confirm placeholder → result swap

Forge: AXI-129