### PR TITLE
fix(plugins): contain generated page paths

### DIFF
--- a/plugin/mobile_plugin_store.py
+++ b/plugin/mobile_plugin_store.py
@@ -271,10 +271,19 @@ class MobilePluginStore:
             )
 
     def _path(self, plugin_id: str) -> Path:
-        path = self.root / f"{plugin_id}.json"
+        safe_id = self.validate_id(plugin_id)
+        root = os.path.realpath(os.fspath(self.root))
+        root_prefix = root.rstrip(os.sep) + os.sep
+        candidate = os.path.normpath(os.path.join(root, f"{safe_id}.json"))
+        if not os.path.normcase(candidate).startswith(os.path.normcase(root_prefix)):
+            raise MobilePluginStoreError("plugin entry escapes the mobile-plugin directory")
+        path = Path(candidate)
         if path.is_symlink():
             raise MobilePluginStoreError("symbolic-link plugin entries are not allowed")
-        return path
+        resolved = os.path.realpath(candidate)
+        if not os.path.normcase(resolved).startswith(os.path.normcase(root_prefix)):
+            raise MobilePluginStoreError("plugin entry escapes the mobile-plugin directory")
+        return Path(resolved)
 
     @staticmethod
     def _digest(entry: dict[str, Any]) -> str:

--- a/plugin/tests/test_mobile_plugin_store.py
+++ b/plugin/tests/test_mobile_plugin_store.py
@@ -128,6 +128,19 @@ class MobilePluginStoreTests(unittest.TestCase):
                 document=document,
             )
 
+    def test_rejects_symbolic_link_entries(self) -> None:
+        self.store.root.mkdir(parents=True)
+        outside = Path(self.temp.name) / "outside.json"
+        outside.write_text("{}", encoding="utf-8")
+        link = self.store.root / "linked.json"
+        try:
+            link.symlink_to(outside)
+        except OSError as exc:
+            self.skipTest(f"symbolic links unavailable: {exc}")
+
+        with self.assertRaisesRegex(MobilePluginStoreError, "symbolic-link"):
+            self.store.get("linked")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- canonicalize generated plugin entry paths beneath the configured mobile-plugin root
- reject lexical or symlink-resolved escapes before any file operation
- retain the existing single-component ID allowlist and explicit symlink rejection
- add focused symlink-entry coverage

## Security context

The strict `dev` to `main` release PR #279 surfaced `py/path-injection` findings for the new mobile plugin store. The original ID regex rejected separators and traversal, but filesystem sinks still consumed a user-derived name without an explicit normalized containment proof. This change adds that proof rather than dismissing the findings.

## Verification

- release-focused plugin suite: 162 passed, 4 skipped on Windows, 4 subtests passed
- mobile store/tool slice: 8 passed, 1 skipped on Windows, 4 subtests passed
- mobile plugin dashboard API: 3 passed
- syntax and whitespace checks pass

The symlink test runs on Linux CI; local Windows skipped it because creating symlinks is unavailable in the current process.