### PR TITLE
release(server): server-v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Windows-trusted certificates work in the desktop CLI.** The packaged Windows binary and newer Node runtimes add the Windows certificate store without dropping bundled or operator-supplied roots, while TLS verification and Relay certificate pinning remain enforced.
 
+## [1.5.0] - 2026-08-02
+
+### Added
+
+- **Realtime Agent sessions can speak only settled answers.** Clients may enable an optional per-session `final_answer_only` policy that suppresses routine acknowledgements, progress narration, and intermediate commentary while preserving spoken approvals, confirmation questions, blocking failures, and the final Hermes answer.
+- **Agents can draft native Android plugin pages through Relay.** New tools store bounded declarative JSON pages under the authenticated Relay plugin namespace, while Android retains control of enablement, publication, write grants, and persistent removal. Generated pages cannot include executable code, arbitrary network calls, Android intents, or backend action requests.
+
 ## [Android 1.5.2] - 2026-07-28
 
 ### Fixed

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,22 +1,17 @@
-# Hermes-Relay-Plugin v__VERSION__
+# Hermes-Relay-Server v__VERSION__
 
-**Release Date:** July 22, 2026
+**Release Date:** August 2, 2026
 
-This patch hardens Relay authorization, adds upstream-aware diagnostics, and keeps plugin bootstrap work off the Gateway event loop.
+This release adds Realtime Agent final-answer-only speech and Relay-hosted declarative plugin pages for Android.
 
-It can accompany Hermes-Relay-Android v1.5.0 for optional Relay diagnostics and power features. Standard chat and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
+Android clients can keep voice progress visual until the settled answer and review agent-created native plugin pages before keeping them. Standard chat and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
 
 ## What's changed
 
 ### Added
 
-- **Upstream-aware Gateway diagnostics.** Doctor and `/relay/info` expose optional health, configuration-route, and capability signals so clients can explain compatibility gaps without treating an older upstream install as a broken Relay.
-
-### Fixed
-
-- **Privileged Relay paths enforce host authorization and active grants.** Pairing, Android bridge, terminal, session policy, remote profile configuration, and voice provider origins retain their intended trust boundaries.
-- **Plugin bootstrap remains responsive.** Database initialization and compatibility inspection run outside the Gateway event loop while preserving compatibility with older upstream bootstrap contracts.
-- **Windows Gateway detection is non-signalling.** Starting Relay and periodic profile rescans no longer risk terminating an existing Gateway process.
+- **Realtime Agent final-answer-only speech.** Session creation accepts an optional `final_answer_only` flag. When enabled, the provider skips routine acknowledgements, spoken progress, service updates, and intermediate commentary, then speaks the settled Hermes answer. Approval and confirmation prompts, along with blocking failures, remain audible so required user action is not hidden.
+- **Agent-created declarative Android plugin pages.** New Relay tools create bounded JSON-only drafts and expose them through authenticated plugin routes. Android owns enablement, write grants, exact-revision approval, publication, and persistent removal. Generated pages reject executable code, arbitrary network requests, Android intents, traversal, symlink entries, oversized documents, and backend action requests.
 
 ## Install / update
 
@@ -24,7 +19,7 @@ It can accompany Hermes-Relay-Android v1.5.0 for optional Relay diagnostics and 
     hermes plugins install Codename-11/hermes-relay/plugin --enable
 
     # Classic install / update on a systemd host:
-    curl -fsSL https://raw.githubusercontent.com/Codename-11/hermes-relay/main/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/Codename-11/hermes-relay/server-v__VERSION__/install.sh | bash
     # or, if already installed:
     hermes-relay-update
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -16,6 +16,10 @@ from .tools.desktop_tool import (
     _HANDLERS as _DESKTOP_HANDLERS,
     _check_tool as _desktop_check_tool,
 )
+from .tools.relay_plugin_tool import (
+    _SCHEMAS as _RELAY_PLUGIN_SCHEMAS,
+    _HANDLERS as _RELAY_PLUGIN_HANDLERS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +51,18 @@ def register(ctx):
             schema=schema,
             handler=_DESKTOP_HANDLERS[tool_name],
             check_fn=_make_desktop_check(tool_name),
+        )
+
+    # Declarative Android pages live on the Hermes host and need no paired
+    # device or relay process. They remain available for authoring/inspection
+    # whenever this plugin is loaded.
+    for tool_name, schema in _RELAY_PLUGIN_SCHEMAS.items():
+        ctx.register_tool(
+            name=tool_name,
+            toolset="relay",
+            schema=schema,
+            handler=_RELAY_PLUGIN_HANDLERS[tool_name],
+            check_fn=lambda: True,
         )
 
     # Register the in-session `/relay` slash command (status/devices/pair) and

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Relay",
   "description": "Paired devices, bridge activity, media inspection, and remote access for hermes-relay",
   "icon": "Activity",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/mobile_plugin_api.py
