### PR TITLE
feat(android): retain active turns in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Background chats stay reachable without an always-on connection.** Android now protects user-started work until every concurrent Gateway session settles, shows active and waiting counts in its ongoing notification, and gives each privacy-safe interaction alert expanded session context plus a direct review, answer, or secure-response action.
 - **Android alerts when a background Gateway turn needs input.** Approval, clarification, elevated-permission, and secret requests post privacy-safe notifications that reopen the correct conversation, survive reconnect replay without duplicates, and clear when the request is answered or expires.
 - **Promoted voice tasks keep their Chat row through background delivery.** Completing the provider's initial spoken handoff no longer removes an otherwise empty assistant bubble that still owns a running background task.
 - **Android accepts deliberately installed private certificate authorities.** Google Play and sideload builds now use Android's user CA store alongside system roots for self-hosted HTTPS/WSS connections while preserving certificate-chain, hostname, and Relay pin verification.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,24 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-25 — Active-turn retention and actionable interaction alerts
+
+Android now promotes user-started chat work to foreground execution until every
+connection/profile/session-scoped turn settles. Independent leases preserve
+concurrent detached Gateway sessions, track sessions paused for input, and
+prevent one completion from stopping protection for siblings. The existing
+Persistent connection switch now extends retention only to idle periods.
+
+The foreground notification reports active and waiting session counts.
+Interaction alerts add privacy-safe expanded profile/session context and an
+explicit review, answer, or secure-response action that deep-links to the exact
+conversation; commands, questions, passwords, secrets, and environment-variable
+names remain confined to the authenticated chat surface.
+
+Audited `ChatViewModel`, `ConnectionViewModel`, `GatewayChatClient`,
+`GatewayKeepAliveService`, `InteractionRequestNotifier`, the shared Android
+manifest, Android settings copy, chat user documentation, and Play foreground
+service declaration guidance.
+
 ## 2026-07-24 — Post-connect permission setup
 
 Android onboarding now finishes with a layered permission step after a

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,12 +90,10 @@
             android:name=".notifications.ProactiveReplyReceiver"
             android:exported="false" />
 
-        <!-- Opt-in "Persistent connection" — holds the user's connection to
-             Hermes open while backgrounded so messages and live features stay
-             responsive (relay-paired setups also keep device control +
-             notification mirroring reachable). In main so BOTH flavors ship it
-             (Home-Assistant-class persistent connection). Off by default; only
-             runs while the user has explicitly enabled the toggle. specialUse
+        <!-- Protects user-started active turns automatically; the optional
+             "Persistent connection" setting extends the same foreground
+             protection to idle/background connectivity (and relay-paired
+             device features). In main so BOTH flavors ship it. specialUse
              needs a Play Console foreground-service declaration at submission. -->
         <service
             android:name=".network.upstream.GatewayKeepAliveService"
