### PR TITLE
fix(android): harden Markdown and private CA connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Malformed code blocks no longer crash Android Markdown rendering.** Syntax highlighting now bounds dependency-provided spans before applying them, preserving valid highlighting while safely ignoring reversed or out-of-bounds ranges.
 - **Windows-trusted certificates work in the desktop CLI.** The packaged Windows binary and newer Node runtimes add the Windows certificate store without dropping bundled or operator-supplied roots, while TLS verification and Relay certificate pinning remain enforced.
 
 ## [Server 1.4.3] - 2026-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Android accepts deliberately installed private certificate authorities.** Google Play and sideload builds now use Android's user CA store alongside system roots for self-hosted HTTPS/WSS connections while preserving certificate-chain, hostname, and Relay pin verification.
 - **Malformed code blocks no longer crash Android Markdown rendering.** Syntax highlighting now bounds dependency-provided spans before applying them, preserving valid highlighting while safely ignoring reversed or out-of-bounds ranges.
 - **Windows-trusted certificates work in the desktop CLI.** The packaged Windows binary and newer Node runtimes add the Windows certificate store without dropping bundled or operator-supplied roots, while TLS verification and Relay certificate pinning remain enforced.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Promoted voice tasks keep their Chat row through background delivery.** Completing the provider's initial spoken handoff no longer removes an otherwise empty assistant bubble that still owns a running background task.
 - **Android accepts deliberately installed private certificate authorities.** Google Play and sideload builds now use Android's user CA store alongside system roots for self-hosted HTTPS/WSS connections while preserving certificate-chain, hostname, and Relay pin verification.
 - **Malformed code blocks no longer crash Android Markdown rendering.** Syntax highlighting now bounds dependency-provided spans before applying them, preserving valid highlighting while safely ignoring reversed or out-of-bounds ranges.
 - **Windows-trusted certificates work in the desktop CLI.** The packaged Windows binary and newer Node runtimes add the Windows certificate store without dropping bundled or operator-supplied roots, while TLS verification and Relay certificate pinning remain enforced.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,28 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-23 — Android user-CA trust for self-hosted Hermes