+++ b/plugin/dashboard/mobile_plugin_api.py
@@ -1,0 +1,114 @@
+"""Authenticated dashboard routes for declarative Android plugin pages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, HTTPException, Path
+
+from ..mobile_plugin_store import (
+    MobilePluginConflictError,
+    MobilePluginNotFoundError,
+    MobilePluginStore,
+    MobilePluginStoreError,
+)
+
+
+router = APIRouter(prefix="/mobile")
+
+
+def _store() -> MobilePluginStore:
+    return MobilePluginStore()
+
+
+def _bad_request(exc: MobilePluginStoreError) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/manifest")
+async def get_mobile_manifest() -> dict[str, Any]:
+    return _store().manifest()
+
+
+@router.get("/pages/{plugin_id}")
+async def get_mobile_page(plugin_id: str = Path(...)) -> dict[str, Any]:
+    try:
+        entry = _store().get(plugin_id)
+        document = dict(entry["document"])
+        document["host_revision"] = entry.get("revision", 1)
+        return document
+    except MobilePluginStoreError as exc:
+        raise _bad_request(exc) from exc
+    except MobilePluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="mobile plugin not found") from exc
+
+
+@router.get("/plugins")
+async def list_mobile_plugins() -> dict[str, Any]:
+    return {"plugins": _store().list()}
+
+
+@router.get("/plugins/{plugin_id}")
+async def get_mobile_plugin(plugin_id: str = Path(...)) -> dict[str, Any]:
+    try:
+        return _store().get(plugin_id)
+    except MobilePluginStoreError as exc:
+        raise _bad_request(exc) from exc
+    except MobilePluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="mobile plugin not found") from exc
+
+
+@router.put("/plugins/{plugin_id}/draft")
+async def put_mobile_plugin_draft(
+    plugin_id: str = Path(...),
+    body: dict[str, Any] = Body(default_factory=dict),
+) -> dict[str, Any]:
+    try:
+        return _store().draft(
+            plugin_id,
+            title=body.get("title", ""),
+            description=body.get("description", ""),
+            document=body.get("document"),
+            lifecycle=body.get("lifecycle", "session"),
+        )
+    except (AttributeError, MobilePluginStoreError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/plugins/{plugin_id}/promote")
+async def promote_mobile_plugin(
+    plugin_id: str = Path(...),
+    body: dict[str, Any] = Body(default_factory=dict),
+) -> dict[str, Any]:
+    try:
+        expected_digest = body.get("expected_digest")
+        if not isinstance(expected_digest, str) or not expected_digest:
+            raise MobilePluginStoreError("expected_digest is required")
+        return _store().publish(plugin_id, expected_digest=expected_digest)
+    except MobilePluginConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except MobilePluginStoreError as exc:
+        raise _bad_request(exc) from exc
+    except MobilePluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="mobile plugin not found") from exc
+
+
+@router.post("/plugins/{plugin_id}/remove")
+async def delete_mobile_plugin(
+    plugin_id: str = Path(...),
+    body: dict[str, Any] = Body(default_factory=dict),
+) -> dict[str, Any]:
+    try:
+        expected_digest = body.get("expected_digest")
+        if not isinstance(expected_digest, str) or not expected_digest:
+            raise MobilePluginStoreError("expected_digest is required")
+        return _store().remove(plugin_id, expected_digest=expected_digest)
+    except MobilePluginConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except MobilePluginStoreError as exc:
+        raise _bad_request(exc) from exc
+    except MobilePluginNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="mobile plugin not found") from exc
+
+
+__all__ = ["router"]

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/dashboard/plugin_api.py
+++ b/plugin/dashboard/plugin_api.py
@@ -139,6 +139,7 @@ def _validate_public_url(url: str) -> str:
 
 
 router = APIRouter()
+router.include_router(_plugin_module("dashboard.mobile_plugin_api").router)
 
 
 def _relay_unreachable(err: Exception) -> HTTPException:

--- a/plugin/dashboard/test_mobile_plugin_api.py
+++ b/plugin/dashboard/test_mobile_plugin_api.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from plugin.dashboard import plugin_api
+
+
+def _document() -> dict:
+    return {
+        "schemaVersion": 1,
+        "pages": [
+            {
+                "id": "home",
+                "title": {"type": "literal", "value": "Status"},
+                "content": {
+                    "type": "text",
+                    "id": "status",
+                    "text": {"type": "literal", "value": "Ready"},
+                },
+            }
+        ],
+    }
+
+
+class MobilePluginApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.env = patch.dict(os.environ, {"HERMES_HOME": self.temp.name})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        app = FastAPI()
+        app.include_router(plugin_api.router)
+        self.client = TestClient(app)
+
+    def test_draft_manifest_page_promote_list_and_remove(self) -> None:
+        response = self.client.put(
+            "/mobile/plugins/system-status/draft",
+            json={"title": "System Status", "description": "Live health", "document": _document()},
+        )
+        self.assertEqual(200, response.status_code, response.text)
+        self.assertEqual("draft", response.json()["status"])
+        draft_digest = response.json()["digest"]
+
+        manifest = self.client.get("/mobile/manifest").json()
+        self.assertEqual("hermes-relay", manifest["id"])
+        self.assertEqual("draft", manifest["contributions"][0]["status"])
+        loaded_document = self.client.get("/mobile/pages/system-status").json()
+        self.assertEqual(1, loaded_document.pop("host_revision"))
+        self.assertEqual(_document(), loaded_document)
+
+        promoted = self.client.post(
+            "/mobile/plugins/system-status/promote",
+            json={"expected_digest": draft_digest},
+        )
+        self.assertEqual("published", promoted.json()["status"])
+        published_digest = promoted.json()["digest"]
+        listing = self.client.get("/mobile/plugins").json()["plugins"]
+        self.assertEqual("published", listing[0]["status"])
+        self.assertNotIn("document", listing[0])
+
+        removed = self.client.post(
+            "/mobile/plugins/system-status/remove",
+            json={"expected_digest": published_digest},
+        )
+        self.assertEqual({"ok": True, "id": "system-status"}, removed.json())
+        self.assertEqual([], self.client.get("/mobile/manifest").json()["contributions"])
+
+    def test_traversal_and_bad_document_are_rejected(self) -> None:
+        traversal = self.client.put(
+            "/mobile/plugins/..%5Coutside/draft",
+            json={"title": "Bad", "document": _document()},
+        )
+        self.assertEqual(400, traversal.status_code)
+
+        bad_document = self.client.put(
+            "/mobile/plugins/bad/draft",
+            json={"title": "Bad", "document": {"schemaVersion": 1, "pages": []}},
+        )
+        self.assertEqual(400, bad_document.status_code)
+
+    def test_promote_rejects_a_stale_review_digest(self) -> None:
+        first = self.client.put(
+            "/mobile/plugins/changing/draft",
+            json={"title": "First", "document": _document()},
+        ).json()
+        self.client.put(
+            "/mobile/plugins/changing/draft",
+            json={"title": "Changed", "document": _document()},
+        )
+
+        response = self.client.post(
+            "/mobile/plugins/changing/promote",
+            json={"expected_digest": first["digest"]},
+        )
+
+        self.assertEqual(409, response.status_code)
+        listing = self.client.get("/mobile/plugins").json()["plugins"]
+        self.assertEqual("draft", listing[0]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/mobile_plugin_store.py
+++ b/plugin/mobile_plugin_store.py
@@ -1,0 +1,343 @@
+"""Durable store for bounded, declarative Android plugin pages.
+
+Documents are JSON data only. They cannot contain executable code, URLs, Android
+intents, or an alternate backend namespace; Android remains the renderer and
+authority boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+
+PLUGIN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+MAX_DOCUMENT_BYTES = 512 * 1024
+ALLOWED_LIFECYCLES = frozenset({"session", "persistent"})
+ALLOWED_ELEMENT_TYPES = frozenset(
+    {
+        "group",
+        "card",
+        "text",
+        "badge",
+        "button",
+        "text_input",
+        "toggle",
+        "progress",
+        "image",
+        "divider",
+        "spacer",
+    }
+)
+
+
+class MobilePluginStoreError(ValueError):
+    """A caller supplied an invalid id, lifecycle, or declarative document."""
+
+
+class MobilePluginNotFoundError(FileNotFoundError):
+    """The requested generated plugin does not exist."""
+
+
+class MobilePluginConflictError(MobilePluginStoreError):
+    """The reviewed draft changed before the user-approved mutation."""
+
+
+def hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+class MobilePluginStore:
+    def __init__(self, root: Optional[Path] = None) -> None:
+        self.root = root or hermes_home() / "mobile-plugins"
+
+    def draft(
+        self,
+        plugin_id: str,
+        *,
+        title: str,
+        description: str,
+        document: dict[str, Any],
+        lifecycle: str = "session",
+    ) -> dict[str, Any]:
+        plugin_id = self.validate_id(plugin_id)
+        title = title.strip()
+        if not title or len(title) > 120:
+            raise MobilePluginStoreError("title must contain 1 to 120 characters")
+        description = description.strip()
+        if len(description) > 1_000:
+            raise MobilePluginStoreError("description must not exceed 1000 characters")
+        if lifecycle not in ALLOWED_LIFECYCLES:
+            raise MobilePluginStoreError("lifecycle must be session or persistent")
+        self.validate_document(document)
+
+        now = int(time.time())
+        prior = self._read(plugin_id, required=False)
+        if prior.get("status") == "published":
+            raise MobilePluginConflictError(
+                "published plugins cannot be replaced by an agent draft; remove it in Android first"
+            )
+        entry = {
+            "id": plugin_id,
+            "title": title,
+            "description": description,
+            "status": "draft",
+            "lifecycle": lifecycle,
+            "document": document,
+            "created_at": prior.get("created_at", now) if prior else now,
+            "updated_at": now,
+            "published_at": prior.get("published_at") if prior else None,
+            "revision": int(prior.get("revision", 0)) + 1 if prior else 1,
+        }
+        entry["digest"] = self._digest(entry)
+        self._write(plugin_id, entry)
+        return entry
+
+    def publish(self, plugin_id: str, *, expected_digest: Optional[str] = None) -> dict[str, Any]:
+        entry = self.get(plugin_id)
+        self._require_digest(entry, expected_digest)
+        now = int(time.time())
+        entry["status"] = "published"
+        entry["lifecycle"] = "persistent"
+        entry["updated_at"] = now
+        entry["published_at"] = now
+        entry["revision"] = int(entry.get("revision", 0)) + 1
+        entry["digest"] = self._digest(entry)
+        self._write(entry["id"], entry)
+        return entry
+
+    def remove(self, plugin_id: str, *, expected_digest: Optional[str] = None) -> dict[str, Any]:
+        plugin_id = self.validate_id(plugin_id)
+        if expected_digest is not None:
+            self._require_digest(self.get(plugin_id), expected_digest)
+        path = self._path(plugin_id)
+        try:
+            path.unlink()
+        except FileNotFoundError as exc:
+            raise MobilePluginNotFoundError(plugin_id) from exc
+        return {"ok": True, "id": plugin_id}
+
+    def get(self, plugin_id: str) -> dict[str, Any]:
+        return self._read(self.validate_id(plugin_id), required=True)
+
+    def list(self) -> list[dict[str, Any]]:
+        if not self.root.is_dir():
+            return []
+        entries: list[dict[str, Any]] = []
+        for path in sorted(self.root.glob("*.json")):
+            if not PLUGIN_ID_RE.fullmatch(path.stem):
+                continue
+            entry = self._read(path.stem, required=False)
+            if entry:
+                entries.append({k: v for k, v in entry.items() if k != "document"})
+        return entries
+
+    def manifest(self) -> dict[str, Any]:
+        contributions = []
+        for summary in self.list():
+            is_draft = summary["status"] == "draft"
+            contributions.append(
+                {
+                    "id": summary["id"],
+                    "surface": "page",
+                    "title": f"Draft: {summary['title']}" if is_draft else summary["title"],
+                    "description": summary.get("description", ""),
+                    "lifecycle": summary.get("lifecycle", "session"),
+                    "status": summary["status"],
+                    "revision": summary.get("revision", 1),
+                    "digest": summary.get("digest", ""),
+                    "document": {
+                        "method": "GET",
+                        "path": f"mobile/pages/{summary['id']}",
+                    },
+                }
+            )
+        return {
+            "schema_version": 1,
+            "id": "hermes-relay",
+            "display_name": "Relay Plugins",
+            "description": "Declarative pages created for Hermes Android",
+            "min_host_api": 1,
+            "default_enabled": False,
+            "contributions": contributions,
+            "requested_capabilities": [
+                {
+                    "id": "plugin.api.write",
+                    "reason": "Keep or remove generated plugin pages after your approval",
+                    "required": False,
+                }
+            ],
+            "updates": {"poll_seconds": 5},
+        }
+
+    @staticmethod
+    def validate_id(plugin_id: str) -> str:
+        normalized = str(plugin_id).strip().lower()
+        if not PLUGIN_ID_RE.fullmatch(normalized):
+            raise MobilePluginStoreError("invalid plugin id")
+        return normalized
+
+    @staticmethod
+    def validate_document(document: dict[str, Any]) -> None:
+        if not isinstance(document, dict):
+            raise MobilePluginStoreError("document must be a JSON object")
+        version = document.get("schemaVersion", document.get("schema_version"))
+        if version != 1:
+            raise MobilePluginStoreError("document schemaVersion must be 1")
+        pages = document.get("pages")
+        if not isinstance(pages, list) or not 1 <= len(pages) <= 32:
+            raise MobilePluginStoreError("document pages must contain 1 to 32 entries")
+        seen_ids: set[str] = set()
+        element_count = [0]
+        for page in pages:
+            if not isinstance(page, dict) or not PLUGIN_ID_RE.fullmatch(str(page.get("id", ""))):
+                raise MobilePluginStoreError("every page requires a safe id")
+            if not isinstance(page.get("title"), dict):
+                raise MobilePluginStoreError("every page requires a declarative title")
+            MobilePluginStore._validate_element(
+                page.get("content"),
+                depth=1,
+                seen_ids=seen_ids,
+                count=element_count,
+            )
+        if MobilePluginStore._contains_action_request(document):
+            raise MobilePluginStoreError(
+                "generated documents cannot contain action.request; backend actions require "
+                "a separately installed plugin"
+            )
+        encoded = json.dumps(document, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        if len(encoded) > MAX_DOCUMENT_BYTES:
+            raise MobilePluginStoreError(
+                f"document exceeds the {MAX_DOCUMENT_BYTES}-byte limit"
+            )
+
+    @staticmethod
+    def _contains_action_request(value: Any) -> bool:
+        if isinstance(value, dict):
+            action = value.get("action")
+            if isinstance(action, dict) and action.get("request") is not None:
+                return True
+            return any(MobilePluginStore._contains_action_request(child) for child in value.values())
+        if isinstance(value, list):
+            return any(MobilePluginStore._contains_action_request(child) for child in value)
+        return False
+
+    @staticmethod
+    def _validate_element(
+        element: Any,
+        *,
+        depth: int,
+        seen_ids: set[str],
+        count: list[int],
+    ) -> None:
+        if not isinstance(element, dict):
+            raise MobilePluginStoreError("every page requires a declarative content element")
+        if depth > 16:
+            raise MobilePluginStoreError("document element depth exceeds 16")
+        element_id = str(element.get("id", ""))
+        if not PLUGIN_ID_RE.fullmatch(element_id):
+            raise MobilePluginStoreError("every element requires a safe id")
+        if element_id in seen_ids:
+            raise MobilePluginStoreError(f"duplicate element id: {element_id}")
+        seen_ids.add(element_id)
+        element_type = element.get("type")
+        if element_type not in ALLOWED_ELEMENT_TYPES:
+            raise MobilePluginStoreError(f"unsupported element type: {element_type}")
+        count[0] += 1
+        if count[0] > 500:
+            raise MobilePluginStoreError("document exceeds 500 elements")
+        if element_type == "group":
+            children = element.get("children")
+            if not isinstance(children, list) or len(children) > 100:
+                raise MobilePluginStoreError("group children must be an array of at most 100 elements")
+            for child in children:
+                MobilePluginStore._validate_element(
+                    child,
+                    depth=depth + 1,
+                    seen_ids=seen_ids,
+                    count=count,
+                )
+        elif element_type == "card":
+            MobilePluginStore._validate_element(
+                element.get("child"),
+                depth=depth + 1,
+                seen_ids=seen_ids,
+                count=count,
+            )
+
+    def _path(self, plugin_id: str) -> Path:
+        path = self.root / f"{plugin_id}.json"
+        if path.is_symlink():
+            raise MobilePluginStoreError("symbolic-link plugin entries are not allowed")
+        return path
+
+    @staticmethod
+    def _digest(entry: dict[str, Any]) -> str:
+        covered = {
+            key: entry.get(key)
+            for key in ("id", "title", "description", "status", "lifecycle", "document", "revision")
+        }
+        payload = json.dumps(
+            covered,
+            separators=(",", ":"),
+            sort_keys=True,
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    @staticmethod
+    def _require_digest(entry: dict[str, Any], expected_digest: Optional[str]) -> None:
+        if expected_digest is not None and entry.get("digest") != expected_digest:
+            raise MobilePluginConflictError("plugin changed after it was reviewed")
+
+    def _read(self, plugin_id: str, *, required: bool) -> dict[str, Any]:
+        try:
+            data = json.loads(self._path(plugin_id).read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            if required:
+                raise MobilePluginNotFoundError(plugin_id)
+            return {}
+        except (OSError, ValueError, json.JSONDecodeError):
+            if required:
+                raise MobilePluginNotFoundError(plugin_id)
+            return {}
+        if not isinstance(data, dict) or data.get("id") != plugin_id:
+            if required:
+                raise MobilePluginNotFoundError(plugin_id)
+            return {}
+        return data
+
+    def _write(self, plugin_id: str, entry: dict[str, Any]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        path = self._path(plugin_id)
+        tmp = path.with_suffix(".json.tmp")
+        if tmp.is_symlink():
+            raise MobilePluginStoreError("symbolic-link temporary entries are not allowed")
+        payload = json.dumps(entry, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        try:
+            with tmp.open("w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            if os.name != "nt":
+                os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        finally:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
+
+
+__all__ = [
+    "MAX_DOCUMENT_BYTES",
+    "MobilePluginNotFoundError",
+    "MobilePluginConflictError",
+    "MobilePluginStore",
+    "MobilePluginStoreError",
+]

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,6 +1,6 @@
 name: hermes-relay
 manifest_version: 1
-version: 1.4.3
+version: 1.5.0
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 # All three are OPTIONAL — only needed if you use the relay's extra /

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -82,6 +82,10 @@ provides_tools:
   - desktop_computer_action
   - desktop_computer_grant_request
   - desktop_computer_cancel
+  - relay_plugin_draft
+  - relay_plugin_publish
+  - relay_plugin_remove
+  - relay_plugin_list
 # Gateway platforms this plugin registers programmatically via
 # ctx.register_platform() in register(). Documentation parity with
 # provides_tools — the plugin stays kind=standalone (multi-capability),

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # Desktop releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.4.3"
+__version__ = "1.5.0"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/plugin/tests/test_mobile_plugin_store.py
+++ b/plugin/tests/test_mobile_plugin_store.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from plugin.mobile_plugin_store import (
+    MobilePluginNotFoundError,
+    MobilePluginStore,
+    MobilePluginStoreError,
+)
+
+
+def _document(label: str = "Hello") -> dict:
+    return {
+        "schemaVersion": 1,
+        "pages": [
+            {
+                "id": "home",
+                "title": {"type": "literal", "value": label},
+                "content": {
+                    "type": "text",
+                    "id": "welcome",
+                    "text": {"type": "literal", "value": label},
+                },
+            }
+        ],
+    }
+
+
+class MobilePluginStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.store = MobilePluginStore(Path(self.temp.name) / "mobile-plugins")
+
+    def test_draft_manifest_page_publish_remove_lifecycle(self) -> None:
+        draft = self.store.draft(
+            "daily-brief",
+            title="Daily Brief",
+            description="A reactive morning page",
+            document=_document(),
+        )
+        self.assertEqual("draft", draft["status"])
+        self.assertEqual("session", draft["lifecycle"])
+
+        manifest = self.store.manifest()
+        self.assertEqual("hermes-relay", manifest["id"])
+        contribution = manifest["contributions"][0]
+        self.assertEqual("Draft: Daily Brief", contribution["title"])
+        self.assertEqual("mobile/pages/daily-brief", contribution["document"]["path"])
+        self.assertEqual(_document(), self.store.get("daily-brief")["document"])
+
+        published = self.store.publish("daily-brief")
+        self.assertEqual("published", published["status"])
+        self.assertEqual("Daily Brief", self.store.manifest()["contributions"][0]["title"])
+
+        self.assertEqual({"ok": True, "id": "daily-brief"}, self.store.remove("daily-brief"))
+        self.assertEqual([], self.store.list())
+        with self.assertRaises(MobilePluginNotFoundError):
+            self.store.get("daily-brief")
+
+    def test_rejects_traversal_invalid_schema_and_empty_pages(self) -> None:
+        for plugin_id in ("../outside", "nested/name", "x\\y", ".hidden"):
+            with self.subTest(plugin_id=plugin_id):
+                with self.assertRaises(MobilePluginStoreError):
+                    self.store.draft(plugin_id, title="Bad", description="", document=_document())
+
+        with self.assertRaisesRegex(MobilePluginStoreError, "schemaVersion"):
+            self.store.draft(
+                "bad-schema",
+                title="Bad",
+                description="",
+                document={"schemaVersion": 2, "pages": [{}]},
+            )
+        with self.assertRaisesRegex(MobilePluginStoreError, "1 to 32"):
+            self.store.draft(
+                "no-pages",
+                title="Bad",
+                description="",
+                document={"schemaVersion": 1, "pages": []},
+            )
+
+    def test_listing_omits_document_payload(self) -> None:
+        self.store.draft("compact", title="Compact", description="", document=_document())
+        self.assertNotIn("document", self.store.list()[0])
+
+    def test_agent_draft_cannot_replace_a_published_plugin(self) -> None:
+        draft = self.store.draft(
+            "protected",
+            title="Protected",
+            description="",
+            document=_document("First"),
+        )
+        self.store.publish("protected", expected_digest=draft["digest"])
+
+        with self.assertRaisesRegex(MobilePluginStoreError, "cannot be replaced"):
+            self.store.draft(
+                "protected",
+                title="Changed",
+                description="",
+                document=_document("Changed"),
+            )
+
+        self.assertEqual("published", self.store.get("protected")["status"])
+        self.assertEqual(_document("First"), self.store.get("protected")["document"])
+
+    def test_rejects_embedded_backend_action_requests(self) -> None:
+        document = _document()
+        document["pages"][0]["content"] = {
+            "type": "button",
+            "id": "privileged-action",
+            "label": {"type": "literal", "value": "Enable"},
+            "action": {
+                "id": "enable",
+                "request": {
+                    "method": "POST",
+                    "path": "remote-access/tailscale/enable",
+                },
+            },
+        }
+
+        with self.assertRaisesRegex(MobilePluginStoreError, "action.request"):
+            self.store.draft(
+                "unsafe-action",
+                title="Unsafe",
+                description="",
+                document=document,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/tests/test_relay_plugin_tool.py
+++ b/plugin/tests/test_relay_plugin_tool.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from plugin.tools.relay_plugin_tool import (
+    relay_plugin_draft,
+    relay_plugin_list,
+    relay_plugin_publish,
+    relay_plugin_remove,
+)
+
+
+class RelayPluginToolTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.env = patch.dict(os.environ, {"HERMES_HOME": self.temp.name})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.document = {
+            "schemaVersion": 1,
+            "pages": [
+                {
+                    "id": "home",
+                    "title": {"type": "literal", "value": "Tool Page"},
+                    "content": {
+                        "type": "text",
+                        "id": "message",
+                        "text": {"type": "literal", "value": "Ready"},
+                    },
+                }
+            ],
+        }
+
+    def test_agent_tool_lifecycle(self) -> None:
+        drafted = relay_plugin_draft("tool-page", "Tool Page", self.document)
+        self.assertEqual("draft", drafted["status"])
+        self.assertEqual("tool-page", relay_plugin_list()["plugins"][0]["id"])
+        publish = relay_plugin_publish("tool-page")
+        self.assertTrue(publish["approval_required"])
+        self.assertEqual("draft", relay_plugin_list()["plugins"][0]["status"])
+        self.assertTrue(relay_plugin_remove("tool-page")["ok"])
+
+    def test_invalid_document_returns_structured_error(self) -> None:
+        result = relay_plugin_draft("bad", "Bad", {"schemaVersion": 1, "pages": []})
+        self.assertIn("error", result)
+
+    def test_persistent_draft_removal_requires_user_approval(self) -> None:
+        relay_plugin_draft(
+            "persistent-page",
+            "Persistent",
+            self.document,
+            lifecycle="persistent",
+        )
+
+        result = relay_plugin_remove("persistent-page")
+
+        self.assertTrue(result["approval_required"])
+        self.assertEqual("persistent-page", relay_plugin_list()["plugins"][0]["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/tools/relay_plugin_tool.py
+++ b/plugin/tools/relay_plugin_tool.py
@@ -1,0 +1,164 @@
+"""Agent-visible tools for creating bounded declarative Android plugin pages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..mobile_plugin_store import MobilePluginStore, MobilePluginStoreError
+
+
+def relay_plugin_draft(
+    plugin_id: str,
+    title: str,
+    document: dict[str, Any],
+    description: str = "",
+    lifecycle: str = "session",
+) -> dict[str, Any]:
+    try:
+        return MobilePluginStore().draft(
+            plugin_id,
+            title=title,
+            description=description,
+            document=document,
+            lifecycle=lifecycle,
+        )
+    except (AttributeError, MobilePluginStoreError) as exc:
+        return {"error": str(exc)}
+
+
+def relay_plugin_publish(plugin_id: str) -> dict[str, Any]:
+    try:
+        entry = MobilePluginStore().get(plugin_id)
+    except (OSError, MobilePluginStoreError) as exc:
+        return {"error": str(exc)}
+    return {
+        "approval_required": True,
+        "id": entry["id"],
+        "status": entry["status"],
+        "revision": entry.get("revision"),
+        "digest": entry.get("digest"),
+        "message": "Publishing requires an explicit authenticated Android user action.",
+        "approval_endpoint": f"mobile/plugins/{entry['id']}/promote",
+    }
+
+
+def relay_plugin_remove(plugin_id: str) -> dict[str, Any]:
+    try:
+        store = MobilePluginStore()
+        entry = store.get(plugin_id)
+    except (OSError, MobilePluginStoreError) as exc:
+        return {"error": str(exc)}
+    if entry["status"] == "draft" and entry.get("lifecycle") == "session":
+        return store.remove(plugin_id)
+    return {
+        "approval_required": True,
+        "id": entry["id"],
+        "status": entry["status"],
+        "message": "Removing a published or persistent plugin requires an explicit Android user action.",
+        "revision": entry.get("revision"),
+        "digest": entry.get("digest"),
+        "approval_endpoint": f"mobile/plugins/{entry['id']}/remove",
+    }
+
+
+def relay_plugin_list() -> dict[str, Any]:
+    return {"plugins": MobilePluginStore().list()}
+
+
+_SCHEMAS: dict[str, dict[str, Any]] = {
+    "relay_plugin_draft": {
+        "name": "relay_plugin_draft",
+        "description": (
+            "Create or replace a draft Android plugin page using the bounded "
+            "declarative schema. This stores JSON data only; executable code is not allowed."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "plugin_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$"},
+                "title": {"type": "string", "minLength": 1, "maxLength": 120},
+                "description": {"type": "string", "maxLength": 1000},
+                "lifecycle": {
+                    "type": "string",
+                    "enum": ["session", "persistent"],
+                    "default": "session",
+                },
+                "document": {
+                    "type": "object",
+                    "description": (
+                        "Schema-version-1 PluginDocument JSON. Use schemaVersion=1 and pages. "
+                        "Each page needs id, title ({type: literal, value: ...} or a binding), "
+                        "and content. Supported content types are group, card, text, badge, "
+                        "button, text_input, toggle, progress, image, divider, and spacer. "
+                        "Groups use children; cards use child. Elements need stable unique ids. "
+                        "initialState may hold string/boolean/number/null typed PluginValue objects. "
+                        "Generated documents must not include action.request."
+                    ),
+                    "properties": {
+                        "schemaVersion": {"type": "integer", "const": 1},
+                        "initialState": {"type": "object"},
+                        "pages": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 32,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "title": {"type": "object"},
+                                    "content": {"type": "object"},
+                                },
+                                "required": ["id", "title", "content"],
+                            },
+                        },
+                    },
+                    "required": ["schemaVersion", "pages"],
+                },
+            },
+            "required": ["plugin_id", "title", "document"],
+            "additionalProperties": False,
+        },
+    },
+    "relay_plugin_publish": {
+        "name": "relay_plugin_publish",
+        "description": (
+            "Request publication of a draft Android plugin page. This does not publish "
+            "directly; it returns the authenticated Android approval action required."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {"plugin_id": {"type": "string"}},
+            "required": ["plugin_id"],
+            "additionalProperties": False,
+        },
+    },
+    "relay_plugin_remove": {
+        "name": "relay_plugin_remove",
+        "description": (
+            "Remove a session-scoped draft. Published or persistent entries are not "
+            "changed and return the authenticated Android approval action required."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {"plugin_id": {"type": "string"}},
+            "required": ["plugin_id"],
+            "additionalProperties": False,
+        },
+    },
+    "relay_plugin_list": {
+        "name": "relay_plugin_list",
+        "description": "List draft and published generated Android plugin pages.",
+        "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+}
+
+
+_HANDLERS = {
+    "relay_plugin_draft": lambda args, **kw: relay_plugin_draft(**args),
+    "relay_plugin_publish": lambda args, **kw: relay_plugin_publish(**args),
+    "relay_plugin_remove": lambda args, **kw: relay_plugin_remove(**args),
+    "relay_plugin_list": lambda args, **kw: relay_plugin_list(),
+}
+
+
+__all__ = ["_HANDLERS", "_SCHEMAS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.4.3"
+version = "1.5.0"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- add optional per-session `final_answer_only` behavior for Realtime Agent voice
- add bounded agent-created declarative Android plugin pages, authenticated plugin routes, and approval-gated lifecycle tools
- bump all server/plugin metadata to 1.5.0 and publish scrubbed release notes
- keep the release diff strictly plugin/server-only

## Verification

- `python scripts/check-plugin-version-sync.py`
- `python scripts/check-version-tracks.py`
- release-focused plugin tests: 162 passed, 3 skipped
- dashboard API tests: 26 passed
- full plugin suite: 1,246 passed, 8 skipped; 3 pre-existing session-extension assertions still expect permission broadening where the documented reduction-only policy returns 403
- explicit mobile-plugin boundary checks for traversal, oversized payloads, nesting depth, backend action requests, stale digests, and published replacement
- dashboard `npm ci` + `npm run build`
- wheel/sdist build and `twine check`; wheel contains the new runtime modules

## Scope

No Android app or Desktop files are changed by this PR.