@@ -103,7 +101,7 @@
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="Keeps the user's connection to their Hermes agent open in the background so messages and live features stay responsive, only when the user has explicitly enabled 'Persistent connection'." />
+                android:value="Keeps user-started Hermes turns connected until they finish or need input, and optionally keeps idle connections responsive when the user enables Persistent connection." />
         </service>
 
     </application>

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ActiveTurnKeepAliveRegistry.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ActiveTurnKeepAliveRegistry.kt
@@ -1,0 +1,76 @@
+package com.hermesandroid.relay.network.upstream
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Process-local ownership of background protection for work the user already
+ * started. Keys are connection/profile/session scoped, so detached sibling
+ * sessions retain independent leases and one completion cannot release
+ * another session's protection.
+ */
+object ActiveTurnKeepAliveRegistry {
+    data class Snapshot(
+        val activeTurnCount: Int = 0,
+        val waitingSessionCount: Int = 0,
+    ) {
+        val required: Boolean get() = activeTurnCount > 0
+    }
+
+    private val lock = Any()
+    private val leases = linkedMapOf<String, Boolean>()
+    private val _snapshot = MutableStateFlow(Snapshot())
+    val snapshot: StateFlow<Snapshot> = _snapshot.asStateFlow()
+
+    fun acquire(key: String) {
+        synchronized(lock) {
+            leases[key] = leases[key] ?: false
+            publishLocked()
+        }
+    }
+
+    fun setWaiting(key: String, waiting: Boolean) {
+        synchronized(lock) {
+            if (key in leases) {
+                leases[key] = waiting
+                publishLocked()
+            }
+        }
+    }
+
+    fun rename(oldKey: String, newKey: String) {
+        if (oldKey == newKey) return
+        synchronized(lock) {
+            val waiting = leases.remove(oldKey) ?: return
+            leases[newKey] = waiting
+            publishLocked()
+        }
+    }
+
+    fun release(key: String) {
+        synchronized(lock) {
+            if (leases.remove(key) != null) publishLocked()
+        }
+    }
+
+    fun releaseAll() {
+        synchronized(lock) {
+            if (leases.isNotEmpty()) {
+                leases.clear()
+                publishLocked()
+            }
+        }
+    }
+
+    internal fun resetForTest() {
+        releaseAll()
+    }
+
+    private fun publishLocked() {
+        _snapshot.value = Snapshot(
+            activeTurnCount = leases.size,
+            waitingSessionCount = leases.count { it.value },
+        )
+    }
+}

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayKeepAliveService.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayKeepAliveService.kt
@@ -22,8 +22,9 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 /**
- * Opt-in foreground service that holds the app process up so the app's
- * connection to Hermes survives Android's background-freeze / Doze — i.e.
+ * Foreground service that holds the app process up so work the user already
+ * started survives Android's background-freeze / Doze. It runs automatically
+ * while one or more turns are active, or continuously when the user enables
  * "persistent connection". Concretely it keeps the gateway chat WebSocket
  * (held by [com.hermesandroid.relay.viewmodel.ConnectionViewModel]'s
  * [GatewayChatClient]) open; for relay-paired setups, holding the whole
@@ -39,13 +40,14 @@ import kotlinx.coroutines.launch
  * connection use case Google Play permits. The `specialUse` type is honest for
  * an always-on connection (`dataSync` is force-stopped after a 6h/day cap on
  * SDK 35) but requires a one-time Play Console foreground-service declaration
- * at submission. Off by default; only runs while the user enables the toggle.
+ * at submission. Continuous idle retention is off by default; active work is
+ * protected automatically and releases its lease on terminal settlement.
  *
  * # It does NOT own the socket
  *
  * The service's only job is to hold the process in the foreground. The socket
  * stays open because [GatewayChatClient.setKeepAliveInBackground] stops its
- * idle-close timer while the toggle is on. On task removal (user swipes the app
+ * idle-close timer while retention is required. On task removal (user swipes the app
  * away) the ViewModel + socket die with the process, so the service stops
  * itself rather than leave a notification that lies about being connected.
  *
@@ -63,9 +65,31 @@ class GatewayKeepAliveService : Service() {
         private const val CHANNEL_NAME = "Persistent connection"
         const val NOTIFICATION_ID = 4713
         const val ACTION_STOP = "com.hermesandroid.relay.gateway.KEEPALIVE_STOP"
+        private const val ACTION_REFRESH = "com.hermesandroid.relay.gateway.KEEPALIVE_REFRESH"
+        private const val EXTRA_PERSISTENT = "persistent"
+        private const val EXTRA_ACTIVE_TURNS = "active_turns"
+        private const val EXTRA_WAITING_SESSIONS = "waiting_sessions"
+        @Volatile private var runningInstance: GatewayKeepAliveService? = null
 
-        fun start(context: Context) {
+        fun update(
+            context: Context,
+            persistent: Boolean,
+            activeTurns: ActiveTurnKeepAliveRegistry.Snapshot,
+        ) {
+            if (!persistent && !activeTurns.required) {
+                stop(context)
+                return
+            }
+            runningInstance?.let { service ->
+                service.applyState(persistent, activeTurns)
+                service.startForegroundNotification()
+                return
+            }
             val intent = Intent(context.applicationContext, GatewayKeepAliveService::class.java)
+                .setAction(ACTION_REFRESH)
+                .putExtra(EXTRA_PERSISTENT, persistent)
+                .putExtra(EXTRA_ACTIVE_TURNS, activeTurns.activeTurnCount)
+                .putExtra(EXTRA_WAITING_SESSIONS, activeTurns.waitingSessionCount)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.applicationContext.startForegroundService(intent)
             } else {
@@ -83,21 +107,38 @@ class GatewayKeepAliveService : Service() {
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var persistent = false
+    private var activeTurns = 0
+    private var waitingSessions = 0
 
     override fun onBind(intent: Intent?): IBinder? = null
 
+    override fun onCreate() {
+        super.onCreate()
+        runningInstance = this
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_REFRESH) {
+            persistent = intent.getBooleanExtra(EXTRA_PERSISTENT, false)
+            activeTurns = intent.getIntExtra(EXTRA_ACTIVE_TURNS, 0).coerceAtLeast(0)
+            waitingSessions = intent.getIntExtra(EXTRA_WAITING_SESSIONS, 0)
+                .coerceIn(0, activeTurns)
+        }
         startForegroundNotification()
         if (intent?.action == ACTION_STOP) {
-            Log.i(TAG, "ACTION_STOP → user dismissed background connection")
-            // Flip the pref off so ConnectionViewModel's collector won't
-            // restart us on the next foreground.
+            Log.i(TAG, "ACTION_STOP → user disabled continuous background connection")
             scope.launch { runCatching { applicationContext.setGatewayKeepAlive(false) } }
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf()
+            persistent = false
+            if (activeTurns == 0) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+            } else {
+                startForegroundNotification()
+            }
             return START_NOT_STICKY
         }
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
@@ -105,13 +146,24 @@ class GatewayKeepAliveService : Service() {
         // The socket lives in the ViewModel, which dies when the task is
         // removed — keeping the notification would be a lie. Stop cleanly.
         Log.i(TAG, "onTaskRemoved → app swiped away; stopping keep-alive")
+        ActiveTurnKeepAliveRegistry.releaseAll()
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
 
     override fun onDestroy() {
+        if (runningInstance === this) runningInstance = null
         scope.cancel()
         super.onDestroy()
+    }
+
+    private fun applyState(
+        persistent: Boolean,
+        turns: ActiveTurnKeepAliveRegistry.Snapshot,
+    ) {
+        this.persistent = persistent
+        activeTurns = turns.activeTurnCount
+        waitingSessions = turns.waitingSessionCount.coerceIn(0, activeTurns)
     }
 
     // The service + specialUse type + FOREGROUND_SERVICE_SPECIAL_USE permission
@@ -148,17 +200,42 @@ class GatewayKeepAliveService : Service() {
         val stopIntent = Intent(this, GatewayKeepAliveService::class.java).setAction(ACTION_STOP)
         val stopPending = PendingIntent.getService(this, 1, stopIntent, pendingFlags)
 
-        return NotificationCompat.Builder(this, CHANNEL_ID)
+        val (title, body) = when {
+            waitingSessions > 0 -> {
+                val title = if (waitingSessions == 1) {
+                    "Hermes is waiting for input"
+                } else {
+                    "$waitingSessions Hermes sessions need input"
+                }
+                title to if (activeTurns > waitingSessions) {
+                    "$waitingSessions waiting · ${activeTurns - waitingSessions} still working"
+                } else {
+                    "Open the requested session to review and continue."
+                }
+            }
+            activeTurns > 0 -> {
+                val title = if (activeTurns == 1) {
+                    "Hermes is finishing a turn"
+                } else {
+                    "Hermes is finishing $activeTurns turns"
+                }
+                title to "The connection stays active until this work completes."
+            }
+            else -> getString(R.string.gateway_keepalive_title) to
+                getString(R.string.gateway_keepalive_body)
+        }
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher)
-            .setContentTitle(getString(R.string.gateway_keepalive_title))
-            .setContentText(getString(R.string.gateway_keepalive_body))
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
             .setContentIntent(tapPending)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
-            .addAction(0, "Turn off", stopPending)
-            .build()
+        if (persistent) builder.addAction(0, "Turn off always-on", stopPending)
+        return builder.build()
     }
 
     private fun ensureChannel() {

--- a/app/src/main/kotlin/com/hermesandroid/relay/notifications/InteractionRequestNotifier.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/notifications/InteractionRequestNotifier.kt
@@ -33,6 +33,7 @@ object InteractionRequestNotifier {
     private const val TAG = "InteractionNotifier"
     internal const val CHANNEL_ID = "chat_interactions"
     private const val CHANNEL_NAME = "Hermes needs input"
+    private const val GROUP_KEY = "gateway-interactions"
     internal const val NOTIFICATION_ID = 3823
     internal const val DEFAULT_PROFILE_ROUTE_VALUE = "__server_default__"
 
@@ -72,6 +73,31 @@ object InteractionRequestNotifier {
         -> "Open Hermes to respond securely."
     }
 
+    internal fun safeExpandedBody(
+        sessionId: String,
+        ask: GatewayAsk,
+        profile: String? = null,
+    ): String {
+        val action = when (ask.kind) {
+            GatewayAsk.Kind.APPROVAL ->
+                "Review the requested action. Nothing is approved from the notification."
+            GatewayAsk.Kind.CLARIFY -> "Open this conversation to answer Hermes' question."
+            GatewayAsk.Kind.SUDO -> "Open this conversation to respond securely or deny."
+            GatewayAsk.Kind.SECRET -> "Open this conversation to respond securely or skip."
+        }
+        val profileLabel = profile?.takeIf { it.isNotBlank() } ?: "Server default"
+        val sessionLabel = sessionId.takeLast(12)
+        return "$action\nProfile: $profileLabel\nSession: …$sessionLabel"
+    }
+
+    internal fun actionLabel(ask: GatewayAsk): String = when (ask.kind) {
+        GatewayAsk.Kind.APPROVAL -> "Review approval"
+        GatewayAsk.Kind.CLARIFY -> "Answer"
+        GatewayAsk.Kind.SUDO,
+        GatewayAsk.Kind.SECRET,
+        -> "Respond securely"
+    }
+
     @SuppressLint("MissingPermission", "NotificationPermission")
     fun notify(
         context: Context,
@@ -106,6 +132,7 @@ object InteractionRequestNotifier {
         )
         val title = safeTitle(ask)
         val body = safeBody(ask)
+        val expandedBody = safeExpandedBody(sessionId, ask, profile)
         val publicVersion = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle("Hermes needs your input")
@@ -117,6 +144,7 @@ object InteractionRequestNotifier {
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
             .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(expandedBody))
             .setContentIntent(tapPending)
             .setAutoCancel(false)
             .setOnlyAlertOnce(true)
@@ -124,6 +152,8 @@ object InteractionRequestNotifier {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             .setPublicVersion(publicVersion)
+            .setGroup(GROUP_KEY)
+            .addAction(0, actionLabel(ask), tapPending)
             .build()
 
         return runCatching {

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
@@ -41,6 +41,7 @@ import com.hermesandroid.relay.diagnostics.DiagnosticCategory
 import com.hermesandroid.relay.diagnostics.DiagnosticSeverity
 import com.hermesandroid.relay.diagnostics.DiagnosticsLog
 import com.hermesandroid.relay.network.upstream.ActiveTurnHandle
+import com.hermesandroid.relay.network.upstream.ActiveTurnKeepAliveRegistry
 import com.hermesandroid.relay.network.upstream.GatewayAsk
 import com.hermesandroid.relay.network.upstream.GatewayAskExpiry
 import com.hermesandroid.relay.network.upstream.GatewayAskResponse
@@ -179,6 +180,20 @@ class ChatViewModel : ViewModel() {
     private data class TurnCheckpointKey(val contextKey: String, val sessionId: String)
     private val backgroundTurnCheckpoints =
         ConcurrentHashMap<TurnCheckpointKey, ChatTurnCheckpoint>()
+
+    private fun TurnCheckpointKey.keepAliveKey(): String = "$contextKey::$sessionId"
+
+    private fun activeTurnCheckpointKey(): TurnCheckpointKey? =
+        activeTurnCheckpointSeed?.let { seed ->
+            (seed.contextKey ?: activeProfileContextKey)?.let { TurnCheckpointKey(it, seed.sessionId) }
+        }
+
+    private fun backgroundTurnKey(sessionId: String, profile: String?): TurnCheckpointKey? {
+        val profileKey = AgentDisplay.profileSessionKey(profile)
+        return backgroundTurnCheckpoints.keys.firstOrNull { key ->
+            key.sessionId == sessionId && key.contextKey.substringAfterLast("::") == profileKey
+        }
+    }
     private var checkpointWriteJob: Job? = null
     private var checkpointStatusJob: Job? = null
     private var checkpointForegroundJob: Job? = null
@@ -1147,22 +1162,29 @@ class ChatViewModel : ViewModel() {
             )
         }
         client?.setBackgroundInteractionListener { event ->
+            val key = backgroundTurnKey(event.storedSessionId, event.profile)
             when (event) {
                 is GatewayBackgroundInteractionEvent.Requested -> {
-                    backgroundPendingInteractions[event.storedSessionId] =
-                        BackgroundPendingInteraction(event.profile, event.ask)
+                    if (key != null) {
+                        backgroundPendingInteractions[key] =
+                            BackgroundPendingInteraction(event.profile, event.ask)
+                        ActiveTurnKeepAliveRegistry.setWaiting(key.keepAliveKey(), true)
+                    }
                     maybeNotifyInteraction(event.storedSessionId, event.ask, event.profile)
                 }
                 is GatewayBackgroundInteractionEvent.Resolved -> {
-                    backgroundPendingInteractions.computeIfPresent(event.storedSessionId) { _, current ->
-                        if (current.profile == event.profile &&
-                            current.ask.kind == event.ask.kind &&
-                            current.ask.requestId == event.ask.requestId
-                        ) {
-                            null
-                        } else {
-                            current
+                    if (key != null) {
+                        backgroundPendingInteractions.computeIfPresent(key) { _, current ->
+                            if (current.profile == event.profile &&
+                                current.ask.kind == event.ask.kind &&
+                                current.ask.requestId == event.ask.requestId
+                            ) {
+                                null
+                            } else {
+                                current
+                            }
                         }
+                        ActiveTurnKeepAliveRegistry.setWaiting(key.keepAliveKey(), false)
                     }
                     cancelInteractionNotification(event.storedSessionId, event.ask, event.profile)
                 }
@@ -1225,6 +1247,10 @@ class ChatViewModel : ViewModel() {
         }
         if (matching.isEmpty()) return
         matching.forEach(backgroundTurnCheckpoints::remove)
+        matching.forEach { key ->
+            backgroundPendingInteractions.remove(key)
+            ActiveTurnKeepAliveRegistry.release(key.keepAliveKey())
+        }
         chatTurnCheckpointStore?.let { store ->
             viewModelScope.launch {
                 checkpointMutex.withLock {
@@ -1662,7 +1688,7 @@ class ChatViewModel : ViewModel() {
     )
 
     private val backgroundPendingInteractions =
-        ConcurrentHashMap<String, BackgroundPendingInteraction>()
+        ConcurrentHashMap<TurnCheckpointKey, BackgroundPendingInteraction>()
 
     /** Ask cardKeys with a respond RPC in flight — blocks double-taps until it settles. */
     private val answeredAskIds = mutableSetOf<String>()
