### PR TITLE
fix(android): coalesce replayed chat message ids

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,17 @@
 # Hermes-Relay — Dev Log
 
+## 2026-07-27 — Android replayed-message identity reconciliation
+
+Android history reconciliation now collapses reconnect/rejoin replays of the
+same persisted message ID before publishing the transcript to Compose. The
+latest repeated snapshot replaces the value at the message's first transcript
+position, preserving stable ordering, distinct messages, and the LazyColumn
+identity contract without index- or random-key fallbacks.
+
+Focused coverage reproduces the duplicate UUID condition and verifies that the
+authoritative final content wins while every rendered message keeps a unique
+stable UI key.
+
 ## 2026-07-26 — Android 1.5.1 patch reconciliation
 
 Android 1.5.1 reconciles the post-1.5.0 voice and chat fixes into versionCode

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
@@ -1223,6 +1223,14 @@ class ChatHandler {
         // so we can attach results back to the originating assistant message's ToolCall
         val toolResults = items.filter { it.role == "tool" }
             .associateBy { it.toolCallId }
+        // A reconnect/rejoin history response can repeat a persisted message row.
+        // Chat's LazyColumn renders domain ids as stable keys (via ChatMessage.uiKey),
+        // so allowing both copies through would crash Compose before either copy
+        // could be reconciled. A domain id identifies one persisted message: retain
+        // its first transcript position while adopting the latest repeated snapshot.
+        // Rows without ids remain independent, and tool/hidden rows keep their
+        // separate handling above/below.
+        val renderedItems = coalesceRenderedHistoryItems(items)
 
         // Accumulator for media markers we find in loaded content — fired AFTER
         // the wholesale `_messages.value = ...` assignment so the ViewModel's
@@ -1240,8 +1248,8 @@ class ChatHandler {
         // silently misses those rows, so a gateway turn's tokens/badges survived
         // only if a content match happened to cover them. See
         // [reconcileLiveIdsToServer].
-        val serverItemIds = items.mapNotNullTo(HashSet()) { it.id }
-        val idRemap = reconcileLiveIdsToServer(items, serverItemIds)
+        val serverItemIds = renderedItems.mapNotNullTo(HashSet()) { it.id }
+        val idRemap = reconcileLiveIdsToServer(renderedItems, serverItemIds)
 
         // Carry CLIENT-ONLY enrichment forward across the reload, keyed by the
         // RECONCILED message id. The server transcript (MessageItem) rebuilds
@@ -1278,7 +1286,7 @@ class ChatHandler {
         // clientOnly bubbles (same exchange, pre-sync copy).
         val syncedRealtimeTurnContents = mutableSetOf<String>()
 
-        val loaded = items.mapNotNull { item ->
+        val loaded = renderedItems.mapNotNull { item ->
             val displayKind = item.displayKind?.trim()?.lowercase()
             if (displayKind == "hidden") return@mapNotNull null
             val role = when {
@@ -1538,6 +1546,34 @@ class ChatHandler {
         for ((messageId, path) in pendingPersistedUserImages) {
             onPersistedUserImageRequested(messageId, path)
         }
+    }
+
+    /**
+     * Collapse replayed visible history rows by their authoritative message id.
+     *
+     * Replacing the value at its first-seen slot preserves transcript ordering;
+     * the last repeated value wins so a later, more complete snapshot is not lost.
+     * Null ids cannot be proven identical and therefore remain separate rows.
+     */
+    private fun coalesceRenderedHistoryItems(items: List<MessageItem>): List<MessageItem> {
+        val firstSlotById = HashMap<String, Int>()
+        val coalesced = ArrayList<MessageItem>(items.size)
+        for (item in items) {
+            if (renderedRoleOf(item) == null) continue
+            val id = item.id
+            if (id == null) {
+                coalesced += item
+                continue
+            }
+            val existingSlot = firstSlotById[id]
+            if (existingSlot == null) {
+                firstSlotById[id] = coalesced.size
+                coalesced += item
+            } else {
+                coalesced[existingSlot] = item
+            }
+        }
+        return coalesced
     }
 
     /** One adoptable server row during id reconciliation. `taken` enforces consume-once. */

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ChatHandlerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ChatHandlerTest.kt
@@ -1518,6 +1518,49 @@ class ChatHandlerTest {
     }
 
     @Test
+    fun loadMessageHistory_coalescesReplayedDomainIdWithoutLosingOrderOrContent() {
+        val replayedId = "2c93af28-0b0b-436b-a112-7f164cac931d"
+
+        handler.loadMessageHistory(
+            listOf(
+                MessageItem(
+                    id = "user-1",
+                    role = "user",
+                    content = JsonPrimitive("question"),
+                    timestamp = 1.0,
+                ),
+                MessageItem(
+                    id = replayedId,
+                    role = "assistant",
+                    content = JsonPrimitive("partial answer"),
+                    timestamp = 2.0,
+                ),
+                MessageItem(
+                    id = "system-1",
+                    role = "system",
+                    content = JsonPrimitive("distinct visible content"),
+                    timestamp = 3.0,
+                ),
+                // Rejoin replay of the same persisted message. The latest
+                // snapshot is authoritative, but its first transcript position
+                // and Compose identity must remain stable.
+                MessageItem(
+                    id = replayedId,
+                    role = "assistant",
+                    content = JsonPrimitive("final answer"),
+                    timestamp = 4.0,
+                ),
+            )
+        )
+
+        val messages = handler.messages.value
+        assertEquals(listOf("user-1", replayedId, "system-1"), messages.map { it.id })
+        assertEquals("final answer", messages[1].content)
+        assertEquals("distinct visible content", messages[2].content)
+        assertEquals(messages.size, messages.map { it.uiKey }.distinct().size)
+    }
+
+    @Test
     fun loadMessageHistory_secondReloadMatchesByIdAfterReconciliation() {
         // Once the first reload adopts the server id, subsequent reloads match by
         // id and update in place while keeping client-only state.


### PR DESCRIPTION
## Summary

- coalesce replayed persisted chat-history rows by domain message ID before publishing them to Compose
- retain the first transcript position while adopting the latest repeated snapshot
- preserve distinct messages and null-ID rows without index, random, or blanket composite UI keys
- document the Android history identity correction

## Root cause

`ChatScreen` renders `ChatHandler.messages` in a `LazyColumn` keyed by `ChatMessage.uiKey`. During reconnect/rejoin history reconciliation, `loadMessageHistory` previously mapped every visible `MessageItem` independently. If upstream history replayed the same persisted UUID, both rows inherited that UUID as their UI key and Compose threw `IllegalArgumentException: Key <UUID> was already used`.

The prior `fix/chat-rejoin-duplicate-keys` work is already present on `dev` as `1ccf874`; it deduplicates session drawer rows and repairs Gateway rejoin activation, but does not deduplicate message history rows. The 1.5.0 tag already contains that earlier session fix, so current `dev` was not fully protected from the reported message-list condition.

The supplied minified stack establishes a Compose lazy-key collision but no matching 1.5.0 mapping artifact is available in the release assets, so it cannot independently name the composable. Source tracing and the focused duplicate-UUID regression identify the still-reproducible chat transcript path.

## Validation

Passed:

- `:app:testSideloadDebugUnitTest --tests "com.hermesandroid.relay.network.upstream.ChatHandlerTest.loadMessageHistory_coalescesReplayedDomainIdWithoutLosingOrderOrContent"`
- `:app:testSideloadDebugUnitTest --tests "com.hermesandroid.relay.network.upstream.ChatHandlerTest"`
- `lint` (`BUILD SUCCESSFUL`, 97 tasks)
- `git diff --check`

Broader signal:

- `:app:testSideloadDebugUnitTest` ran 1,506 tests; 16 unrelated tests failed in existing DataStore/file-storage, voice resume timing, attachment UI timing, and stream-recovery timing paths. The complete `ChatHandlerTest` class passed.

## Scope

Android only. No version bump, release entry, deploy, tag, or merge.

Fixes #258