### PR TITLE
fix(android): keep Relay tools aligned with transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Relay no longer reports Connected while its tools are silently disabled.** Full-capability sideload builds default Relay tools on, QR and manual Relay pairing enable them automatically, and the Relay status sheet exposes a direct tools switch that keeps transport state synchronized instead of hiding the control behind Developer Options.
 - **Background chats stay reachable without an always-on connection.** Android now protects user-started work until every concurrent Gateway session settles, shows active and waiting counts in its ongoing notification, and gives each privacy-safe interaction alert expanded session context plus a direct review, answer, or secure-response action.
 - **Android alerts when a background Gateway turn needs input.** Approval, clarification, elevated-permission, and secret requests post privacy-safe notifications that reopen the correct conversation, survive reconnect replay without duplicates, and clear when the request is answered or expires.
 - **Promoted voice tasks keep their Chat row through background delivery.** Completing the provider's initial spoken handoff no longer removes an otherwise empty assistant bubble that still owns a running background task.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,23 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-25 — Relay tools are a visible product control
+
+Fixed the Android state where the Relay WebSocket could display `Connected`
+while the legacy release feature flag still read `Relay enabled: No`, leaving
+both connection controls disabled. The sideload flavor now defaults Relay tools
+on, while an explicit stored user choice remains authoritative and the Google
+Play flavor retains its conservative opt-in default.
+
+The Relay status sheet now distinguishes transport state from the tools
+capability and exposes the tools switch directly. Toggling it connects or
+disconnects the transport, so the UI cannot recreate the contradictory state.
+QR and manual Relay pairing also enable the tools automatically. Locking
+Developer Options no longer disables stable Relay functionality.
+
+Added pure-JVM coverage for debug, sideload, Google Play, explicit opt-in, and
+explicit opt-out resolution. Updated the Relay copy in every shipped Android
+locale catalog.
+
 ## 2026-07-25 — Active-turn retention and actionable interaction alerts
 
 Android now promotes user-started chat work to foreground execution until every

--- a/app/src/main/kotlin/com/hermesandroid/relay/data/FeatureFlags.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/FeatureFlags.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.flow.map
 /**
  * Feature flags with compile-time defaults and runtime overrides.
  *
- * In debug builds, all features are unlocked by default.
- * In release builds, experimental features are hidden unless the user
- * enables Developer Options (tap version 7 times in Settings > About).
+ * Debug builds unlock experimental features by default. Stable Relay tools
+ * are also enabled by default in the full-capability sideload flavor; the
+ * Google Play flavor keeps the conservative opt-in default.
  *
  * Runtime overrides persist in DataStore so testers can toggle features
  * without needing a debug APK.
@@ -26,16 +26,33 @@ object FeatureFlags {
     /** Whether the app is running a debug build. */
     val isDevBuild: Boolean get() = BuildConfig.DEV_MODE
 
+    /** Initial Relay-tools value before DataStore emits its persisted override. */
+    val defaultRelayEnabled: Boolean
+        get() = resolveRelayEnabled(
+            isDevBuild = isDevBuild,
+            isSideload = BuildFlavor.isSideload,
+            storedOverride = null,
+        )
+
     /** Observe whether Developer Options have been unlocked. */
     fun devOptionsUnlocked(context: Context): Flow<Boolean> =
         context.relayDataStore.data.map { prefs ->
             if (isDevBuild) true else prefs[KEY_DEV_OPTIONS_UNLOCKED] ?: false
         }
 
-    /** Observe whether relay features (settings, pairing, onboarding pages) are enabled. */
+    /**
+     * Observe whether Relay tools are enabled.
+     *
+     * Sideload builds are the full-capability product, so Relay defaults on.
+     * A persisted user choice always wins, while debug builds remain unlocked.
+     */
     fun relayEnabled(context: Context): Flow<Boolean> =
         context.relayDataStore.data.map { prefs ->
-            if (isDevBuild) true else prefs[KEY_RELAY_ENABLED] ?: false
+            resolveRelayEnabled(
+                isDevBuild = isDevBuild,
+                isSideload = BuildFlavor.isSideload,
+                storedOverride = prefs[KEY_RELAY_ENABLED],
+            )
         }
 
     /** Unlock Developer Options. */
@@ -45,11 +62,10 @@ object FeatureFlags {
         }
     }
 