@@ -3303,7 +3329,8 @@ class ChatViewModel : ViewModel() {
         existing?.let { pending ->
             sessionId?.let { cancelInteractionNotification(it, pending.ask) }
         }
-        sessionId?.let { backgroundPendingInteractions.remove(it) }
+        val activeKey = activeTurnCheckpointKey()
+        if (activeKey != null) backgroundPendingInteractions.remove(activeKey)
         val now = restored?.receivedAt ?: System.currentTimeMillis()
         val cardKey = restored?.cardKey ?: ask.requestId
             ?: "approval-${handler.currentSessionId.value ?: "session"}-$now"
@@ -3403,6 +3430,7 @@ class ChatViewModel : ViewModel() {
             cardKey = cardKey,
             receivedAt = now,
         )
+        activeKey?.let { ActiveTurnKeepAliveRegistry.setWaiting(it.keepAliveKey(), true) }
         scheduleCheckpointWrite(immediate = true)
         sessionId?.let { maybeNotifyInteraction(it, ask) }
     }
@@ -3507,6 +3535,9 @@ class ChatViewModel : ViewModel() {
                             cancelInteractionNotification(it, pending.ask)
                         }
                         _pendingAsk.value = null
+                        activeTurnCheckpointKey()?.let {
+                            ActiveTurnKeepAliveRegistry.setWaiting(it.keepAliveKey(), false)
+                        }
                         scheduleCheckpointWrite(immediate = true)
                     }
                 },
