### PR TITLE
fix(android): repair immutable release dispatch

### DIFF
--- a/.github/workflows/approve-release-android.yml
+++ b/.github/workflows/approve-release-android.yml
@@ -89,7 +89,7 @@ jobs:
           VERSION: ${{ steps.metadata.outputs.version }}
         run: |
           gh workflow run release-android.yml \
-            --ref="android-v${VERSION}" \
+            --ref=main \
             -f version="$VERSION"
 
       - name: Approval summary
@@ -97,4 +97,4 @@ jobs:
           echo "## Android release approved" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Created \`android-v${{ steps.metadata.outputs.version }}\` from main at \`$GITHUB_SHA\`." >> "$GITHUB_STEP_SUMMARY"
-          echo "The release workflow was dispatched at that tag. It will submit the preflighted Play draft before creating the public GitHub Release." >> "$GITHUB_STEP_SUMMARY"
+          echo "The current release workflow was dispatched from main and will check out that immutable tag. It will submit the preflighted Play draft before creating the public GitHub Release." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -12,8 +12,9 @@ on:
     tags:
       - "android-v*"
   # Approve Android Release creates its tag with GITHUB_TOKEN, whose tag event
-  # does not recursively start workflows. It explicitly dispatches this file
-  # at that tag instead. Manual tag pushes continue to use the push trigger.
+  # does not recursively start workflows. It dispatches the current workflow
+  # definition from main, while every job checks out the immutable tag. Manual
+  # tag pushes continue to use the push trigger.
   workflow_dispatch:
     inputs:
       version:
@@ -37,19 +38,22 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('android-v{0}', inputs.version) || github.ref }}
 
       - name: Extract version from tag
         id: version
         env:
           DISPATCHED_VERSION: ${{ inputs.version }}
         run: |
-          REF_VERSION="${GITHUB_REF#refs/tags/android-v}"
-          if [ "$GITHUB_REF" = "$REF_VERSION" ]; then
+          if [ -n "$DISPATCHED_VERSION" ]; then
             REF_VERSION="$DISPATCHED_VERSION"
-          fi
-          if [ -n "$DISPATCHED_VERSION" ] && [ "$DISPATCHED_VERSION" != "$REF_VERSION" ]; then
-            echo "::error::Dispatched version $DISPATCHED_VERSION does not match ref version $REF_VERSION"
-            exit 1
+            TAG_COMMIT=$(git rev-list -n 1 "android-v${REF_VERSION}")
+            if [ -z "$TAG_COMMIT" ] || [ "$TAG_COMMIT" != "$(git rev-parse HEAD)" ]; then
+              echo "::error::Checked-out commit does not match immutable tag android-v${REF_VERSION}"
+              exit 1
+            fi
+          else
+            REF_VERSION="${GITHUB_REF#refs/tags/android-v}"
           fi
           VERSION_CODE=$(grep -oP 'appVersionCode\s*=\s*"\K[^"]+' gradle/libs.versions.toml)
           echo "version=$REF_VERSION" >> "$GITHUB_OUTPUT"
@@ -67,8 +71,8 @@ jobs:
             echo "::error::Tag version ($TAG_VERSION) does not match appVersionName ($TOML_VERSION) in gradle/libs.versions.toml"
             exit 1
           fi
-          if ! grep -Fq "## [$TAG_VERSION]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no release heading for $TAG_VERSION"
+          if ! grep -Eq "^## \\[(Android )?${TAG_VERSION}\\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no Android release heading for $TAG_VERSION"
             exit 1
           fi
 
@@ -111,6 +115,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('android-v{0}', inputs.version) || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -147,6 +153,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('android-v{0}', inputs.version) || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,18 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-25 — Immutable Android release dispatch repair
+
+Android approval now dispatches the current release workflow definition from
+`main`, while every release job explicitly checks out the immutable
+`android-v*` tag. Validation confirms the dispatched version resolves to that
+checked-out commit and accepts the repository's surface-qualified
+`[Android x.y.z]` changelog heading. Existing tags remain unchanged, and a
+workflow-only correction can resume a failed publication without rebuilding
+from a different application tree.
+
+Audited `.github/workflows/approve-release-android.yml`,
+`.github/workflows/release-android.yml`, `RELEASE.md`, and `DEVLOG.md`.
+
 ## 2026-07-25 — Android 1.5.0 final release reconciliation
 
 The final Android 1.5.0 release tree reconciles the accumulated Dashboard-first

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -610,8 +610,12 @@ git push origin dev
 Then open **Actions → Approve Android Release**, choose **Run workflow**, select
 `main`, and enter the version. Starting the workflow is the release approval. It
 verifies that `main` has the exact preflighted tree and creates the
-`android-v<version>` tag. Manual stable tags are still guarded by the same
-preflight proof in the tag workflow.
+`android-v<version>` tag. Because tags created with `GITHUB_TOKEN` do not trigger
+another workflow, approval dispatches the current release workflow definition
+from `main`; every release job explicitly checks out and verifies the immutable
+`android-v<version>` tag. This lets release-workflow fixes apply without moving
+an existing tag or changing its artifact tree. Manual stable tags are still
+guarded by the same preflight proof in the tag workflow.
 
 The tag-triggered `.github/workflows/release-android.yml` rebuilds and scans the
 artifacts, changes the existing Play Production draft to `completed` (submitting


### PR DESCRIPTION
## Release workflow hotfix

Promotes the workflow-only repair from `dev` to `main` after the immutable `android-v1.5.0` tag exposed a validation mismatch.

- keeps `android-v1.5.0` unchanged at `c9a03c9ed73c3ea07dba1e822fe4f54d042da3f1`
- dispatches the current workflow definition from `main`
- checks out and verifies the existing immutable tag in every release job
- accepts the canonical `[Android 1.5.0]` changelog heading

No application source, version, release artifact tree, or Play draft changes are included.

Forge: AXI-158