### PR TITLE
fix(android): support Nous system-browser sign-in

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardAuth.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardAuth.kt
@@ -108,13 +108,18 @@ class NativeDashboardAuthClient(
         provider: String? = null,
     ): NativeDashboardAuthorization {
         requireStrictLoopbackRedirect(redirectUri)
-        val verifier = randomBytes(32).base64Url()
+        // RFC 7636 uses unpadded Base64URL. Okio's base64Url() preserves
+        // trailing "=", which makes Hermes' standards-compliant S256
+        // comparison fail even though both sides hashed the same bytes.
+        val verifier = randomBytes(32).base64Url().trimEnd('=')
         val challenge = MessageDigest.getInstance("SHA-256")
             .digest(verifier.toByteArray(Charsets.US_ASCII))
             .toByteString()
             .base64Url()
+            .trimEnd('=')
         val state = randomBytes(24).base64Url()
-        val root = "$baseUrl/auth/native/authorize".toHttpUrlOrNull()
+        val authorizationBaseUrl = resolveAuthorizationBaseUrl(provider)
+        val root = "$authorizationBaseUrl/auth/native/authorize".toHttpUrlOrNull()
             ?: throw IOException("Dashboard URL is not a valid http(s) address")
         val url = root.newBuilder()
             .addQueryParameter("code_challenge", challenge)
@@ -128,6 +133,41 @@ class NativeDashboardAuthClient(
             tokenStore.coordinationKey,
         )
         return NativeDashboardAuthorization(url, verifier, state, generation)
+    }
+
+    /**
+     * A private-route dashboard may be configured with a canonical HTTPS
+     * callback origin for its provider. Starting the browser on the private
+     * origin would scope Hermes' temporary PKCE cookie to the wrong host, so
+     * discover the provider's declared callback and start native auth there.
+     * Token exchange still uses [baseUrl], keeping the resulting bearer bound
+     * to the active connection route.
+     */
+    private fun resolveAuthorizationBaseUrl(provider: String?): String {
+        val configured = baseUrl.toHttpUrlOrNull() ?: return baseUrl
+        if (
+            !provider.equals("nous", ignoreCase = true) ||
+            configured.scheme != "http" ||
+            !isPrivateNetworkLiteral(configured.host)
+        ) {
+            return baseUrl
+        }
+        val loginUrl = configured.newBuilder()
+            .addPathSegments("auth/login")
+            .addQueryParameter("provider", provider)
+            .addQueryParameter("next", "/")
+            .build()
+        val discoveryClient = client.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+        val location = discoveryClient.newCall(
+            Request.Builder().url(loginUrl).get().build(),
+        ).execute().use { response ->
+            if (response.code !in 300..399) null else response.header("Location")
+        }
+        return canonicalDashboardBaseFromNousRedirect(location)
+            ?: throw IOException("Dashboard did not advertise a secure Nous callback origin")
     }
 
     fun exchangeCallback(
@@ -280,7 +320,52 @@ internal class NativeDashboardCallbackException(
 internal fun isNativeDashboardTransportEligible(baseUrl: String): Boolean {
     val url = baseUrl.trim().trimEnd('/').toHttpUrlOrNull() ?: return false
     return url.scheme == "https" ||
-        (url.scheme == "http" && url.host == "127.0.0.1")
+        (
+            url.scheme == "http" &&
+                (url.host == "127.0.0.1" || isPrivateNetworkLiteral(url.host))
+            )
+}
+
+/**
+ * Hermes already permits explicitly configured HTTP dashboard sessions on
+ * local routes. The brokered flow is no less protected than that cookie flow,
+ * but remains unavailable to arbitrary cleartext Internet hosts.
+ */
+private fun isPrivateNetworkLiteral(host: String): Boolean {
+    val octets = host.split('.').mapNotNull(String::toIntOrNull)
+    if (octets.size != 4 || octets.any { it !in 0..255 }) return false
+    val first = octets[0]
+    val second = octets[1]
+    return first == 10 ||
+        (first == 172 && second in 16..31) ||
+        (first == 192 && second == 168) ||
+        (first == 100 && second in 64..127)
+}
+
+internal fun canonicalDashboardBaseFromNousRedirect(location: String?): String? {
+    val providerUrl = location?.toHttpUrlOrNull() ?: return null
+    if (
+        providerUrl.scheme != "https" ||
+        !providerUrl.host.equals("portal.nousresearch.com", ignoreCase = true)
+    ) {
+        return null
+    }
+    val callback = providerUrl.queryParameter("redirect_uri")
+        ?.toHttpUrlOrNull()
+        ?: return null
+    if (callback.scheme != "https") return null
+    val callbackSuffix = "/auth/callback"
+    if (!callback.encodedPath.endsWith(callbackSuffix)) return null
+    val basePath = callback.encodedPath
+        .removeSuffix(callbackSuffix)
+        .ifBlank { "/" }
+    return callback.newBuilder()
+        .encodedPath(basePath)
+        .query(null)
+        .fragment(null)
+        .build()
+        .toString()
+        .trimEnd('/')
 }
 
 /**

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardSignInCoordinator.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardSignInCoordinator.kt
@@ -34,6 +34,24 @@ internal fun dashboardRedirectAuthMode(authFlows: List<String>): DashboardRedire
     }
 
 /**
+ * Nous Portal uses Cloudflare Turnstile and does not support embedded Android
+ * WebViews. Keep self-hosted OIDC on the dashboard cookie flow, but use the
+ * gateway's brokered system-browser flow for Nous when it is advertised.
+ */
+internal fun androidDashboardRedirectAuthMode(
+    providerName: String,
+    authFlows: List<String>,
+): DashboardRedirectAuthMode =
+    if (
+        providerName.equals("nous", ignoreCase = true) &&
+        dashboardRedirectAuthMode(authFlows) == DashboardRedirectAuthMode.NativePkce
+    ) {
+        DashboardRedirectAuthMode.NativePkce
+    } else {
+        DashboardRedirectAuthMode.WebView
+    }
+
+/**
  * Owns one native dashboard sign-in attempt.
  *
  * The listener and PKCE authorization are both local to [signIn], so leaving

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DashboardSignInScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DashboardSignInScreen.kt
@@ -1,18 +1,19 @@
 package com.hermesandroid.relay.ui.screens
 
 import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -21,12 +22,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -42,7 +45,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.window.Dialog
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.ui.components.ConnectionSetupTimeline
 import com.hermesandroid.relay.ui.components.ConnectionSetupTimelineStep
@@ -50,10 +52,18 @@ import com.hermesandroid.relay.network.upstream.DashboardApiClient
 import com.hermesandroid.relay.network.upstream.DashboardAuthProvider
 import com.hermesandroid.relay.network.upstream.DashboardAuthSession
 import com.hermesandroid.relay.network.upstream.DashboardCookieStore
+import com.hermesandroid.relay.network.upstream.DashboardRedirectAuthMode
 import com.hermesandroid.relay.network.upstream.EncryptedDashboardCookieStore
+import com.hermesandroid.relay.network.upstream.NativeDashboardSignInCoordinator
+import com.hermesandroid.relay.network.upstream.androidDashboardRedirectAuthMode
 import com.hermesandroid.relay.network.upstream.importDashboardCookieHeader
+import com.hermesandroid.relay.network.upstream.isNativeDashboardTransportEligible
 import com.hermesandroid.relay.viewmodel.ConnectionViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 /**
@@ -84,6 +94,10 @@ fun DashboardSignInScreen(
     var actionMessage by remember { mutableStateOf<String?>(null) }
     var actionIsError by remember { mutableStateOf(false) }
     var oauthProvider by remember { mutableStateOf<DashboardAuthProvider?>(null) }
+    var authFlows by remember(dashboardUrl, connectionId) {
+        mutableStateOf<List<String>>(emptyList())
+    }
+    var nativeSignInJob by remember(dashboardUrl, connectionId) { mutableStateOf<Job?>(null) }
     var authenticationComplete by remember { mutableStateOf(false) }
 
     val cookieStoreFactory = remember(appContext, connectionId) {
@@ -138,6 +152,7 @@ fun DashboardSignInScreen(
             providers = client.getAuthProviders().getOrNull()
                 ?.takeIf { it.isNotEmpty() }
                 ?: status.authProviderDetails
+            authFlows = status.authFlows
             val session = if (status.authRequired) client.currentSession().getOrNull() else null
             connectionViewModel.recordDashboardStatus(
                 status = status,
@@ -183,14 +198,70 @@ fun DashboardSignInScreen(
 
     fun startRedirectSignIn(provider: DashboardAuthProvider) {
         if (actionInFlight || dashboardUrl.isBlank()) return
-        // `native_pkce` is an upstream desktop capability. Android owns the
-        // dashboard cookie flow so the provider returns to the public
-        // /auth/callback, whose cookies are then verified via /api/auth/me.
-        oauthProvider = provider
+        if (
+            androidDashboardRedirectAuthMode(provider.name, authFlows) ==
+            DashboardRedirectAuthMode.WebView
+        ) {
+            oauthProvider = provider
+            return
+        }
+        if (!isNativeDashboardTransportEligible(dashboardUrl)) {
+            actionMessage = resources.getString(R.string.dashboard_native_signin_requires_https)
+            actionIsError = true
+            return
+        }
+        val authClient = connectionViewModel.nativeDashboardAuthClientForActive(dashboardUrl)
+        if (authClient == null) {
+            actionMessage = resources.getString(R.string.dashboard_native_signin_unavailable)
+            actionIsError = true
+            return
+        }
+
+        actionInFlight = true
+        actionIsError = false
+        actionMessage = resources.getString(R.string.dashboard_native_signin_opening)
+        nativeSignInJob = scope.launch {
+            try {
+                NativeDashboardSignInCoordinator(authClient).signIn(provider.name) { authorizationUrl ->
+                    withContext(Dispatchers.Main.immediate) {
+                        launchNativeDashboardAuthorization(context, authorizationUrl)
+                    }
+                }
+                val client = clientFactory()
+                val session = try {
+                    verifyAndRecord(client)
+                } finally {
+                    client.shutdown()
+                }
+                if (session?.authenticated == true) {
+                    actionMessage = session.provider?.let {
+                        resources.getString(R.string.dashboard_signed_in_with, it)
+                    } ?: resources.getString(R.string.dashboard_signed_in)
+                    actionIsError = false
+                    finishAuthentication()
+                } else {
+                    actionMessage = resources.getString(R.string.dashboard_signin_no_session)
+                    actionIsError = true
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                actionMessage = error.message
+                    ?: resources.getString(R.string.dashboard_signin_failed)
+                actionIsError = true
+            } finally {
+                actionInFlight = false
+                nativeSignInJob = null
+            }
+        }
+    }
+
+    DisposableEffect(dashboardUrl, connectionId) {
+        onDispose { nativeSignInJob?.cancel() }
     }
 
     oauthProvider?.let { provider ->
-        DashboardOAuthDialog(
+        DashboardOAuthScreen(
             dashboardUrl = dashboardUrl,
             provider = provider,
             cookieStoreFactory = cookieStoreFactory,
@@ -216,6 +287,7 @@ fun DashboardSignInScreen(
                 actionIsError = true
             },
         )
+        return
     }
 
     Scaffold(
@@ -252,8 +324,14 @@ fun DashboardSignInScreen(
                     actionInFlight = actionInFlight,
                     actionMessage = actionMessage,
                     actionIsError = actionIsError,
+                    nativeSignInInFlight = nativeSignInJob != null,
                     onSignIn = ::submitPassword,
                     onOAuthSignIn = ::startRedirectSignIn,
+                    onCancelNativeSignIn = {
+                        actionMessage = resources.getString(R.string.dashboard_native_signin_cancelled)
+                        actionIsError = false
+                        nativeSignInJob?.cancel()
+                    },
                 )
             }
         }
@@ -319,8 +397,10 @@ private fun DashboardSignInForm(
     actionInFlight: Boolean,
     actionMessage: String?,
     actionIsError: Boolean,
+    nativeSignInInFlight: Boolean,
     onSignIn: (String, String, String) -> Unit,
     onOAuthSignIn: (DashboardAuthProvider) -> Unit,
+    onCancelNativeSignIn: () -> Unit,
 ) {
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -350,6 +430,14 @@ private fun DashboardSignInForm(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(stringResource(R.string.dashboard_signin_with_provider, provider.displayName ?: provider.name))
+        }
+    }
+    if (nativeSignInInFlight) {
+        Button(
+            onClick = onCancelNativeSignIn,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.dashboard_cancel))
         }
     }
     if (passwordProvider != null || providers.isEmpty()) {
@@ -390,8 +478,9 @@ private fun DashboardSignInForm(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DashboardOAuthDialog(
+private fun DashboardOAuthScreen(
     dashboardUrl: String,
     provider: DashboardAuthProvider,
     cookieStoreFactory: () -> DashboardCookieStore,
@@ -408,6 +497,8 @@ private fun DashboardOAuthDialog(
     val verifyFailedStatus = stringResource(R.string.dashboard_oauth_verify_failed)
     var statusText by remember(initialStatus) { mutableStateOf(initialStatus) }
     var checking by remember { mutableStateOf(false) }
+    var pageProgress by remember { mutableStateOf(0) }
+    var webView by remember { mutableStateOf<WebView?>(null) }
     val loginUrl = remember(dashboardUrl, provider.name) {
         DashboardApiClient.authLoginUrl(
             baseUrl = dashboardUrl,
@@ -456,49 +547,113 @@ private fun DashboardOAuthDialog(
         }
     }
 
-    Dialog(onDismissRequest = onDismiss) {
-        Card(modifier = Modifier.fillMaxWidth().heightIn(max = 640.dp)) {
-            Column(
-                modifier = Modifier.padding(12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                IconButton(onClick = onDismiss) {
-                    Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.dashboard_close_signin))
-                }
-                Text(statusText, style = MaterialTheme.typography.bodySmall)
-                AndroidView(
-                    modifier = Modifier.fillMaxWidth().weight(1f),
-                    factory = { viewContext ->
-                        CookieManager.getInstance().setAcceptCookie(true)
-                        WebView(viewContext).apply {
-                            settings.javaScriptEnabled = true
-                            settings.domStorageEnabled = true
-                            webViewClient = object : WebViewClient() {
-                                override fun shouldOverrideUrlLoading(
-                                    view: WebView,
-                                    request: WebResourceRequest,
-                                ): Boolean {
-                                    val target = request.url.toString()
-                                    if (
-                                        dashboardWebViewAuthNavigation(dashboardUrl, target) ==
-                                        DashboardWebViewAuthNavigation.RejectLoopbackCallback
-                                    ) {
-                                        handleNavigation(target)
-                                        return true
-                                    }
-                                    return false
-                                }
+    BackHandler(onBack = onDismiss)
 
-                                override fun onPageFinished(view: WebView, url: String?) {
-                                    super.onPageFinished(view, url)
-                                    handleNavigation(url)
-                                }
-                            }
-                            loadUrl(loginUrl)
-                        }
-                    },
+    DisposableEffect(Unit) {
+        onDispose {
+            webView?.stopLoading()
+            webView?.destroy()
+            webView = null
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            text = stringResource(
+                                R.string.dashboard_signin_with_provider,
+                                provider.displayName ?: provider.name,
+                            ),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            text = statusText,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.dashboard_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            if (pageProgress in 0..99) {
+                LinearProgressIndicator(
+                    progress = { pageProgress / 100f },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
+            AndroidView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                factory = { viewContext ->
+                    CookieManager.getInstance().setAcceptCookie(true)
+                    WebView(viewContext).apply {
+                        settings.javaScriptEnabled = true
+                        settings.domStorageEnabled = true
+                        webChromeClient = object : WebChromeClient() {
+                            override fun onProgressChanged(view: WebView, newProgress: Int) {
+                                pageProgress = newProgress
+                            }
+                        }
+                        webViewClient = object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView,
+                                request: WebResourceRequest,
+                            ): Boolean {
+                                val target = request.url.toString()
+                                if (
+                                    dashboardWebViewAuthNavigation(dashboardUrl, target) ==
+                                    DashboardWebViewAuthNavigation.RejectLoopbackCallback
+                                ) {
+                                    handleNavigation(target)
+                                    return true
+                                }
+                                return false
+                            }
+
+                            override fun onReceivedError(
+                                view: WebView,
+                                request: WebResourceRequest,
+                                error: WebResourceError,
+                            ) {
+                                super.onReceivedError(view, request, error)
+                                if (request.isForMainFrame) {
+                                    val message = error.description?.toString()
+                                        ?.takeIf { it.isNotBlank() }
+                                        ?: verifyFailedStatus
+                                    statusText = message
+                                    onError(message)
+                                }
+                            }
+
+                            override fun onPageFinished(view: WebView, url: String?) {
+                                super.onPageFinished(view, url)
+                                handleNavigation(url)
+                            }
+                        }
+                        webView = this
+                        loadUrl(loginUrl)
+                    }
+                },
+            )
         }
     }
 }

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardAuthTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardAuthTest.kt
@@ -68,8 +68,34 @@ class NativeDashboardAuthTest {
         assertEquals("http://127.0.0.1:43123/callback", query["redirect_uri"])
         assertEquals("nous", query["provider"])
         assertTrue(query.getValue("state").length >= 32)
-        assertTrue(query.getValue("code_challenge").length >= 43)
+        assertEquals(43, query.getValue("code_challenge").length)
+        assertFalse(query.getValue("code_challenge").contains('='))
         assertNotEquals(query["state"], query["code_challenge"])
+    }
+
+    @Test
+    fun canonicalNousCallbackBase_usesSecurePublicOriginAndPreservesPrefix() {
+        val location = "https://portal.nousresearch.com/oauth/authorize" +
+            "?redirect_uri=https%3A%2F%2Fhermes.example.test%2Fgateway%2Fauth%2Fcallback"
+
+        assertEquals(
+            "https://hermes.example.test/gateway",
+            canonicalDashboardBaseFromNousRedirect(location),
+        )
+        assertEquals(
+            null,
+            canonicalDashboardBaseFromNousRedirect(
+                "https://portal.nousresearch.com/oauth/authorize" +
+                    "?redirect_uri=http%3A%2F%2Fhermes.example.test%2Fauth%2Fcallback",
+            ),
+        )
+        assertEquals(
+            null,
+            canonicalDashboardBaseFromNousRedirect(
+                "https://attacker.example/oauth/authorize" +
+                    "?redirect_uri=https%3A%2F%2Fhermes.example.test%2Fauth%2Fcallback",
+            ),
+        )
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -103,6 +129,7 @@ class NativeDashboardAuthTest {
             .digest(verifier.toByteArray(Charsets.US_ASCII))
             .toByteString()
             .base64Url()
+            .trimEnd('=')
         val authorizeChallenge = java.net.URI(authorization.authorizationUrl).rawQuery
             .split("&")
             .first { it.startsWith("code_challenge=") }

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardSignInCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/NativeDashboardSignInCoordinatorTest.kt
@@ -115,7 +115,28 @@ class NativeDashboardSignInCoordinatorTest {
         )
         assertTrue(isNativeDashboardTransportEligible("https://hermes.example.test/prefix"))
         assertTrue(isNativeDashboardTransportEligible("http://127.0.0.1:9119"))
+        assertTrue(isNativeDashboardTransportEligible("http://172.16.24.250:9119"))
+        assertTrue(isNativeDashboardTransportEligible("http://100.71.8.56:9119"))
         assertFalse(isNativeDashboardTransportEligible("http://hermes.local:9119"))
+        assertFalse(isNativeDashboardTransportEligible("http://203.0.113.10:9119"))
+    }
+
+    @Test
+    fun androidRedirectMode_usesBrowserForNous_andCookieFlowForSelfHostedOidc() {
+        val flows = listOf("cookie", "native_pkce")
+
+        assertEquals(
+            DashboardRedirectAuthMode.NativePkce,
+            androidDashboardRedirectAuthMode("nous", flows),
+        )
+        assertEquals(
+            DashboardRedirectAuthMode.WebView,
+            androidDashboardRedirectAuthMode("oidc", flows),
+        )
+        assertEquals(
+            DashboardRedirectAuthMode.WebView,
+            androidDashboardRedirectAuthMode("nous", listOf("cookie")),
+        )
     }
 
     private suspend fun completeSignIn(

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2205,9 +2205,9 @@ socket.
 
 ---
 
-## ADR 40 — Android dashboard redirect auth remains cookie/OIDC
+## ADR 40 — Android dashboard redirect auth is provider-compatible
 
-**Status:** Accepted (2026-07-27).
+**Status:** Amended (2026-07-28).
 
 **Context.** Upstream advertises `native_pkce` in `/api/status.auth_flows` for
 its desktop client. The corresponding `/auth/native/*` broker is explicitly a
@@ -2217,10 +2217,11 @@ Android incorrectly treated that server-wide capability as a platform-neutral
 mode selector, so redirect providers such as self-hosted OIDC were sent through
 the desktop loopback contract.
 
-**Decision.** Android redirect-provider sign-in always uses the upstream
-dashboard cookie flow:
+**Decision.** Android redirect-provider sign-in uses the upstream dashboard
+cookie flow by default:
 
-- open `/auth/login?provider=...&next=...` in the embedded sign-in WebView;
+- open `/auth/login?provider=...&next=...` in a full-screen embedded sign-in
+  destination with a normal app bar rather than a modal WebView;
 - allow the provider to return through the dashboard's public
   `/auth/callback`;
 - import only cookies observed on the configured dashboard origin;
@@ -2228,10 +2229,20 @@ dashboard cookie flow:
 - reject a foreign `http://127.0.0.1`, `localhost`, or `[::1]` `/callback`
   navigation instead of following or importing it.
 
-Android does not select `/auth/native/authorize` from `auth_flows`. Desktop
-native PKCE remains an upstream desktop capability and is unchanged. Existing
-encrypted native-token support is retained only so already-issued Android
-sessions can be cleared or age out safely; it is not a sign-in entry point.
+Android does not select `/auth/native/authorize` merely because it appears in
+`auth_flows`. Self-hosted OIDC remains on the cookie contract above. Nous Portal
+is the narrow exception: its Cloudflare Turnstile challenge rejects embedded
+Android WebViews, so Android uses the gateway-brokered native PKCE route for
+that provider when advertised and opens it in a system Custom Tab. The
+ephemeral loopback listener, S256 verifier, state validation, encrypted bearer
+store, and exact-origin attachment remain app-owned. Public cleartext
+dashboards are rejected; explicitly configured RFC 1918 and Tailscale-IP
+dashboard routes retain the same HTTP allowance as their existing cookie
+sessions. If the provider redirect from a private route declares a canonical
+HTTPS dashboard callback, Android begins browser authorization on that
+canonical origin so the temporary PKCE cookie and callback remain same-origin;
+the one-time code exchange and resulting exact-origin bearer stay bound to the
+active private route.
 
 **Consequences.**
 
@@ -2240,5 +2251,6 @@ sessions can be cleared or age out safely; it is not a sign-in entry point.
   dashboard cookie session.
 - A server-wide desktop capability can no longer switch Android into a
   loopback callback flow.
-- Android retains an embedded WebView for dashboard authentication; provider
-  compatibility and WebView security updates remain part of Android upkeep.
+- Android retains a full-screen embedded WebView for compatible dashboard
+  cookie providers, while providers that prohibit embedding use the explicit
+  brokered native route.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -170,16 +170,21 @@ Phone control — mirrors upstream relay protocol.
 
 ### 3.3 Auth Flow
 
-Dashboard/Gateway redirect providers use the upstream native PKCE contract when
-`GET /api/status` advertises `native_pkce`. Android opens the selected provider
-in a Custom Tab and owns a single ephemeral callback on
-`http://127.0.0.1:<os-assigned-port>/callback`. PKCE verifier and CSRF state
-exist only for that sign-in coroutine. Access and refresh tokens are encrypted
-per connection and are attached only to the exact trusted dashboard base for
-Manage, Gateway tickets, and standard voice. Native exchange is allowed only
-for HTTPS dashboard addresses (plus literal loopback for development). A
-gateway without the capability uses the legacy cookie/WebView flow; a failed
-native attempt never silently downgrades.
+Dashboard/Gateway redirect authentication is provider-compatible. Nous Portal,
+which relies on a challenge that rejects embedded Android WebViews, uses the
+upstream brokered `native_pkce` flow in a system Custom Tab when the dashboard
+advertises it. The app owns an ephemeral loopback callback and stores the
+resulting bearer session only for that connection and exact dashboard origin.
+Self-hosted OIDC remains on the dashboard cookie flow: Android opens
+`/auth/login` in a full-screen embedded browser destination, lets the provider
+return through the public `/auth/callback`, imports only same-origin cookies,
+and verifies them through `/api/auth/me`. HTTPS is required on public routes;
+explicit private-LAN and Tailscale-IP dashboards may use their existing HTTP
+transport. When such a private route advertises a canonical HTTPS Nous callback,
+Android starts the browser on that canonical origin so Hermes' temporary PKCE
+cookie and the provider callback remain same-origin, then exchanges the
+one-time code through the active private route. The verified session is shared
+by Manage, Gateway tickets, and standard voice.
 
 Pairing is QR-driven. The operator runs the pair command on the host — `hermes pair`, `/hermes-relay-pair` from any Hermes chat surface, or the compatibility `hermes-pair` shell shim. All share the same implementation in `plugin/pair.py`. The command probes for a running relay, generates a fresh 6-char code, pre-registers it with the relay via the loopback-only `POST /pairing/register` endpoint, then embeds the relay URL + code + **chosen TTL + per-channel grants + HMAC signature** (plus the API server credentials and optional dashboard URL) in a single QR payload. The phone scans once, **confirms the TTL and grants via a picker dialog**, and is configured for both chat AND terminal/bridge.
 


### PR DESCRIPTION
## What changed

- open Nous Portal authentication in the system browser through Hermes' advertised native PKCE broker while keeping self-hosted OIDC on the dashboard cookie/WebView flow
- discover a private dashboard's configured canonical HTTPS callback origin without hardcoding an operator URL
- use RFC 7636 unpadded Base64URL verifier/challenge encoding and retain exact-route token storage
- replace the constrained OAuth modal with a full-screen in-app browser for compatible providers
- document the provider-compatible Android auth contract

## Why

Nous Portal's Turnstile flow rejects embedded Android WebViews. The first brokered attempt also exposed two interoperability boundaries: private-route authorization must begin on the canonical callback origin so PKCE cookies remain same-origin, and the S256 verifier/challenge must use unpadded Base64URL.

## Verification

- `python scripts/android-prepush.py` (repository checks, Google Play lint, focused Android shard)
- focused `NativeDashboardAuthTest` and `NativeDashboardSignInCoordinatorTest`
- `:app:assembleSideloadDebug`
- on-device sideload smoke against a private dashboard route
- live dashboard audit recorded `native_token_success` followed by gateway ticket minting