-    /** Lock Developer Options and disable all experimental features. */
+    /** Lock Developer Options. Stable Relay tools keep their own user setting. */
     suspend fun lockDevOptions(context: Context) {
         context.relayDataStore.edit { prefs ->
             prefs[KEY_DEV_OPTIONS_UNLOCKED] = false
-            prefs[KEY_RELAY_ENABLED] = false
         }
     }
 
@@ -70,6 +86,20 @@ object FeatureFlags {
      * effect — it's a placeholder hook, not yet load-bearing.
      */
     const val useExoPlayerVoice: Boolean = true
+
+    /**
+     * Pure resolver kept internal so flavor/default behavior has fast JVM
+     * regression coverage without Android DataStore or BuildConfig fixtures.
+     */
+    internal fun resolveRelayEnabled(
+        isDevBuild: Boolean,
+        isSideload: Boolean,
+        storedOverride: Boolean?,
+    ): Boolean = if (isDevBuild) {
+        true
+    } else {
+        storedOverride ?: isSideload
+    }
 }
 
 /**

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ConnectionInfoSheet.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ConnectionInfoSheet.kt
@@ -531,7 +531,8 @@ fun RelayInfoSheet(
     val isInsecureConnection by connectionViewModel.isInsecureConnection.collectAsState()
     val insecureMode by connectionViewModel.insecureMode.collectAsState()
     val relayEnabled by FeatureFlags.relayEnabled(context)
-        .collectAsState(initial = FeatureFlags.isDevBuild)
+        .collectAsState(initial = FeatureFlags.defaultRelayEnabled)
+    val scope = rememberCoroutineScope()
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -557,7 +558,9 @@ fun RelayInfoSheet(
             HorizontalDivider()
 
             InfoRow(label = stringResource(R.string.conn_info_url), value = relayUrl, monospace = true)
-            ChipRow(label = stringResource(R.string.conn_info_connection_state)) { connectionChip(relayConnectionState) }
+            ChipRow(label = stringResource(R.string.conn_info_relay_transport_state)) {
+                connectionChip(relayConnectionState)
+            }
 
             if (isInsecureConnection) {
                 Row(
@@ -586,10 +589,40 @@ fun RelayInfoSheet(
                 label = stringResource(R.string.conn_info_insecure_mode_allowed),
                 value = if (insecureMode) stringResource(R.string.conn_info_yes) else stringResource(R.string.conn_info_no)
             )
-            InfoRow(
-                label = stringResource(R.string.conn_info_relay_enabled_flag),
-                value = if (relayEnabled) stringResource(R.string.conn_info_yes) else stringResource(R.string.conn_info_no)
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.conn_info_relay_tools),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = stringResource(R.string.conn_info_relay_tools_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = relayEnabled,
+                    onCheckedChange = { enabled ->
+                        scope.launch {
+                            FeatureFlags.setRelayEnabled(context, enabled)
+                            if (enabled) {
+                                connectionViewModel.connectRelay()
+                            } else {
+                                connectionViewModel.disconnectRelay()
+                            }
+                        }
+                    },
+                )
+            }
 
             Spacer(modifier = Modifier.height(4.dp))
 
@@ -597,24 +630,32 @@ fun RelayInfoSheet(
                 relayConnectionState == ConnectionState.Connecting ||
                 relayConnectionState == ConnectionState.Reconnecting
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                OutlinedButton(
-                    onClick = { connectionViewModel.connectRelay() },
-                    enabled = relayEnabled && !isConnected,
-                    modifier = Modifier.fillMaxWidth(0.5f)
+            if (relayEnabled) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Text(stringResource(R.string.conn_info_connect))
+                    OutlinedButton(
+                        onClick = { connectionViewModel.connectRelay() },
+                        enabled = !isConnected,
+                        modifier = Modifier.fillMaxWidth(0.5f)
+                    ) {
+                        Text(stringResource(R.string.conn_info_connect))
+                    }
+                    OutlinedButton(
+                        onClick = { connectionViewModel.disconnectRelay() },
+                        enabled = isConnected,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.conn_info_disconnect))
+                    }
                 }
-                OutlinedButton(
-                    onClick = { connectionViewModel.disconnectRelay() },
-                    enabled = relayEnabled && isConnected,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(stringResource(R.string.conn_info_disconnect))
-                }
+            } else {
+                Text(
+                    text = stringResource(R.string.conn_info_relay_tools_off_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
             HorizontalDivider()

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ConnectionWizard.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ConnectionWizard.kt
@@ -198,7 +198,7 @@ fun ConnectionWizard(
     val isTailscaleDetected by connectionViewModel.isTailscaleDetected.collectAsState()
     val authState by connectionViewModel.authState.collectAsState()
     val relayEnabled by FeatureFlags.relayEnabled(context)
-        .collectAsState(initial = FeatureFlags.isDevBuild)
+        .collectAsState(initial = FeatureFlags.defaultRelayEnabled)
     val pairingCode by connectionViewModel.pairingCode.collectAsState()
     val currentApiUrl by connectionViewModel.apiServerUrl.collectAsState()
     val currentRelayUrl by connectionViewModel.relayUrl.collectAsState()
@@ -1017,6 +1017,7 @@ private fun applyManualPair(
 ) {
     if (apiUrl.isNotBlank()) vm.updateApiServerUrl(apiUrl)
     vm.updateRelayUrl(relayUrl)
+    vm.enableRelayToolsForPairing()
     vm.authManager.applyServerIssuedCodeAndReset(code.trim().uppercase())
     vm.disconnectRelay()
     vm.connectRelay(relayUrl)

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ConnectionDetailScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ConnectionDetailScreen.kt
@@ -111,7 +111,7 @@ fun ConnectionDetailScreen(
     val activeConnectionId by connectionViewModel.activeConnectionId.collectAsState()
     val relayUiState by connectionViewModel.relayUiState.collectAsState()
     val relayEnabled by FeatureFlags.relayEnabled(context)
-        .collectAsState(initial = FeatureFlags.isDevBuild)
+        .collectAsState(initial = FeatureFlags.defaultRelayEnabled)
 
     val connection = connections.firstOrNull { it.id == connectionId }
     // Connection was removed (e.g. via the overflow menu) — leave the screen.

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DeveloperSettingsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DeveloperSettingsScreen.kt
@@ -79,7 +79,8 @@ fun DeveloperSettingsScreen(
     val scope = rememberCoroutineScope()
     val isDarkTheme = LocalBrand.current.isDark
 
-    val relayEnabled by FeatureFlags.relayEnabled(context).collectAsState(initial = FeatureFlags.isDevBuild)
+    val relayEnabled by FeatureFlags.relayEnabled(context)
+        .collectAsState(initial = FeatureFlags.defaultRelayEnabled)
 
     // Data management local state — unfolded from the private
     // DataManagementSection helper in the old SettingsScreen.
@@ -330,7 +331,16 @@ fun DeveloperSettingsScreen(
                         }
                         Switch(
                             checked = relayEnabled,
-                            onCheckedChange = { scope.launch { FeatureFlags.setRelayEnabled(context, it) } }
+                            onCheckedChange = { enabled ->
+                                scope.launch {
+                                    FeatureFlags.setRelayEnabled(context, enabled)
+                                    if (enabled) {
+                                        connectionViewModel.connectRelay()
+                                    } else {
+                                        connectionViewModel.disconnectRelay()
+                                    }
+                                }
+                            }
                         )
                     }
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
@@ -40,6 +40,7 @@ import com.hermesandroid.relay.data.ConnectionStore
 import com.hermesandroid.relay.data.ConnectionValidation
 import com.hermesandroid.relay.data.computeConnectionSecurity
 import com.hermesandroid.relay.data.BuildFlavor
+import com.hermesandroid.relay.data.FeatureFlags
 import com.hermesandroid.relay.data.Profile
 import com.hermesandroid.relay.data.ProfilePresentation
 import com.hermesandroid.relay.data.SessionTransport
@@ -4493,6 +4494,12 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
     //
     // The payload's relay block is optional — when null, only the API server
     // side is configured (matches the legacy "API-only" QR flow).
+    fun enableRelayToolsForPairing() {
+        viewModelScope.launch {
+            FeatureFlags.setRelayEnabled(getApplication<Application>(), true)
+        }
+    }
+
     fun applyPairingPayload(
         payload: com.hermesandroid.relay.ui.components.HermesPairingPayload,
         ttlSeconds: Long,
@@ -4519,6 +4526,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
             authManager.setPendingGrants(relay.grants)
         }
         authManager.setPendingTtlSeconds(ttlSeconds)
+        if (payload.relay != null) {
+            enableRelayToolsForPairing()
+        }
         val existingStandardRoutes = if (preserveStandardConfig) {
             activeConnection.value?.routeCandidates.orEmpty()
         } else {

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -1128,7 +1128,7 @@
     <string name="dev_settings_reset_all_data_cd">Redefinir todos os dados</string>
     <string name="dev_options_section">Opções do desenvolvedor</string>
     <string name="dev_settings_relay_features">Recursos do Relay</string>
-    <string name="dev_settings_relay_features_desc">Mostrar configurações do Servidor Relay e de pareamento para desenvolvimento do Bridge/Terminal</string>
+    <string name="dev_settings_relay_features_desc">Mostrar ou ocultar Terminal, Bridge, ferramentas do dispositivo, sessões Relay e rotas remotas seguras</string>
     <string name="dev_settings_realtime_voice_lab">Laboratório de voz em tempo real</string>
     <string name="dev_settings_realtime_voice_lab_desc">Abrir a bancada de testes do WebSocket do provedor em versões de desenvolvimento</string>
     <string name="dev_settings_open_realtime_voice_lab_cd">Abrir laboratório de voz em tempo real</string>
@@ -2220,6 +2220,10 @@
     <string name="conn_info_regenerate_code">Gerar código novamente</string>
     <string name="conn_info_relay_desc">Status e configuração da conexão do Relay.</string>
     <string name="conn_info_relay_enabled_flag">Relay ativado</string>
+    <string name="conn_info_relay_transport_state">Estado do transporte</string>
+    <string name="conn_info_relay_tools">Ferramentas Relay</string>
+    <string name="conn_info_relay_tools_desc">Terminal, Bridge, ferramentas do dispositivo, sessões Relay e rotas remotas seguras.</string>
+    <string name="conn_info_relay_tools_off_hint">Ative as ferramentas Relay para usar esta conexão Relay pareada.</string>
     <string name="conn_info_relay_title">Relay</string>
     <string name="conn_info_relay_url">URL do Relay</string>
     <string name="conn_info_route_preference">Preferência de rota</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -1183,7 +1183,7 @@
     <string name="dev_settings_reset_all_data_cd">重置全部数据</string>
     <string name="dev_options_section">开发者选项</string>
     <string name="dev_settings_relay_features">Relay 功能</string>
-    <string name="dev_settings_relay_features_desc">显示 Relay 服务器和配对设置，用于 Bridge/Terminal 开发</string>
+    <string name="dev_settings_relay_features_desc">显示或隐藏终端、Bridge、设备工具、Relay 会话和安全远程路由</string>
     <string name="dev_settings_realtime_voice_lab">实时语音实验室</string>
     <string name="dev_settings_realtime_voice_lab_desc">为开发构建打开 provider websocket 测试台</string>
     <string name="dev_settings_open_realtime_voice_lab_cd">打开实时语音实验室</string>
@@ -2314,6 +2314,10 @@
     <string name="conn_info_regenerate_code">重新生成代码</string>
     <string name="conn_info_relay_desc">Relay 连接状态和配置。</string>
     <string name="conn_info_relay_enabled_flag">Relay 已启用</string>
+    <string name="conn_info_relay_transport_state">传输状态</string>
+    <string name="conn_info_relay_tools">Relay 工具</string>
+    <string name="conn_info_relay_tools_desc">终端、Bridge、设备工具、Relay 会话和安全远程路由。</string>
+    <string name="conn_info_relay_tools_off_hint">开启 Relay 工具以使用此已配对的 Relay 连接。</string>
     <string name="conn_info_relay_title">Relay</string>
     <string name="conn_info_relay_url">Relay 地址</string>
     <string name="conn_info_route_preference">路由偏好</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1186,7 +1186,7 @@
     <string name="dev_settings_reset_all_data_cd">Alle Daten zurücksetzen</string>
     <string name="dev_options_section">Entwickleroptionen</string>
     <string name="dev_settings_relay_features">Relay-Funktionen</string>
-    <string name="dev_settings_relay_features_desc">Relay-Server- und Kopplungseinstellungen für Bridge-/Terminal-Entwicklung anzeigen</string>
+    <string name="dev_settings_relay_features_desc">Terminal, Bridge, Gerätewerkzeuge, Relay-Sitzungen und sichere Remote-Routen ein- oder ausblenden</string>
     <string name="dev_settings_realtime_voice_lab">Echtzeit-Sprachlabor</string>
     <string name="dev_settings_realtime_voice_lab_desc">WebSocket-Testumgebung des Anbieters für Entwicklungs-Builds öffnen</string>
     <string name="dev_settings_open_realtime_voice_lab_cd">Echtzeit-Sprachlabor öffnen</string>
@@ -2319,6 +2319,10 @@
     <string name="conn_info_regenerate_code">Code neu erzeugen</string>
     <string name="conn_info_relay_desc">Relay-Verbindungsstatus und -konfiguration.</string>
     <string name="conn_info_relay_enabled_flag">Relay aktiviert</string>
+    <string name="conn_info_relay_transport_state">Transportstatus</string>
+    <string name="conn_info_relay_tools">Relay-Werkzeuge</string>
+    <string name="conn_info_relay_tools_desc">Terminal, Bridge, Gerätewerkzeuge, Relay-Sitzungen und sichere Remote-Routen.</string>
+    <string name="conn_info_relay_tools_off_hint">Aktiviere die Relay-Werkzeuge, um diese gekoppelte Relay-Verbindung zu verwenden.</string>
     <string name="conn_info_relay_title">Relay</string>
     <string name="conn_info_relay_url">Relay-URL</string>
     <string name="conn_info_route_preference">Routenpräferenz</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1074,7 +1074,7 @@
     <string name="dev_settings_reset_all_data_cd">Restablecer todos los datos</string>
     <string name="dev_options_section">Opciones de desarrollador</string>
     <string name="dev_settings_relay_features">Características de Relay</string>
-    <string name="dev_settings_relay_features_desc">Mostrar el servidor Relay y la configuración de emparejamiento para el desarrollo de Bridge/Terminal</string>
+    <string name="dev_settings_relay_features_desc">Mostrar u ocultar Terminal, Bridge, herramientas del dispositivo, sesiones Relay y rutas remotas seguras</string>
     <string name="dev_settings_realtime_voice_lab">Laboratorio de voz en tiempo real</string>
     <string name="dev_settings_realtime_voice_lab_desc">Abra el banco de pruebas del proveedor websocket para compilaciones de desarrollo.</string>
     <string name="dev_settings_open_realtime_voice_lab_cd">Abrir laboratorio de voz en tiempo real</string>
@@ -2119,6 +2119,10 @@
     <string name="conn_info_regenerate_code">regenerar código</string>
     <string name="conn_info_relay_desc">Estado y configuración de la conexión Relay.</string>
     <string name="conn_info_relay_enabled_flag">Relay habilitado</string>
+    <string name="conn_info_relay_transport_state">Estado del transporte</string>
+    <string name="conn_info_relay_tools">Herramientas Relay</string>
+    <string name="conn_info_relay_tools_desc">Terminal, Bridge, herramientas del dispositivo, sesiones Relay y rutas remotas seguras.</string>
+    <string name="conn_info_relay_tools_off_hint">Activa las herramientas Relay para usar esta conexión Relay emparejada.</string>
     <string name="conn_info_relay_title">Relay</string>
     <string name="conn_info_relay_url">URL de Relay</string>
     <string name="conn_info_route_preference">Preferencia de ruta</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1199,7 +1199,7 @@
     <string name="dev_settings_reset_all_data_cd">すべてのデータをリセット</string>
     <string name="dev_options_section">開発者向けオプション</string>
     <string name="dev_settings_relay_features">Relay の特徴</string>
-    <string name="dev_settings_relay_features_desc">Relay サーバーと Bridge/ターミナル開発用のペアリング設定を表示</string>
+    <string name="dev_settings_relay_features_desc">ターミナル、Bridge、デバイスツール、Relay セッション、安全なリモートルートを表示または非表示にする</string>
     <string name="dev_settings_realtime_voice_lab">リアルタイム音声ラボ</string>
     <string name="dev_settings_realtime_voice_lab_desc">開発ビルド用のプロバイダー WebSocket テストベンチを開きます</string>
     <string name="dev_settings_open_realtime_voice_lab_cd">リアルタイム音声ラボを開く</string>
@@ -2330,6 +2330,10 @@
     <string name="conn_info_regenerate_code">コードを再生成する</string>
     <string name="conn_info_relay_desc">Relay 接続ステータスと構成。</string>
     <string name="conn_info_relay_enabled_flag">Relay が有効になりました</string>
+    <string name="conn_info_relay_transport_state">トランスポートの状態</string>
+    <string name="conn_info_relay_tools">Relay ツール</string>
+    <string name="conn_info_relay_tools_desc">ターミナル、Bridge、デバイスツール、Relay セッション、安全なリモートルート。</string>
+    <string name="conn_info_relay_tools_off_hint">このペアリング済み Relay 接続を使用するには、Relay ツールをオンにしてください。</string>
     <string name="conn_info_relay_title">Relay</string>
     <string name="conn_info_relay_url">Relay URL</string>
     <string name="conn_info_route_preference">ルートの優先順位</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1288,7 +1288,7 @@
     <string name="dev_settings_reset_all_data_cd">Reset all data</string>
     <string name="dev_options_section">Developer Options</string>
     <string name="dev_settings_relay_features">Relay features</string>
-    <string name="dev_settings_relay_features_desc">Show Relay Server and Pairing settings for Bridge/Terminal development</string>
+    <string name="dev_settings_relay_features_desc">Show or hide Terminal, Bridge, device tools, Relay sessions, and secure remote routes</string>
     <string name="dev_settings_realtime_voice_lab">Realtime voice lab</string>
     <string name="dev_settings_realtime_voice_lab_desc">Open the provider websocket testbench for dev builds</string>
     <string name="dev_settings_open_realtime_voice_lab_cd">Open realtime voice lab</string>
@@ -2439,6 +2439,10 @@
     <string name="conn_info_regenerate_code">Regenerate code</string>
     <string name="conn_info_relay_desc">Relay connection status and configuration.</string>
     <string name="conn_info_relay_enabled_flag">Relay enabled</string>
+    <string name="conn_info_relay_transport_state">Transport state</string>
+    <string name="conn_info_relay_tools">Relay tools</string>
+    <string name="conn_info_relay_tools_desc">Terminal, Bridge, device tools, Relay sessions, and secure remote routes.</string>
+    <string name="conn_info_relay_tools_off_hint">Turn on Relay tools to use this paired Relay connection.</string>
     <string name="conn_info_relay_title">Relay</string>
     <string name="conn_info_relay_url">Relay URL</string>
     <string name="conn_info_route_preference">Route preference</string>

--- a/app/src/test/kotlin/com/hermesandroid/relay/data/FeatureFlagsTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/data/FeatureFlagsTest.kt
@@ -1,0 +1,63 @@
+package com.hermesandroid.relay.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FeatureFlagsTest {
+
+    @Test
+    fun debugBuildAlwaysEnablesRelayTools() {
+        assertTrue(
+            FeatureFlags.resolveRelayEnabled(
+                isDevBuild = true,
+                isSideload = false,
+                storedOverride = false,
+            )
+        )
+    }
+
+    @Test
+    fun sideloadDefaultsRelayToolsOnWithoutStoredChoice() {
+        assertTrue(
+            FeatureFlags.resolveRelayEnabled(
+                isDevBuild = false,
+                isSideload = true,
+                storedOverride = null,
+            )
+        )
+    }
+
+    @Test
+    fun googlePlayDefaultsRelayToolsOffWithoutStoredChoice() {
+        assertFalse(
+            FeatureFlags.resolveRelayEnabled(
+                isDevBuild = false,
+                isSideload = false,
+                storedOverride = null,
+            )
+        )
+    }
+
+    @Test
+    fun explicitOptInEnablesGooglePlayRelayTools() {
+        assertTrue(
+            FeatureFlags.resolveRelayEnabled(
+                isDevBuild = false,
+                isSideload = false,
+                storedOverride = true,
+            )
+        )
+    }
+
+    @Test
+    fun explicitOptOutDisablesSideloadRelayTools() {
+        assertFalse(
+            FeatureFlags.resolveRelayEnabled(
+                isDevBuild = false,
+                isSideload = true,
+                storedOverride = false,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- default stable Relay tools on for the full-capability sideload flavor while preserving explicit user overrides
- expose a visible Relay tools switch that synchronizes feature state with transport connect/disconnect
- enable Relay tools automatically for QR and manual Relay pairing
- keep Developer Options locking independent from stable Relay functionality
- update all shipped Android locale catalogs and add regression coverage

## Validation
- `:app:testSideloadDebugUnitTest --tests com.hermesandroid.relay.data.FeatureFlagsTest`: 5 passed, 0 failed
- changed sideload Android sources and resources compile successfully
- `git diff --check`: passed
- `lint`: repository baseline remains red with 41 existing app errors; no lint errors point to changed code or resources. First existing failure is `DashboardSignInScreen.kt:138` (`LocalContextGetResourceValueCall`).

## Device verification
Per repository policy, APK build/install and on-device smoke testing remain owner-run from Android Studio. Verify that the sideload build opens Relay with tools enabled, the direct switch disconnects/reconnects transport, and QR/manual pairing re-enables tools.