+
+The shared Android network security configuration now accepts CA certificates
+that the device owner deliberately installed in Android's user credential store,
+in addition to system roots. Because the policy is attached to the common
+application manifest, it covers both product flavors and every platform-backed
+Hermes transport: endpoint probes, Dashboard requests and authentication
+WebView, redirects, Gateway WebSockets, API streaming, Standard Voice, and
+Relay HTTPS/WSS. Default OkHttp and WebView certificate-chain and hostname
+checks remain active, and Relay's independent certificate pinner is not
+overridden.
+
+An app-wide policy is required for arbitrary operator-supplied server names and
+for consistent WebView behavior. A runtime opt-in would require parallel custom
+trust implementations for each client and could not safely reconfigure WebView;
+per-connection CA import would add private trust-material lifecycle without
+covering all transports. The tradeoff is that Android disables public
+Certificate Transparency verification when user trust anchors are enabled.
+User documentation records the deliberate-installation boundary and a device or
+emulator validation procedure with positive chain and negative hostname checks.
+JVM coverage locks the accepted anchor sources and rejects pin overrides or
+debug-only trust additions.
+
 ## 2026-07-23 — Bounded Android code-highlighting ranges
 
 Android Markdown code rendering now validates every syntax-highlighting span

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,16 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-23 — Bounded Android code-highlighting ranges
+
+Android Markdown code rendering now validates every syntax-highlighting span
+before applying it to Compose text. The bundled highlighting dependency can
+emit a reversed multiline-comment range when malformed or incomplete code
+contains a closing delimiter before its opening delimiter; the Markdown
+renderer previously passed that range directly to `AnnotatedString` and
+crashed. Both fenced and indented code use the guarded renderer, valid spans
+remain highlighted, and malformed ranges are clipped or ignored. Focused JVM
+coverage reproduces the dependency output and verifies the safe conversion.
+
 ## 2026-07-20 — Image generation placeholder during turns
 
 Android chat now specializes the generic tool lifecycle for active

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,14 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-24 — Realtime background-task delivery continuity
+
+Chat stream completion now preserves an otherwise empty assistant row when it
+owns a promoted background task. This keeps the task identity available after
+the provider's initial spoken handoff, so later progress, completion, and
+forced-summary events update and settle the initiating row even when a newer
+persistent Voice command has started. Existing empty-response cleanup remains
+unchanged for assistant rows without background work.
+
 ## 2026-07-23 — Android user-CA trust for self-hosted Hermes
 
 The shared Android network security configuration now accepts CA certificates

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
@@ -2923,6 +2923,7 @@ class ChatHandler {
                         msg.id == messageId &&
                         msg.role == MessageRole.ASSISTANT &&
                         msg.toolCalls.isEmpty() &&
+                        msg.backgroundTask == null &&
                         msg.thinkingContent.isBlank() &&
                         (msg.content.isBlank() || isIntentionalSilenceMarker(msg.content))
                 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MarkdownContent.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MarkdownContent.kt
@@ -41,8 +41,6 @@ import com.mikepenz.markdown.compose.components.MarkdownComponentModel
 import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.compose.LocalMarkdownDimens
 import com.mikepenz.markdown.compose.elements.MarkdownDivider
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeBlock
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeFence
 import com.mikepenz.markdown.compose.elements.MarkdownTable
 import com.mikepenz.markdown.compose.elements.MarkdownTableHeader
 import com.mikepenz.markdown.compose.elements.MarkdownTableRow
@@ -152,7 +150,7 @@ fun MarkdownContent(
         ),
         components = markdownComponents(
             codeBlock = {
-                MarkdownHighlightedCodeBlock(
+                SafeMarkdownHighlightedCodeBlock(
                     content = it.content,
                     node = it.node,
                     highlightsBuilder = highlightsBuilder,
@@ -160,7 +158,7 @@ fun MarkdownContent(
                 )
             },
             codeFence = {
-                MarkdownHighlightedCodeFence(
+                SafeMarkdownHighlightedCodeFence(
                     content = it.content,
                     node = it.node,
                     highlightsBuilder = highlightsBuilder,

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SafeMarkdownHighlightedCode.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SafeMarkdownHighlightedCode.kt
@@ -1,0 +1,145 @@
+package com.hermesandroid.relay.ui.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.compose.LocalMarkdownDimens
+import com.mikepenz.markdown.compose.LocalMarkdownPadding
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBackground
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
+import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
+import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
+import dev.snipme.highlights.Highlights
+import dev.snipme.highlights.model.BoldHighlight
+import dev.snipme.highlights.model.ColorHighlight
+import dev.snipme.highlights.model.SyntaxLanguage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.intellij.markdown.ast.ASTNode
+
+@Composable
+internal fun SafeMarkdownHighlightedCodeFence(
+    content: String,
+    node: ASTNode,
+    style: TextStyle = LocalMarkdownTypography.current.code,
+    highlightsBuilder: Highlights.Builder,
+    showHeader: Boolean = false,
+) {
+    MarkdownCodeFence(content, node, style) { code, language, codeStyle ->
+        SafeMarkdownHighlightedCode(
+            code = code,
+            language = language,
+            style = codeStyle,
+            highlightsBuilder = highlightsBuilder,
+            showHeader = showHeader,
+        )
+    }
+}
+
+@Composable
+internal fun SafeMarkdownHighlightedCodeBlock(
+    content: String,
+    node: ASTNode,
+    style: TextStyle = LocalMarkdownTypography.current.code,
+    highlightsBuilder: Highlights.Builder,
+    showHeader: Boolean = false,
+) {
+    MarkdownCodeBlock(content, node, style) { code, language, codeStyle ->
+        SafeMarkdownHighlightedCode(
+            code = code,
+            language = language,
+            style = codeStyle,
+            highlightsBuilder = highlightsBuilder,
+            showHeader = showHeader,
+        )
+    }
+}
+
+@Composable
+private fun SafeMarkdownHighlightedCode(
+    code: String,
+    language: String?,
+    style: TextStyle,
+    highlightsBuilder: Highlights.Builder,
+    showHeader: Boolean,
+) {
+    val codeHighlights by produceState(
+        initialValue = AnnotatedString(code),
+        key1 = code,
+        key2 = language,
+        key3 = highlightsBuilder,
+    ) {
+        value = withContext(Dispatchers.Default) {
+            buildSafeHighlightedAnnotatedString(code, language, highlightsBuilder)
+        }
+    }
+
+    val codeBackgroundCornerSize = LocalMarkdownDimens.current.codeBackgroundCornerSize
+    MarkdownCodeBackground(
+        color = LocalMarkdownColors.current.codeBackground,
+        shape = RoundedCornerShape(codeBackgroundCornerSize),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        showHeader = showHeader,
+        language = language,
+        code = code,
+    ) {
+        MarkdownBasicText(
+            text = codeHighlights,
+            style = style,
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(LocalMarkdownPadding.current.codeBlock),
+        )
+    }
+}
+
+/**
+ * Converts Highlights ranges into Compose spans without trusting dependency
+ * offsets. Highlights 1.1.0 can return a reversed multiline-comment range
+ * when a multiline-comment closing delimiter precedes its opening delimiter.
+ * Streaming can expose that shape before a code block is complete.
+ */
+internal fun buildSafeHighlightedAnnotatedString(
+    code: String,
+    language: String?,
+    highlightsBuilder: Highlights.Builder,
+): AnnotatedString {
+    val syntaxLanguage = language?.let(SyntaxLanguage::getByName)
+    val highlights = highlightsBuilder
+        .code(code)
+        .let { if (syntaxLanguage != null) it.language(syntaxLanguage) else it }
+        .build()
+        .getHighlights()
+
+    return buildAnnotatedString {
+        append(code)
+        highlights.forEach { highlight ->
+            val start = highlight.location.start.coerceIn(0, code.length)
+            val end = highlight.location.end.coerceIn(0, code.length)
+            if (start >= end) return@forEach
+
+            val style = when (highlight) {
+                is ColorHighlight -> SpanStyle(color = Color(highlight.rgb).copy(alpha = 1f))
+                is BoldHighlight -> SpanStyle(fontWeight = FontWeight.Bold)
+            }
+            addStyle(style = style, start = start, end = end)
+        }
+    }
+}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -9,12 +9,15 @@
     - Visible warning badge when connected over http:// or ws://
     - Users are encouraged to set up TLS for production deployments
 
-    The app makes NO connections to external services — only user-configured endpoints.
+    System CAs and CAs deliberately installed in Android's user credential store
+    are accepted. This expands the available trust anchors without bypassing
+    certificate-chain, hostname, or Relay certificate-pin verification.
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
-            <certificates src="system" />
+            <certificates src="system" overridePins="false" />
+            <certificates src="user" overridePins="false" />
         </trust-anchors>
     </base-config>
 </network-security-config>

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/NetworkSecurityConfigTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/NetworkSecurityConfigTest.kt
@@ -1,0 +1,42 @@
+package com.hermesandroid.relay.network
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkSecurityConfigTest {
+    private val document by lazy {
+        val config = sequenceOf(
+            File("src/main/res/xml/network_security_config.xml"),
+            File("app/src/main/res/xml/network_security_config.xml"),
+        ).firstOrNull(File::isFile)
+            ?: error("network_security_config.xml not found")
+
+        DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(config)
+    }
+
+    @Test
+    fun releaseConfig_trustsOnlySystemAndUserCredentialStores() {
+        val certificates = document.getElementsByTagName("certificates")
+        val sources = (0 until certificates.length).map { index ->
+            certificates.item(index).attributes.getNamedItem("src").nodeValue
+        }
+
+        assertEquals(listOf("system", "user"), sources)
+        assertTrue(
+            (0 until certificates.length).all { index ->
+                certificates.item(index).attributes.getNamedItem("overridePins").nodeValue == "false"
+            },
+        )
+    }
+
+    @Test
+    fun releaseConfig_hasNoTrustOrHostnameBypass() {
+        assertEquals(0, document.getElementsByTagName("debug-overrides").length)
+        assertFalse(document.documentElement.textContent.contains("trust-all", ignoreCase = true))
+        assertFalse(document.documentElement.textContent.contains("ignore tls", ignoreCase = true))
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/SafeMarkdownHighlightedCodeTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/SafeMarkdownHighlightedCodeTest.kt
@@ -1,0 +1,49 @@
+package com.hermesandroid.relay.ui.components
+
+import dev.snipme.highlights.Highlights
+import dev.snipme.highlights.model.SyntaxThemes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SafeMarkdownHighlightedCodeTest {
+    @Test
+    fun malformedMultilineComment_ignoresReversedHighlightRange() {
+        val code = "*/path/*"
+        val unsafeHighlights = builder()
+            .code(code)
+            .build()
+            .getHighlights()
+
+        assertTrue(
+            "The dependency reproducer must contain a reversed range",
+            unsafeHighlights.any { it.location.start > it.location.end },
+        )
+
+        val annotated = buildSafeHighlightedAnnotatedString(
+            code = code,
+            language = null,
+            highlightsBuilder = builder(),
+        )
+
+        assertEquals(code, annotated.text)
+        assertTrue(annotated.spanStyles.all { it.start in 0..it.end && it.end <= code.length })
+    }
+
+    @Test
+    fun validCode_keepsSyntaxHighlighting() {
+        val code = "val answer = 42"
+        val annotated = buildSafeHighlightedAnnotatedString(
+            code = code,
+            language = "kotlin",
+            highlightsBuilder = builder(),
+        )
+
+        assertEquals(code, annotated.text)
+        assertTrue(annotated.spanStyles.isNotEmpty())
+        assertTrue(annotated.spanStyles.all { it.start in 0 until it.end && it.end <= code.length })
+    }
+
+    private fun builder(): Highlights.Builder =
+        Highlights.Builder().theme(SyntaxThemes.atom(darkMode = true))
+}

--- a/docs/localization-status.json
+++ b/docs/localization-status.json
@@ -13,7 +13,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "886cf9b7710af423aab0e51ada49dfbf78cfacd71265eb1f0d973d309004b2ea",
+        "main": "5bd4e324513379be98126b6b78d4f5bfd94e9fcbc81a3cd949c2b6f20948617d",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -26,7 +26,7 @@
       "docs_source_sha256": {
         "index.md": "bbaa33578cd9d8963150ed861e7a0bd489d3938b7c6c2d572beea725f319e136",
         "guide/quick-start.md": "1a5c4c89a992bd57c1e93702b270a466675c7f65fb8ebe20968febc621877049",
-        "guide/getting-started.md": "42fcf0913c8ba840ff3cffbdcff65f9ba47eeb18fe5faa7122f8eecdcc046c62",
+        "guide/getting-started.md": "fd646f9c6ad11a3da148c6026fa9479045af8a0ce09457f11e385961b301ec15",
         "guide/release-tracks.md": "390982de1e1430bed0b8a0e854431c97e3368cf04e477197eb5cb893db225f51",
         "guide/troubleshooting.md": "43677454b94dd7810adc9b685266598353b851b549b151de31cfa053cf74f6c1"
       },
@@ -48,7 +48,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "886cf9b7710af423aab0e51ada49dfbf78cfacd71265eb1f0d973d309004b2ea",
+        "main": "5bd4e324513379be98126b6b78d4f5bfd94e9fcbc81a3cd949c2b6f20948617d",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -61,7 +61,7 @@
       "docs_source_sha256": {
         "index.md": "bbaa33578cd9d8963150ed861e7a0bd489d3938b7c6c2d572beea725f319e136",
         "guide/quick-start.md": "1a5c4c89a992bd57c1e93702b270a466675c7f65fb8ebe20968febc621877049",
-        "guide/getting-started.md": "42fcf0913c8ba840ff3cffbdcff65f9ba47eeb18fe5faa7122f8eecdcc046c62",
+        "guide/getting-started.md": "fd646f9c6ad11a3da148c6026fa9479045af8a0ce09457f11e385961b301ec15",
         "guide/release-tracks.md": "390982de1e1430bed0b8a0e854431c97e3368cf04e477197eb5cb893db225f51",
         "guide/troubleshooting.md": "43677454b94dd7810adc9b685266598353b851b549b151de31cfa053cf74f6c1"
       },
@@ -72,7 +72,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "886cf9b7710af423aab0e51ada49dfbf78cfacd71265eb1f0d973d309004b2ea",
+        "main": "5bd4e324513379be98126b6b78d4f5bfd94e9fcbc81a3cd949c2b6f20948617d",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -85,7 +85,7 @@
       "docs_source_sha256": {
         "index.md": "bbaa33578cd9d8963150ed861e7a0bd489d3938b7c6c2d572beea725f319e136",
         "guide/quick-start.md": "1a5c4c89a992bd57c1e93702b270a466675c7f65fb8ebe20968febc621877049",
-        "guide/getting-started.md": "42fcf0913c8ba840ff3cffbdcff65f9ba47eeb18fe5faa7122f8eecdcc046c62",
+        "guide/getting-started.md": "fd646f9c6ad11a3da148c6026fa9479045af8a0ce09457f11e385961b301ec15",
         "guide/release-tracks.md": "390982de1e1430bed0b8a0e854431c97e3368cf04e477197eb5cb893db225f51",
         "guide/troubleshooting.md": "43677454b94dd7810adc9b685266598353b851b549b151de31cfa053cf74f6c1"
       },
@@ -96,7 +96,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "886cf9b7710af423aab0e51ada49dfbf78cfacd71265eb1f0d973d309004b2ea",
+        "main": "5bd4e324513379be98126b6b78d4f5bfd94e9fcbc81a3cd949c2b6f20948617d",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -109,7 +109,7 @@
       "docs_source_sha256": {
         "index.md": "bbaa33578cd9d8963150ed861e7a0bd489d3938b7c6c2d572beea725f319e136",
         "guide/quick-start.md": "1a5c4c89a992bd57c1e93702b270a466675c7f65fb8ebe20968febc621877049",
-        "guide/getting-started.md": "42fcf0913c8ba840ff3cffbdcff65f9ba47eeb18fe5faa7122f8eecdcc046c62",
+        "guide/getting-started.md": "fd646f9c6ad11a3da148c6026fa9479045af8a0ce09457f11e385961b301ec15",
         "guide/release-tracks.md": "390982de1e1430bed0b8a0e854431c97e3368cf04e477197eb5cb893db225f51",
         "guide/troubleshooting.md": "43677454b94dd7810adc9b685266598353b851b549b151de31cfa053cf74f6c1"
       },
@@ -120,7 +120,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "886cf9b7710af423aab0e51ada49dfbf78cfacd71265eb1f0d973d309004b2ea",
+        "main": "5bd4e324513379be98126b6b78d4f5bfd94e9fcbc81a3cd949c2b6f20948617d",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -133,7 +133,7 @@
       "docs_source_sha256": {
         "index.md": "bbaa33578cd9d8963150ed861e7a0bd489d3938b7c6c2d572beea725f319e136",
         "guide/quick-start.md": "1a5c4c89a992bd57c1e93702b270a466675c7f65fb8ebe20968febc621877049",
-        "guide/getting-started.md": "42fcf0913c8ba840ff3cffbdcff65f9ba47eeb18fe5faa7122f8eecdcc046c62",
+        "guide/getting-started.md": "fd646f9c6ad11a3da148c6026fa9479045af8a0ce09457f11e385961b301ec15",
         "guide/release-tracks.md": "390982de1e1430bed0b8a0e854431c97e3368cf04e477197eb5cb893db225f51",
         "guide/troubleshooting.md": "43677454b94dd7810adc9b685266598353b851b549b151de31cfa053cf74f6c1"
       },

--- a/user-docs/features/connections.md
+++ b/user-docs/features/connections.md
@@ -72,6 +72,44 @@ dashboard when required. The API server and Relay are optional and can be added
 later without recreating the connection. Existing API-first setup QRs remain
 importable for compatibility.
 
+## Private and user-installed certificate authorities
+
+Both Google Play and sideload builds accept HTTPS/WSS certificates that chain
+to either Android's system roots or a CA deliberately installed in the phone's
+**user credential store**. This supports private, self-hosted PKI without an
+"ignore TLS errors" mode. The server certificate must still be within its
+validity period, chain to the installed CA, and contain the exact Dashboard/API/
+Relay hostname or IP address in its Subject Alternative Name. Relay certificate
+pins, when present, remain an additional check.
+
+This is an app-wide Android trust policy because connections can use arbitrary
+operator-supplied hostnames and the same policy must cover native HTTP, redirects,
+Dashboard sign-in, Gateway WebSockets, API streaming, voice, and Relay. A
+per-domain XML policy cannot name hosts that are not known at build time. Android
+does not apply public Certificate Transparency verification to connections when
+the app allows user-installed trust anchors; install only CAs you control and
+remove them from Android Settings when they are no longer needed.
+
+To validate a local CA on a device or emulator:
+
+1. Issue the reverse proxy's leaf certificate from the local CA. Include the
+   exact test DNS name or IP address in the leaf certificate's SAN extension.
+2. Copy only the CA certificate (never its private key) to the device. For an
+   emulator, `adb push local-ca.crt /sdcard/Download/` is convenient.
+3. In Android Settings, open **Security & privacy → More security settings →
+   Encryption & credentials → Install a certificate → CA certificate**. Menu
+   wording varies slightly by Android version. Select `local-ca.crt` and confirm
+   it appears under **Trusted credentials → User**.
+4. Configure the Dashboard, optional API server, and optional Relay reverse
+   proxy to present the leaf certificate plus any required intermediate chain.
+5. Add the HTTPS Dashboard address in Hermes-Relay. Verify Dashboard discovery
+   and sign-in, start a Chat reply to exercise the Gateway WSS route, open
+   Manage, and run a Standard Voice preview. If API fallback or Relay uses the
+   same private CA, test those capabilities from the connection detail screen.
+6. Negative-check hostname verification by trying the same server through an
+   address absent from the certificate SAN. It must still fail with a certificate
+   hostname error.
+
 ## Live status and diagnostics
 
 Pairing and live reachability are shown separately. A connection can still be

--- a/user-docs/reference/relay-api.md
+++ b/user-docs/reference/relay-api.md
@@ -59,6 +59,17 @@ longer-lived Relay session and its clamped grants.
 All file routes resolve real paths under configured allowed roots and reject
 symlink escapes.
 
+## Chat activity compatibility
+
+| Method | Route | Auth | Purpose |
+|---|---|---|---|
+| `GET` | `/chat/image-activity` | Paired `chat` grant | Read image-generation activity from the selected Hermes session when the upstream Gateway does not expose native tool progress |
+
+This optional route reports only image-generation lifecycle state. It does not
+proxy chat prompts, response text, tool results, or session control. Android
+uses native Gateway events when available and silently stops polling when an
+older Relay does not provide the route.
+
 ## Relay voice
 
 Every route below is Relay-owned. Vanilla Hermes voice uses Dashboard


### PR DESCRIPTION
## Summary

- guard syntax-highlighting spans before applying them to Compose text
- trust CAs deliberately installed in Android's user credential store across both product flavors
- document the trust-policy tradeoff and device/emulator validation procedure

## Root causes

### Markdown crash

Highlights 1.1.0 can emit a reversed multiline-comment range when malformed or incomplete code contains a closing delimiter before its opening delimiter. markdown-renderer 0.43.0 passes that range directly to `AnnotatedString.addStyle`, which throws `IllegalArgumentException: Reversed range is not supported`.

The app now uses a bounded highlighted-code component for both fenced and indented code. Reversed/empty spans are ignored, out-of-bounds spans are clamped, and valid syntax highlighting remains enabled. Live streaming continues to render stable plain text until the finalized Markdown boundary.

### User-installed CA failure

The shared Android Network Security Configuration explicitly trusted only `system` roots. Apps targeting modern Android therefore rejected certificates chaining to a CA that the device owner installed in the user credential store.

The common config now adds `src="user"` with `overridePins="false"`. This reaches Google Play and sideload builds, native HTTP and redirects, Dashboard authentication WebView, Gateway WebSockets, API streaming, Standard Voice, and Relay HTTPS/WSS. Normal chain and hostname verification remain enabled, and Relay's independent OkHttp certificate pinning is unchanged.

The policy is app-wide because server hostnames are operator-defined at runtime and the Dashboard WebView cannot be safely reconfigured with a per-connection OkHttp trust manager. Android disables public Certificate Transparency checks when user trust anchors are enabled; the user documentation calls out that tradeoff and the deliberate-installation boundary.

## Validation

Passed:

- focused Google Play JVM tests:
  - `SafeMarkdownHighlightedCodeTest`
  - `StreamingMarkdownContentTest`
  - `NetworkSecurityConfigTest`
- the same focused sideload JVM tests
- `:app:lintGooglePlayDebug`
- `:app:lintSideloadDebug`
- `:app:assembleGooglePlayDebug`
- `:app:assembleSideloadDebug`
- `npm run build` in `user-docs`
- manual diff review for TLS/hostname/pin bypasses, Markdown entry-point coverage, upstream compatibility, and public-repo hygiene

The full Google Play JVM suite was attempted twice. The latest run executed 1,386 tests with 17 failures and 12 skips. Failures were in untouched Windows DataStore temp-file rename tests and timing-sensitive Compose/Relay voice/chat tests; the count changed from 18 to 17 between runs. No failing class overlaps this diff.

## On-device follow-up

Before merge/release acceptance, validate on a device or emulator with a local CA:

- positive chain through an Android user-installed CA
- Dashboard discovery and authentication WebView
- Gateway chat WSS, Manage, Standard Voice, optional API fallback, and Relay when configured
- negative hostname mismatch, which must still fail

Fixes #230
Fixes #239