@@ -3535,6 +3566,9 @@ class ChatViewModel : ViewModel() {
             cancelInteractionNotification(it, pending.ask)
         }
         _pendingAsk.value = null
+        activeTurnCheckpointKey()?.let {
+            ActiveTurnKeepAliveRegistry.setWaiting(it.keepAliveKey(), false)
+        }
         answeredAskIds.remove(pending.cardKey)
         scheduleCheckpointWrite(immediate = true)
         chatHandler?.recordCardDispatch(
@@ -3568,6 +3602,9 @@ class ChatViewModel : ViewModel() {
             cancelInteractionNotification(it, pending.ask)
         }
         _pendingAsk.value = null
+        activeTurnCheckpointKey()?.let {
+            ActiveTurnKeepAliveRegistry.setWaiting(it.keepAliveKey(), false)
+        }
         scheduleCheckpointWrite(immediate = true)
         if (pending.ask.kind == GatewayAsk.Kind.APPROVAL) {
             chatHandler?.recordCardDispatch(pending.messageId, pending.cardKey, approvalStamp)
@@ -3930,9 +3967,9 @@ class ChatViewModel : ViewModel() {
                         if (sessionId != null && pending != null) {
                             maybeNotifyInteraction(sessionId, pending.ask)
                         }
-                        backgroundPendingInteractions.forEach { (backgroundSessionId, pending) ->
+                        backgroundPendingInteractions.forEach { (key, pending) ->
                             maybeNotifyInteraction(
-                                backgroundSessionId,
+                                key.sessionId,
                                 pending.ask,
                                 pending.profile,
                             )
@@ -3952,6 +3989,7 @@ class ChatViewModel : ViewModel() {
         assistantMessageId: String,
         assistantTimestamp: Long,
     ) {
+        activeTurnCheckpointKey()?.let { ActiveTurnKeepAliveRegistry.release(it.keepAliveKey()) }
         val userMessage = handler.messages.value.lastOrNull { it.id == userMessageId }
         val snapshot = handler.messages.value
         val generation = checkpointGeneration.incrementAndGet()
@@ -3973,6 +4011,7 @@ class ChatViewModel : ViewModel() {
             },
             startedAt = assistantTimestamp,
         )
+        activeTurnCheckpointKey()?.let { ActiveTurnKeepAliveRegistry.acquire(it.keepAliveKey()) }
         // Remove a prior turn for THIS session immediately. Detached sibling
         // turns retain their own durable checkpoints while this chat starts a
         // new one.
@@ -3991,6 +4030,7 @@ class ChatViewModel : ViewModel() {
     }
 
     private fun adoptTurnCheckpoint(checkpoint: ChatTurnCheckpoint) {
+        activeTurnCheckpointKey()?.let { ActiveTurnKeepAliveRegistry.release(it.keepAliveKey()) }
         checkpointGeneration.incrementAndGet()
         checkpointWriteJob?.cancel()
         activeTurnCheckpointSeed = ActiveTurnCheckpointSeed(
@@ -4007,12 +4047,21 @@ class ChatViewModel : ViewModel() {
             baselineAssistantCount = checkpoint.baselineAssistantCount,
             startedAt = checkpoint.startedAt,
         )
+        activeTurnCheckpointKey()?.let { key ->
+            ActiveTurnKeepAliveRegistry.acquire(key.keepAliveKey())
+            ActiveTurnKeepAliveRegistry.setWaiting(key.keepAliveKey(), checkpoint.pendingAsk != null)
+        }
     }
 
     private fun updateTurnCheckpointSession(sessionId: String) {
         activeTurnCheckpointSeed?.let { seed ->
+            val oldKey = activeTurnCheckpointKey()
             seed.sessionId = sessionId
             seed.liveSessionId = gatewayClient?.currentLiveSessionId(sessionId)
+            val newKey = activeTurnCheckpointKey()
+            if (oldKey != null && newKey != null) {
+                ActiveTurnKeepAliveRegistry.rename(oldKey.keepAliveKey(), newKey.keepAliveKey())
+            }
             scheduleCheckpointWrite(immediate = true)
         }
     }
@@ -4156,7 +4205,11 @@ class ChatViewModel : ViewModel() {
         val generation = checkpointGeneration.incrementAndGet()
         checkpointWriteJob?.cancel()
         checkpointWriteJob = null
-        if (key != null) backgroundTurnCheckpoints.remove(key)
+        if (key != null) {
+            backgroundTurnCheckpoints.remove(key)
+            backgroundPendingInteractions.remove(key)
+            ActiveTurnKeepAliveRegistry.release(key.keepAliveKey())
+        }
         val store = chatTurnCheckpointStore ?: return
         viewModelScope.launch {
             checkpointMutex.withLock {

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
@@ -71,6 +71,7 @@ import com.hermesandroid.relay.network.upstream.DashboardStatus
 import com.hermesandroid.relay.network.upstream.ToolsetInfo
 import com.hermesandroid.relay.network.shared.EndpointResolver
 import com.hermesandroid.relay.network.upstream.GatewayAvailability
+import com.hermesandroid.relay.network.upstream.ActiveTurnKeepAliveRegistry
 import com.hermesandroid.relay.data.KEY_GATEWAY_KEEP_ALIVE
 import com.hermesandroid.relay.network.upstream.GatewayChatClient
 import com.hermesandroid.relay.network.upstream.GatewayKeepAliveService
@@ -623,7 +624,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
         context = application,
         activeConnectionIdProvider = { connectionStore.activeConnectionId.value },
         dashboardUrlProvider = { activeDashboardUrl() },
-        gatewayKeepAliveProvider = { gatewayKeepAlive.value },
+        gatewayKeepAliveProvider = {
+            gatewayKeepAlive.value || ActiveTurnKeepAliveRegistry.snapshot.value.required
+        },
         // Lets the dashboard cookie store ride the connection's token keyset
         // (one keyset build instead of two on cold start).
         tokenStoreKeyProvider = { cid ->
@@ -1671,17 +1674,19 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
     }
 
     init {
-        // Drive the keep-alive: flip the active client's no-background-close
-        // flag and start/stop the foreground service. Both flavors — the
+        // Drive the keep-alive from either the user's always-on preference or
+        // work the user already started. Active-turn leases are session scoped,
+        // so sibling turns release independently. Both flavors — the
         // GatewayKeepAliveService is declared in the main manifest (Play permits
         // this Home-Assistant-class persistent-connection use case). Mirrors
         // BridgeViewModel's masterToggle → BridgeForegroundService driver.
         viewModelScope.launch {
-            gatewayKeepAlive.collect { enabled ->
-                upstreamTransport.applyGatewayKeepAlive(enabled)
+            combine(gatewayKeepAlive, ActiveTurnKeepAliveRegistry.snapshot) { persistent, turns ->
+                persistent to turns
+            }.distinctUntilChanged().collect { (persistent, turns) ->
+                upstreamTransport.applyGatewayKeepAlive(persistent || turns.required)
                 val ctx = getApplication<Application>()
-                if (enabled) runCatching { GatewayKeepAliveService.start(ctx) }
-                else runCatching { GatewayKeepAliveService.stop(ctx) }
+                runCatching { GatewayKeepAliveService.update(ctx, persistent, turns) }
             }
         }
     }

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -631,8 +631,8 @@
     <string name="settings_profile_lock_desc">Fixe o app em um perfil de agente</string>
     <string name="settings_quick_controls">Controles rápidos</string>
     <string name="settings_persistent_connection">Conexão persistente</string>
-    <string name="settings_persistent_connection_desc">Mantém sua conexão com o Hermes aberta em segundo plano</string>
-    <string name="settings_connect_on_demand">Conectar somente quando necessário · economiza bateria</string>
+    <string name="settings_persistent_connection_desc">Manter a conexão mesmo sem nenhum chat em andamento</string>
+    <string name="settings_connect_on_demand">Chats ativos permanecem conectados automaticamente · a conexão ociosa é fechada para economizar bateria</string>
     <string name="settings_turn_complete_alerts">Alertas de chat</string>
     <string name="settings_turn_complete_alerts_desc">Notifique quando o Hermes precisar de uma resposta ou terminar em segundo plano</string>
     <string name="settings_turn_complete_alerts_off">Sem alertas para atividade de chat em segundo plano</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -672,8 +672,8 @@
     <string name="settings_profile_lock_desc">将应用固定到一个代理配置文件</string>
     <string name="settings_quick_controls">快捷控制</string>
     <string name="settings_persistent_connection">持久连接</string>
-    <string name="settings_persistent_connection_desc">在后台保持与 Hermes 的连接</string>
-    <string name="settings_connect_on_demand">仅按需连接 · 省电</string>
+    <string name="settings_persistent_connection_desc">即使没有聊天运行也保持连接</string>
+    <string name="settings_connect_on_demand">活跃聊天会自动保持连接 · 空闲时关闭连接以节省电量</string>
     <string name="settings_turn_complete_alerts">聊天提醒</string>
     <string name="settings_turn_complete_alerts_desc">Hermes 在后台需要输入或完成回复时通知</string>
     <string name="settings_turn_complete_alerts_off">不提醒后台聊天活动</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -672,8 +672,8 @@
     <string name="settings_profile_lock_desc">App auf ein Agentenprofil festlegen</string>
     <string name="settings_quick_controls">Schnellsteuerung</string>
     <string name="settings_persistent_connection">Dauerhafte Verbindung</string>
-    <string name="settings_persistent_connection_desc">Verbindung zu Hermes im Hintergrund offen halten</string>
-    <string name="settings_connect_on_demand">Nur bei Bedarf verbinden · spart Akku</string>
+    <string name="settings_persistent_connection_desc">Auch ohne laufenden Chat verbunden bleiben</string>
+    <string name="settings_connect_on_demand">Aktive Chats bleiben automatisch verbunden · Leerlaufverbindung wird geschlossen, um Akku zu sparen</string>
     <string name="settings_turn_complete_alerts">Chat-Benachrichtigungen</string>
     <string name="settings_turn_complete_alerts_desc">Benachrichtigen, wenn Hermes Eingaben benötigt oder im Hintergrund fertig wird</string>
     <string name="settings_turn_complete_alerts_off">Keine Benachrichtigungen für Chat-Aktivität im Hintergrund</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -599,8 +599,8 @@
     <string name="settings_profile_lock_desc">Anclar la aplicación a un perfil de agente</string>
     <string name="settings_quick_controls">Controles rápidos</string>
     <string name="settings_persistent_connection">Conexión persistente</string>
-    <string name="settings_persistent_connection_desc">Mantener abierta su conexión a Hermes en segundo plano</string>
-    <string name="settings_connect_on_demand">Conexión solo bajo demanda · ahorra batería</string>
+    <string name="settings_persistent_connection_desc">Mantener la conexión aunque no haya ningún chat en curso</string>
+    <string name="settings_connect_on_demand">Los chats activos siguen conectados automáticamente · la conexión inactiva se cierra para ahorrar batería</string>
     <string name="settings_turn_complete_alerts">Alertas de chat</string>
     <string name="settings_turn_complete_alerts_desc">Notificar cuando Hermes necesite información o termine en segundo plano</string>
     <string name="settings_turn_complete_alerts_off">Sin alertas de actividad de chat en segundo plano</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -672,8 +672,8 @@
     <string name="settings_profile_lock_desc">アプリを 1 つのエージェント プロファイルに固定する</string>
     <string name="settings_quick_controls">クイックコントロール</string>
     <string name="settings_persistent_connection">永続的な接続</string>
-    <string name="settings_persistent_connection_desc">Hermes への接続をバッ​​クグラウンドで開いたままにします</string>
-    <string name="settings_connect_on_demand">オンデマンドのみに接続します · バッテリーを節約します</string>
+    <string name="settings_persistent_connection_desc">チャットが実行されていないときも接続を維持</string>
+    <string name="settings_connect_on_demand">アクティブなチャットは自動的に接続を維持 · アイドル時はバッテリー節約のため接続を閉じます</string>
     <string name="settings_turn_complete_alerts">チャット通知</string>
     <string name="settings_turn_complete_alerts_desc">バックグラウンドで Hermes が入力を必要としたとき、または完了したときに通知します</string>
     <string name="settings_turn_complete_alerts_off">バックグラウンドのチャット動作を通知しません</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -689,8 +689,8 @@
     <string name="settings_profile_lock_desc">Pin the app to one agent profile</string>
     <string name="settings_quick_controls">Quick Controls</string>
     <string name="settings_persistent_connection">Persistent connection</string>
-    <string name="settings_persistent_connection_desc">Keeping your connection to Hermes open in the background</string>
-    <string name="settings_connect_on_demand">Connect on demand only · saves battery</string>
+    <string name="settings_persistent_connection_desc">Stay connected even when no chat is running</string>
+    <string name="settings_connect_on_demand">Active chats stay connected automatically · idle connection closes to save battery</string>
     <string name="settings_turn_complete_alerts">Chat alerts</string>
     <string name="settings_turn_complete_alerts_desc">Notify when Hermes needs input or finishes while the app is in the background</string>
     <string name="settings_turn_complete_alerts_off">No alerts for background chat activity</string>

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ActiveTurnKeepAliveRegistryTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ActiveTurnKeepAliveRegistryTest.kt
@@ -1,0 +1,43 @@
+package com.hermesandroid.relay.network.upstream
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActiveTurnKeepAliveRegistryTest {
+    @After
+    fun tearDown() = ActiveTurnKeepAliveRegistry.resetForTest()
+
+    @Test
+    fun siblingSessionsHoldIndependentLeases() {
+        ActiveTurnKeepAliveRegistry.acquire("connection::victor::session-a")
+        ActiveTurnKeepAliveRegistry.acquire("connection::default::session-b")
+        ActiveTurnKeepAliveRegistry.setWaiting("connection::victor::session-a", true)
+
+        assertEquals(
+            ActiveTurnKeepAliveRegistry.Snapshot(activeTurnCount = 2, waitingSessionCount = 1),
+            ActiveTurnKeepAliveRegistry.snapshot.value,
+        )
+
+        ActiveTurnKeepAliveRegistry.release("connection::victor::session-a")
+
+        assertEquals(1, ActiveTurnKeepAliveRegistry.snapshot.value.activeTurnCount)
+        assertEquals(0, ActiveTurnKeepAliveRegistry.snapshot.value.waitingSessionCount)
+        assertTrue(ActiveTurnKeepAliveRegistry.snapshot.value.required)
+    }
+
+    @Test
+    fun sessionRenameMovesRatherThanDuplicatesLease() {
+        ActiveTurnKeepAliveRegistry.acquire("temporary")
+        ActiveTurnKeepAliveRegistry.setWaiting("temporary", true)
+        ActiveTurnKeepAliveRegistry.rename("temporary", "durable")
+
+        assertEquals(1, ActiveTurnKeepAliveRegistry.snapshot.value.activeTurnCount)
+        assertEquals(1, ActiveTurnKeepAliveRegistry.snapshot.value.waitingSessionCount)
+
+        ActiveTurnKeepAliveRegistry.release("durable")
+        assertFalse(ActiveTurnKeepAliveRegistry.snapshot.value.required)
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/notifications/InteractionRequestNotifierTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/notifications/InteractionRequestNotifierTest.kt
@@ -83,15 +83,34 @@ class InteractionRequestNotifierTest {
 
         val notification = manager.activeNotifications.single().notification
         val privateText = notification.extras.getCharSequence(Notification.EXTRA_TEXT).toString()
+        val expandedText = notification.extras
+            .getCharSequence(Notification.EXTRA_BIG_TEXT)
+            .toString()
         val privateTitle = notification.extras.getCharSequence(Notification.EXTRA_TITLE).toString()
         val publicText = notification.publicVersion.extras
             .getCharSequence(Notification.EXTRA_TEXT)
             .toString()
-        val visibleCopy = "$privateTitle $privateText $publicText"
+        val visibleCopy = "$privateTitle $privateText $expandedText $publicText"
         assertFalse(visibleCopy.contains(secret.text))
         assertFalse(visibleCopy.contains(secret.envVar!!))
         assertTrue(visibleCopy.contains("Open Hermes"))
+        assertTrue(expandedText.contains("Profile: Server default"))
+        assertEquals("Respond securely", notification.actions.single().title)
         assertEquals(Notification.VISIBILITY_PRIVATE, notification.visibility)
+    }
+
+    @Test
+    fun sameStoredSessionInTwoProfilesKeepsIndependentNotificationSlots() {
+        val ask = approval(command = "private")
+
+        assertTrue(post(ask, SESSION_ID, "victor"))
+        assertTrue(post(ask, SESSION_ID, "server-default"))
+
+        assertEquals(2, manager.activeNotifications.size)
+        assertEquals(
+            2,
+            manager.activeNotifications.map { it.tag }.distinct().size,
+        )
     }
 
     @Test

--- a/docs/localization-status.json
+++ b/docs/localization-status.json
@@ -13,7 +13,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "4b26eae02b463489ea2777b30571bbd16939a0b4878cd3b0ffa1aec1aafb7c29",
+        "main": "8d2bfde6d800b7838e1a31415c9b05cac80a65872417e3db8bb6d18941cd7f1e",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -48,7 +48,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "4b26eae02b463489ea2777b30571bbd16939a0b4878cd3b0ffa1aec1aafb7c29",
+        "main": "8d2bfde6d800b7838e1a31415c9b05cac80a65872417e3db8bb6d18941cd7f1e",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -72,7 +72,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "4b26eae02b463489ea2777b30571bbd16939a0b4878cd3b0ffa1aec1aafb7c29",
+        "main": "8d2bfde6d800b7838e1a31415c9b05cac80a65872417e3db8bb6d18941cd7f1e",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -96,7 +96,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "4b26eae02b463489ea2777b30571bbd16939a0b4878cd3b0ffa1aec1aafb7c29",
+        "main": "8d2bfde6d800b7838e1a31415c9b05cac80a65872417e3db8bb6d18941cd7f1e",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -120,7 +120,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "4b26eae02b463489ea2777b30571bbd16939a0b4878cd3b0ffa1aec1aafb7c29",
+        "main": "8d2bfde6d800b7838e1a31415c9b05cac80a65872417e3db8bb6d18941cd7f1e",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -156,12 +156,12 @@ This app is a client for a Hermes server the user runs themselves, so a fresh in
 
 ### Foreground service permissions
 
-The Play build declares `**FOREGROUND_SERVICE_SPECIAL_USE**` for `GatewayKeepAliveService`, backing the opt-in **Persistent connection** feature (off by default). At submission, complete **App content → Foreground service permissions** for `specialUse`:
+The Play build declares `**FOREGROUND_SERVICE_SPECIAL_USE**` for `GatewayKeepAliveService`. It protects user-started active chat turns automatically and also backs the opt-in **Persistent connection** feature for idle connectivity. At submission, complete **App content → Foreground service permissions** for `specialUse`:
 
-- **Use case:** maintains a persistent connection to the user's own Hermes agent server so the assistant stays responsive and delivers replies while the app is backgrounded.
+- **Use case:** keeps a user-started Hermes turn connected until it finishes or pauses for user input, including multiple concurrent sessions; optionally maintains the idle connection when the user enables Persistent connection.
 - **Why a foreground service:** it's a real-time, user-initiated streaming connection that must survive Doze / background execution limits; `dataSync` is force-stopped after a 6-hour/day cap on Android 15, so `specialUse` is the only fit for "stay connected."
-- **User control:** off by default; enabled only via *Settings → Quick Controls → Persistent connection*; shows an ongoing notification with a **Turn off** action; ends when the app is swiped from recents.
-- Google usually asks for a short screen recording of the toggle + notification.
+- **User control:** the service starts when the user sends a chat message and stops after all active turns settle. Continuous idle retention is off by default and enabled only via *Settings → Quick Controls → Persistent connection*. The ongoing notification shows the active/waiting session count; its **Turn off always-on** action disables idle retention without interrupting active work. Swiping the app from recents ends it.
+- Google usually asks for a short screen recording of a backgrounded active turn, the ongoing notification, and the optional persistent toggle.
 
 The Play build does **not** declare `FOREGROUND_SERVICE_MEDIA_PROJECTION` or the Device Control accessibility/bridge services — those are sideload-only.
 

--- a/user-docs/architecture/flavor-differences.md
+++ b/user-docs/architecture/flavor-differences.md
@@ -63,13 +63,13 @@ INTERNET, ACCESS_NETWORK_STATE, CAMERA, RECORD_AUDIO, MODIFY_AUDIO_SETTINGS,
 POST_NOTIFICATIONS, FOREGROUND_SERVICE, FOREGROUND_SERVICE_SPECIAL_USE
 ```
 
-It also declares the optional notification companion service and the opt-in `GatewayKeepAliveService` — the "Persistent connection" feature, a `specialUse` foreground service that is off by default and ships on **both** flavors. It does not declare the accessibility service, the Device Control bridge foreground service, overlay permission, wake lock, MediaProjection foreground-service type, contacts, location, SMS, or call permissions.
+It also declares the optional notification companion service and `GatewayKeepAliveService`, a `specialUse` foreground service that protects user-started active turns automatically and optionally extends to idle time through "Persistent connection." It ships on **both** flavors. It does not declare the accessibility service, the Device Control bridge foreground service, overlay permission, wake lock, MediaProjection foreground-service type, contacts, location, SMS, or call permissions.
 
 ### Google Play manifest
 
 The Play manifest does not add Device Control permissions or services. The merged Play manifest should contain no `AccessibilityService`, `BIND_ACCESSIBILITY_SERVICE`, `SYSTEM_ALERT_WINDOW`, `WAKE_LOCK`, `FOREGROUND_SERVICE_MEDIA_PROJECTION`, or `BridgeForegroundService` declaration.
 
-> **Exception — `FOREGROUND_SERVICE_SPECIAL_USE` + `GatewayKeepAliveService` _are_ in the merged Play manifest.** They back the opt-in "Persistent connection" feature (off by default), which ships on both flavors via the main manifest. This means the Play build carries one `specialUse` foreground service and therefore needs a Play Console foreground-service declaration at submission (see `docs/play-store-listing.md`). The Device Control bridge's `specialUse|mediaProjection` service stays sideload-only.
+> **Exception — `FOREGROUND_SERVICE_SPECIAL_USE` + `GatewayKeepAliveService` _are_ in the merged Play manifest.** They protect user-started active turns and back the opt-in idle "Persistent connection" feature, which ships on both flavors via the main manifest. This means the Play build carries one `specialUse` foreground service and therefore needs a Play Console foreground-service declaration at submission (see `docs/play-store-listing.md`). The Device Control bridge's `specialUse|mediaProjection` service stays sideload-only.
 
 ### Sideload manifest
 

--- a/user-docs/guide/chat.md
+++ b/user-docs/guide/chat.md
@@ -245,16 +245,23 @@ A running Gateway chat keeps its event connection attached; if that connection
 drops, the app reconnects while the server continues working. Idle chats pre-warm
 when reopened so the next message is fast.
 
-If you want the connection to stay fully open even when the app is in the
-background, turn on **Settings → Quick Controls → Persistent connection** (off by
-default). It holds the app's connection to Hermes open via an ongoing
+While any chat is running, Hermes-Relay automatically uses an ongoing Android
+notification to keep the app and its connection active until every concurrent
+turn finishes or is interrupted. If a turn needs approval, clarification, or
+sensitive input, its separate alert reopens the exact profile and conversation.
+Expanding that alert shows safe session context, but never the requested command,
+question, password, secret, or environment-variable name.
+
+If you want the connection to stay fully open even when no chat is running,
+turn on **Settings → Quick Controls → Persistent connection** (off by default).
+It extends the same foreground protection to idle time via an ongoing
 notification, so messages and live features stay responsive; for relay-paired
 setups it also keeps device control and notification mirroring reachable. Tap
-**Turn off** on the notification, or flip the toggle, to stop. This uses more
+**Turn off always-on** on the notification, or flip the toggle, to stop the idle
+retention without interrupting active work. This uses more
 battery; swiping the app away from recents also ends it. It's the same approach
 apps like Home Assistant use to stay connected.
 
-Chat alerts do not require Persistent connection while an already-running turn
-is attached, but Android may stop an idle background app later. Enable
-Persistent connection when approval and other action-required alerts must
-remain reachable during long idle or Doze periods.
+Chat alerts and active-turn protection do not require Persistent connection.
+Enable it only when an idle connection or Relay-powered live features must
+remain reachable during long background or Doze periods.


### PR DESCRIPTION
## Summary
- protect user-started active turns automatically with connection/profile/session-scoped foreground leases
- keep concurrent detached sessions independent and show active/waiting counts
- add privacy-safe expanded interaction alerts with exact-conversation actions
- clarify Persistent connection as idle/always-on retention and update Play/docs/locales

## Verification
- focused ActiveTurnKeepAliveRegistryTest and InteractionRequestNotifierTest
- full Android lint
- Android locale and collection API guards
- public docs build

Forge: AXI-152