### PR TITLE
fix(android): preserve secure gateway routes

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/data/ConnectionData.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/ConnectionData.kt
@@ -247,6 +247,7 @@ data class Connection(
             apiServerUrl: String,
             relayUrl: String,
             extraApiUrls: List<Pair<String, String>> = emptyList(),
+            dashboardUrl: String? = null,
         ): List<EndpointCandidate> {
             val routes = buildList {
                 endpointCandidateFromApiUrl(
@@ -255,6 +256,7 @@ data class Connection(
                     apiServerUrl = apiServerUrl,
                     relayUrl = relayUrl.takeIf { it.isNotBlank() }
                         ?: deriveDefaultRelayUrl(apiServerUrl).orEmpty(),
+                    dashboardUrl = dashboardUrl,
                 )?.let(::add)
 
                 extraApiUrls
@@ -266,6 +268,7 @@ data class Connection(
                             priority = index + 1,
                             apiServerUrl = url,
                             relayUrl = deriveDefaultRelayUrl(url).orEmpty(),
+                            dashboardUrl = dashboardUrl,
                         )?.let(::add)
                     }
             }
@@ -340,6 +343,7 @@ data class Connection(
             priority: Int,
             apiServerUrl: String,
             relayUrl: String,
+            dashboardUrl: String? = null,
         ): EndpointCandidate? {
             val uri = runCatching { URI(apiServerUrl.trim().trimEnd('/')) }.getOrNull()
                 ?: return null
@@ -363,10 +367,60 @@ data class Connection(
                 role = role.ifBlank { inferRouteRole(apiServerUrl) },
                 priority = priority,
                 api = ApiEndpoint(host = host, port = port, tls = tls),
-                dashboard = deriveDefaultDashboardUrl(apiServerUrl)
+                dashboard = dashboardUrl
+                    ?.trim()
+                    ?.trimEnd('/')
+                    ?.takeIf { it.isNotBlank() && urlsShareHost(it, apiServerUrl) }
+                    ?.let { DashboardEndpoint(url = it) }
+                    ?: deriveDefaultDashboardUrl(apiServerUrl)
                     ?.let { DashboardEndpoint(url = it) },
                 relay = RelayEndpoint(url = resolvedRelayUrl, transportHint = transportHint),
             )
+        }
+
+        /**
+         * Reconcile stored API-derived routes with the Dashboard origin that
+         * was actually verified during setup. Older app versions synthesized
+         * `:9119` for every API route, even when the same host was reached
+         * through an HTTPS reverse proxy on 443. Replace only that conventional
+         * synthesized value (or a missing value); preserve explicit and
+         * different-host LAN/Tailscale routes.
+         */
+        fun reconcileDashboardRoutes(
+            dashboardUrl: String?,
+            candidates: List<EndpointCandidate>,
+        ): List<EndpointCandidate> {
+            val explicitDashboard = dashboardUrl
+                ?.trim()
+                ?.trimEnd('/')
+                ?.takeIf { it.isNotBlank() }
+                ?: return candidates
+            return candidates.map { candidate ->
+                val apiUrl = candidate.api?.url ?: return@map candidate
+                if (!urlsShareHost(explicitDashboard, apiUrl)) return@map candidate
+
+                val currentDashboard = candidate.dashboard?.url
+                val derivedDashboard = deriveDefaultDashboardUrl(apiUrl)
+                val canReplace = currentDashboard.isNullOrBlank() ||
+                    (
+                        derivedDashboard != null &&
+                            currentDashboard.trim().trimEnd('/')
+                                .equals(derivedDashboard, ignoreCase = true)
+                    )
+                if (canReplace) {
+                    candidate.copy(dashboard = DashboardEndpoint(url = explicitDashboard))
+                } else {
+                    candidate
+                }
+            }
+        }
+
+        fun urlsShareHost(leftUrl: String, rightUrl: String): Boolean {
+            val leftHost = runCatching { URI(leftUrl.trim()) }.getOrNull()?.host
+            val rightHost = runCatching { URI(rightUrl.trim()) }.getOrNull()?.host
+            return !leftHost.isNullOrBlank() &&
+                !rightHost.isNullOrBlank() &&
+                leftHost.equals(rightHost, ignoreCase = true)
         }
 
         /**

--- a/app/src/main/kotlin/com/hermesandroid/relay/data/ConnectionStore.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/ConnectionStore.kt
@@ -543,29 +543,6 @@ class ConnectionStore private constructor(
         }
     }
 
-    private fun Connection.withDashboardDefaults(): Connection {
-        val derivedDashboardUrl = Connection.deriveDefaultDashboardUrl(apiServerUrl)
-        val normalizedRoutes = routeCandidates.ifEmpty {
-            Connection.buildRouteCandidates(apiServerUrl, relayUrl)
-        }
-        val normalizedPreferredRouteRole = preferredRouteRole?.takeIf { preferred ->
-            normalizedRoutes.any { it.role.equals(preferred, ignoreCase = true) }
-        }
-        return if (
-            (dashboardUrl.isNullOrBlank() && derivedDashboardUrl != null) ||
-            normalizedRoutes != routeCandidates ||
-            normalizedPreferredRouteRole != preferredRouteRole
-        ) {
-            copy(
-                dashboardUrl = dashboardUrl?.takeIf { it.isNotBlank() } ?: derivedDashboardUrl,
-                routeCandidates = normalizedRoutes,
-                preferredRouteRole = normalizedPreferredRouteRole,
-            )
-        } else {
-            this
-        }
-    }
-
     companion object {
         private const val TAG = "ConnectionStore"
 
@@ -583,5 +560,42 @@ class ConnectionStore private constructor(
         // a fresh install would.
         private const val DEFAULT_API_URL = "http://localhost:8642"
         private const val DEFAULT_RELAY_URL = "ws://localhost:8767"
+    }
+}
+
+/**
+ * Restore route defaults after loading a serialized connection. This remains
+ * internal so focused persistence tests can exercise the same normalization
+ * path used by [ConnectionStore].
+ */
+internal fun Connection.withDashboardDefaults(): Connection {
+    val derivedDashboardUrl = Connection.deriveDefaultDashboardUrl(apiServerUrl)
+    val effectiveDashboardUrl = dashboardUrl?.takeIf { it.isNotBlank() } ?: derivedDashboardUrl
+    val storedOrDefaultRoutes = routeCandidates.ifEmpty {
+        Connection.buildRouteCandidates(
+            apiServerUrl = apiServerUrl,
+            relayUrl = relayUrl,
+            dashboardUrl = effectiveDashboardUrl,
+        )
+    }
+    val normalizedRoutes = Connection.reconcileDashboardRoutes(
+        dashboardUrl = effectiveDashboardUrl,
+        candidates = storedOrDefaultRoutes,
+    )
+    val normalizedPreferredRouteRole = preferredRouteRole?.takeIf { preferred ->
+        normalizedRoutes.any { it.role.equals(preferred, ignoreCase = true) }
+    }
+    return if (
+        dashboardUrl != effectiveDashboardUrl ||
+        normalizedRoutes != routeCandidates ||
+        normalizedPreferredRouteRole != preferredRouteRole
+    ) {
+        copy(
+            dashboardUrl = effectiveDashboardUrl,
+            routeCandidates = normalizedRoutes,
+            preferredRouteRole = normalizedPreferredRouteRole,
+        )
+    } else {
+        this
     }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -183,8 +184,8 @@ val LocalSnackbarHost = staticCompositionLocalOf<SnackbarHostState> {
 
 // Short-lived snackbar by default; retryable errors get Long so users have
 // time to tap the action before it auto-dismisses.
-suspend fun SnackbarHostState.showHumanError(err: HumanError) {
-    showSnackbar(
+suspend fun SnackbarHostState.showHumanError(err: HumanError): SnackbarResult {
+    return showSnackbar(
         message = err.body,
         actionLabel = err.actionLabel,
         duration = if (err.retryable) SnackbarDuration.Long else SnackbarDuration.Short,
@@ -1942,6 +1943,16 @@ fun RelayApp() {
                         },
                         onNavigateToConnect = {
                             navController.navigate(Screen.Pair.route()) {
+                                launchSingleTop = true
+                            }
+                        },
+                        onRepairConnection = {
+                            navController.navigate(
+                                Screen.Pair.route(
+                                    connectionId = activeConnectionId,
+                                    autoStart = "relay",
+                                ),
+                            ) {
                                 launchSingleTop = true
                             }
                         },

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -139,6 +139,7 @@ import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarResult
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
@@ -206,6 +207,7 @@ import com.hermesandroid.relay.ui.components.showsImageGenerationPlaceholder
 import com.hermesandroid.relay.ui.components.VoiceModeOverlay
 import com.hermesandroid.relay.ui.LocalSnackbarHost
 import com.hermesandroid.relay.ui.showHumanError
+import com.hermesandroid.relay.util.HumanErrorAction
 import com.hermesandroid.relay.ui.theme.RelayRefresh
 import kotlin.math.abs
 import com.hermesandroid.relay.ui.theme.relayGridTexture
@@ -466,6 +468,7 @@ fun ChatScreen(
     // don't wire navigation.
     onNavigateToConnections: () -> Unit = {},
     onNavigateToConnect: () -> Unit = onNavigateToConnections,
+    onRepairConnection: () -> Unit = onNavigateToConnect,
     // Offline demo entry, surfaced on the empty-chat "needs connection" card so a
     // skipped / never-connected first run can explore without a server. null hides it.
     onTryDemo: (() -> Unit)? = null,
@@ -493,7 +496,13 @@ fun ChatScreen(
     val snackbarHost = LocalSnackbarHost.current
     LaunchedEffect(chatViewModel) {
         chatViewModel.errorEvents.collect { err ->
-            snackbarHost.showHumanError(err)
+            val result = snackbarHost.showHumanError(err)
+            if (
+                result == SnackbarResult.ActionPerformed &&
+                err.action == HumanErrorAction.Repair
+            ) {
+                onRepairConnection()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
@@ -22,11 +22,16 @@ import javax.net.ssl.SSLPeerUnverifiedException
  * showHumanError in RelayApp.kt.
  */
 
+enum class HumanErrorAction {
+    Repair,
+}
+
 data class HumanError(
     val title: String,
     val body: String,
     val retryable: Boolean = false,
     val actionLabel: String? = null,
+    val action: HumanErrorAction? = null,
 )
 
 private fun titlePrefix(context: String?, ctx: Context?): String = ctx?.let { c ->
@@ -116,6 +121,7 @@ private fun classifyIoMessage(msg: String, context: String?, ctx: Context?): Hum
             body = "Your session is no longer valid — re-pair this device",
             retryable = false,
             actionLabel = ctx?.getString(R.string.error_classify_repair) ?: "Re-pair",
+            action = HumanErrorAction.Repair,
         )
         "403" in msg || "forbidden" in msg -> HumanError(
             title = ctx?.getString(R.string.error_classify_not_allowed) ?: "Not allowed",
@@ -271,6 +277,7 @@ private fun classifyErrorInternal(t: Throwable?, context: String?, ctx: Context?
             body = "The server certificate changed since you paired — re-pair to trust it",
             retryable = false,
             actionLabel = ctx?.getString(R.string.error_classify_repair) ?: "Re-pair",
+            action = HumanErrorAction.Repair,
         )
         is SecurityException -> HumanError(
             title = ctx?.getString(R.string.error_classify_perm_needed) ?: "Permission needed",

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
@@ -212,9 +212,12 @@ internal fun resolveEffectiveDashboardUrl(
     endpoint?.dashboard?.url
         ?.takeIf { it.isNotBlank() }
         ?.let { return it }
-    endpoint?.api?.url
-        ?.let(Connection::deriveDefaultDashboardUrl)
-        ?.let { return it }
+    endpoint?.api?.url?.let { apiUrl ->
+        connection.dashboardUrl
+            ?.takeIf { it.isNotBlank() && Connection.urlsShareHost(it, apiUrl) }
+            ?.let { return it }
+        Connection.deriveDefaultDashboardUrl(apiUrl)?.let { return it }
+    }
     return connection.resolvedDashboardUrl
 }
 
@@ -788,6 +791,7 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
             apiServerUrl = apiServerUrl,
             relayUrl = relayUrl,
             extraApiUrls = extraApiUrls,
+            dashboardUrl = activeConnection.value?.resolvedDashboardUrl,
         ),
         existing = activeConnection.value?.routeCandidates.orEmpty(),
     )
@@ -4686,17 +4690,21 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                             } else {
                                 current.dashboardUrl
                             }
+                        val newRouteCandidates = Connection.reconcileDashboardRoutes(
+                            dashboardUrl = newDashboardUrl,
+                            candidates = payload.endpoints.orEmpty(),
+                        )
                         val needsUpdate = current.apiServerUrl != payload.serverUrl ||
                             current.relayUrl != newRelayUrl ||
                             current.dashboardUrl != newDashboardUrl ||
-                            current.routeCandidates != payload.endpoints.orEmpty()
+                            current.routeCandidates != newRouteCandidates
                         if (needsUpdate) {
                             connectionStore.updateConnection(
                                 current.copy(
                                     apiServerUrl = payload.serverUrl,
                                     relayUrl = newRelayUrl,
                                     dashboardUrl = newDashboardUrl,
-                                    routeCandidates = payload.endpoints.orEmpty(),
+                                    routeCandidates = newRouteCandidates,
                                     preferredRouteRole = current.preferredRouteRole
                                         ?.takeIf { preferred ->
                                             payload.endpoints.orEmpty().any {
@@ -4927,6 +4935,22 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                     current.copy(
                         label = nextLabel,
                         dashboardUrl = normalized,
+                        routeCandidates = Connection.reconcileDashboardRoutes(
+                            dashboardUrl = normalized,
+                            candidates = current.routeCandidates.ifEmpty {
+                                listOfNotNull(
+                                    Connection.endpointCandidateFromDashboardUrl(
+                                        role = Connection.inferRouteRole(normalized),
+                                        priority = 0,
+                                        dashboardUrl = normalized,
+                                        apiServerUrl = current.apiServerUrl
+                                            .takeIf { it.isNotBlank() },
+                                        relayUrl = current.relayUrl
+                                            .takeIf { it.isNotBlank() },
+                                    ),
+                                )
+                            },
+                        ),
                     ),
                 )
                 probeStandardVoice()
@@ -6116,16 +6140,6 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
     ) {
         val activeId = connectionStore.activeConnectionId.value ?: return
         val current = connectionStore.connections.value.firstOrNull { it.id == activeId } ?: return
-        val nextRouteCandidates = routeCandidates ?: current.routeCandidates
-        val nextPreferredRouteRole = when {
-            preferredRouteRole != null -> preferredRouteRole.takeIf { it.isNotBlank() }
-            routeCandidates != null &&
-                current.preferredRouteRole != null &&
-                nextRouteCandidates.none {
-                    it.role.equals(current.preferredRouteRole, ignoreCase = true)
-                } -> null
-            else -> current.preferredRouteRole
-        }
         val nextDashboardUrl = when {
             dashboardUrlOverride != null -> {
                 dashboardUrlOverride
@@ -6138,6 +6152,19 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                 Connection.deriveDefaultDashboardUrl(apiServerUrl)
             }
             else -> current.dashboardUrl
+        }
+        val nextRouteCandidates = Connection.reconcileDashboardRoutes(
+            dashboardUrl = nextDashboardUrl,
+            candidates = routeCandidates ?: current.routeCandidates,
+        )
+        val nextPreferredRouteRole = when {
+            preferredRouteRole != null -> preferredRouteRole.takeIf { it.isNotBlank() }
+            routeCandidates != null &&
+                current.preferredRouteRole != null &&
+                nextRouteCandidates.none {
+                    it.role.equals(current.preferredRouteRole, ignoreCase = true)
+                } -> null
+            else -> current.preferredRouteRole
         }
         if (
             current.apiServerUrl == apiServerUrl &&

--- a/app/src/test/kotlin/com/hermesandroid/relay/data/ConnectionDashboardFieldsTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/data/ConnectionDashboardFieldsTest.kt
@@ -112,6 +112,75 @@ class ConnectionDashboardFieldsTest {
     }
 
     @Test
+    fun buildRouteCandidates_preservesExplicitSameHostHttpsDashboard() {
+        val routes = Connection.buildRouteCandidates(
+            apiServerUrl = "https://hermes.example.com:8643",
+            relayUrl = "wss://hermes.example.com:8767",
+            dashboardUrl = "https://hermes.example.com:443",
+        )
+
+        assertEquals(1, routes.size)
+        assertEquals("https://hermes.example.com:443", routes.single().dashboard?.url)
+        assertEquals("https://hermes.example.com:8643", routes.single().api?.url)
+    }
+
+    @Test
+    fun reconcileDashboardRoutes_repairsStoredSameHostDerivedPort() {
+        val stored = Connection.buildRouteCandidates(
+            apiServerUrl = "https://hermes.example.com:8643",
+            relayUrl = "wss://hermes.example.com:8767",
+        )
+
+        val repaired = Connection.reconcileDashboardRoutes(
+            dashboardUrl = "https://hermes.example.com:443",
+            candidates = stored,
+        )
+
+        assertEquals("https://hermes.example.com:443", repaired.single().dashboard?.url)
+    }
+
+    @Test
+    fun reconcileDashboardRoutes_keepsDifferentHostRoamingDashboard() {
+        val stored = Connection.buildRouteCandidates(
+            apiServerUrl = "http://100.71.8.56:8642",
+            relayUrl = "ws://100.71.8.56:8767",
+        )
+
+        val repaired = Connection.reconcileDashboardRoutes(
+            dashboardUrl = "https://hermes.example.com:443",
+            candidates = stored,
+        )
+
+        assertEquals("http://100.71.8.56:9119", repaired.single().dashboard?.url)
+    }
+
+    @Test
+    fun persistedSecureDashboard_repairsDerivedGatewayRouteOnReload() {
+        val stored = Connection(
+            id = "conn-https",
+            label = "Secure Hermes",
+            apiServerUrl = "https://hermes.example.com:8643",
+            relayUrl = "wss://hermes.example.com:8767",
+            tokenStoreKey = "hermes_auth_https",
+            dashboardUrl = "https://hermes.example.com:443",
+            routeCandidates = Connection.buildRouteCandidates(
+                apiServerUrl = "https://hermes.example.com:8643",
+                relayUrl = "wss://hermes.example.com:8767",
+            ),
+        )
+
+        val reloaded = json.decodeFromString<Connection>(
+            json.encodeToString(Connection.serializer(), stored),
+        ).withDashboardDefaults()
+
+        assertEquals("https://hermes.example.com:443", reloaded.dashboardUrl)
+        assertEquals(
+            "https://hermes.example.com:443",
+            reloaded.routeCandidates.single().dashboard?.url,
+        )
+    }
+
+    @Test
     fun dashboardRouteBuilder_acceptsBareTailscaleHostWithoutOptionalSurfaces() {
         val route = Connection.endpointCandidateFromDashboardUrl(
             role = "",

--- a/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
@@ -4,6 +4,7 @@ import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import javax.net.ssl.SSLException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -60,6 +61,15 @@ class RelayErrorClassifierTest {
 
         assertEquals("Session expired", err.title)
         assertTrue(err.body.contains("re-pair", ignoreCase = true))
+        assertEquals(HumanErrorAction.Repair, err.action)
+    }
+
+    @Test
+    fun certificateMismatchExposesRepairAction() {
+        val err = classifyError(SSLException("certificate changed"))
+
+        assertEquals("Certificate mismatch", err.title)
+        assertEquals(HumanErrorAction.Repair, err.action)
     }
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/EffectiveDashboardRouteTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/EffectiveDashboardRouteTest.kt
@@ -54,7 +54,25 @@ class EffectiveDashboardRouteTest {
     }
 
     @Test
-    fun `selected API-only route derives dashboard even when primary dashboard is explicit`() {
+    fun `selected API-only route keeps explicit same-host secure dashboard`() {
+        val connection = connection(
+            dashboardUrl = "https://hermes.example.com:443",
+            apiServerUrl = "https://hermes.example.com:8643",
+        )
+        val fallback = EndpointCandidate(
+            role = "public",
+            priority = 1,
+            api = ApiEndpoint("hermes.example.com", 8643, tls = true),
+        )
+
+        assertEquals(
+            "https://hermes.example.com:443",
+            resolveEffectiveDashboardUrl(connection, fallback),
+        )
+    }
+
+    @Test
+    fun `selected API-only route derives dashboard for a different route host`() {
         val connection = connection(
             dashboardUrl = "http://192.168.1.20:9119",
             apiServerUrl = "http://192.168.1.20:8642",


### PR DESCRIPTION
## Summary

- preserve a verified same-host Dashboard/Gateway origin such as `https://host:443` when API fallback routes are rebuilt
- repair older persisted candidates that synthesized an unreachable `:9119` Dashboard while retaining explicit different-host LAN/Tailscale routes
- reconcile Dashboard routes across setup, reload, URL persistence, and pairing payload updates
- make the chat session-expired/certificate-mismatch **Re-pair** snackbar action open targeted recovery

## Root cause

The connection retained the correct HTTPS Dashboard URL, but API-derived route candidates always synthesized a Dashboard URL on port 9119. Route selection preferred that candidate, so standard Gateway traffic missed the reachable reverse-proxy origin and chat could appear to work only through the optional API fallback.

Current unmodified upstream `hermes-agent` exposes standard Dashboard/Gateway chat at the Dashboard origin (`/api/ws`) and liveness at `/api/status`; it does not require Android to invent an externally reachable port 9119 route.

## Validation

- `./gradlew testSideloadDebugUnitTest --tests "com.hermesandroid.relay.data.ConnectionDashboardFieldsTest" --tests "com.hermesandroid.relay.viewmodel.EffectiveDashboardRouteTest" --tests "com.hermesandroid.relay.util.RelayErrorClassifierTest" --tests "com.hermesandroid.relay.data.ConnectionRouteCandidateMergeTest" --tests "com.hermesandroid.relay.data.ConnectionUrlInputNormalizationTest" --no-daemon`
- `./gradlew lint assembleSideloadDebug --no-daemon`
- `git diff --check`

No trust-all TLS, hostname-verifier bypass, silent certificate acceptance, hardcoded deployment URL, version change, or server/fork dependency was added.

Closes #249