### PR TITLE
fix(android): retry mic lease acquisition to absorb barge-in teardown

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/audio/VoiceRecorder.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/audio/VoiceRecorder.kt
@@ -50,6 +50,13 @@ class VoiceRecorder(
         // implementation so the on-screen meter feels the same.
         private const val NOISE_FLOOR = 0.01f
         private const val SPEECH_CEILING = 0.35f
+
+        /** Attempts to open the mic before giving up on a transient failure. */
+        private const val AUDIO_RECORD_RETRIES = 3
+
+        /** Backoff between [AUDIO_RECORD_RETRIES]; covers the barge-in
+         *  listener's async AudioRecord release window (~1 frame). */
+        private const val AUDIO_RECORD_RETRY_BACKOFF_MS = 50L
     }
 
     private val _amplitude = MutableStateFlow(0f)
@@ -83,21 +90,11 @@ class VoiceRecorder(
                 releaseRecorder()
             }
         }
-        val lease = MicrophoneOwnershipCoordinator.tryAcquire(MicrophoneOwner.VoiceCapture)
-            ?: throw IllegalStateException("Microphone is in use by another voice feature")
-        microphoneLease = lease
-
-        val minBuffer = try {
-            AudioRecord.getMinBufferSize(
+        val minBuffer = AudioRecord.getMinBufferSize(
             SAMPLE_RATE,
             AudioFormat.CHANNEL_IN_MONO,
             AudioFormat.ENCODING_PCM_16BIT,
-            ).coerceAtLeast(SAMPLE_RATE / 10 * BYTES_PER_SAMPLE)
-        } catch (t: Throwable) {
-            MicrophoneOwnershipCoordinator.release(lease)
-            microphoneLease = null
-            throw t
-        }
+        ).coerceAtLeast(SAMPLE_RATE / 10 * BYTES_PER_SAMPLE)
 
         val outFile = File(context.cacheDir, "voice_rec_${System.currentTimeMillis()}.wav")
         currentOutputFile = outFile
@@ -108,39 +105,18 @@ class VoiceRecorder(
         stopRequested.set(false)
         _amplitude.value = 0f
 
+        // The mic is a contended resource. The barge-in listener holds a
+        // MicrophoneOwnershipCoordinator lease during Speaking and releases
+        // it asynchronously ("typically a single frame later" per
+        // BargeInListener.stop's KDoc), so a mic tap can land in the window
+        // where the lease is still held and fail with "Microphone is in use
+        // by another voice feature" even though capture would succeed
+        // milliseconds later. Retry the lease + open briefly; a persistent
+        // failure (permission revoked, mic truly busy) still surfaces.
         val recorder = try {
-            AudioRecord.Builder()
-                .setAudioSource(MediaRecorder.AudioSource.MIC)
-                .setAudioFormat(
-                    AudioFormat.Builder()
-                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                        .setSampleRate(SAMPLE_RATE)
-                        .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
-                        .build()
-                )
-                .setBufferSizeInBytes(minBuffer * 2)
-                .build()
-        } catch (t: Throwable) {
-            MicrophoneOwnershipCoordinator.release(lease)
-            microphoneLease = null
-            throw t
-        }
-
-        if (recorder.state != AudioRecord.STATE_INITIALIZED) {
-            recorder.release()
-            currentOutputFile = null
-            MicrophoneOwnershipCoordinator.release(lease)
-            microphoneLease = null
-            throw IllegalStateException("AudioRecord failed to initialize")
-        }
-
-        try {
-            recorder.startRecording()
+            openRecorderWithRetry(minBuffer)
         } catch (e: Exception) {
-            recorder.release()
             currentOutputFile = null
-            MicrophoneOwnershipCoordinator.release(lease)
-            microphoneLease = null
             throw e
         }
 
@@ -156,6 +132,79 @@ class VoiceRecorder(
             "HermesVoiceRecorder",
         ).also { it.start() }
         return outFile
+    }
+
+    /**
+     * Acquire the microphone lease and build/start an [AudioRecord], retrying
+     * on transient failure. [MicrophoneOwnershipCoordinator] prevents
+     * concurrent capture, but a just-released lease (barge-in teardown,
+     * wake-word handoff) can make both the lease acquisition and the
+     * underlying open fail for a few frames; a bounded retry absorbs those
+     * windows without holding the lease past an attempt. On final failure the
+     * lease is released and the last exception is rethrown for the caller's
+     * error surfacing.
+     */
+    private fun openRecorderWithRetry(minBuffer: Int): AudioRecord {
+        var attempt = 0
+        var lastFailure: Exception? = null
+        while (attempt < AUDIO_RECORD_RETRIES) {
+            attempt++
+            val lease = MicrophoneOwnershipCoordinator.tryAcquire(MicrophoneOwner.VoiceCapture)
+            if (lease == null) {
+                lastFailure = IllegalStateException("Microphone is in use by another voice feature")
+                if (!retryBackoff(attempt)) break
+                continue
+            }
+            microphoneLease = lease
+            try {
+                val recorder = AudioRecord.Builder()
+                    .setAudioSource(MediaRecorder.AudioSource.MIC)
+                    .setAudioFormat(
+                        AudioFormat.Builder()
+                            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                            .setSampleRate(SAMPLE_RATE)
+                            .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+                            .build()
+                    )
+                    .setBufferSizeInBytes(minBuffer * 2)
+                    .build()
+
+                if (recorder.state != AudioRecord.STATE_INITIALIZED) {
+                    recorder.release()
+                    throw IllegalStateException("AudioRecord failed to initialize")
+                }
+
+                try {
+                    recorder.startRecording()
+                } catch (e: Exception) {
+                    recorder.release()
+                    throw e
+                }
+                return recorder
+            } catch (e: Exception) {
+                lastFailure = e
+                MicrophoneOwnershipCoordinator.release(lease)
+                microphoneLease = null
+                Log.w(
+                    TAG,
+                    "AudioRecord open attempt $attempt/$AUDIO_RECORD_RETRIES failed: ${e.message}",
+                )
+                if (!retryBackoff(attempt)) break
+            }
+        }
+        throw lastFailure ?: IllegalStateException("AudioRecord failed to initialize")
+    }
+
+    /** Sleep the retry backoff unless the last attempt was reached. */
+    private fun retryBackoff(attempt: Int): Boolean {
+        if (attempt >= AUDIO_RECORD_RETRIES) return false
+        return try {
+            Thread.sleep(AUDIO_RECORD_RETRY_BACKOFF_MS)
+            true
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
@@ -233,6 +233,22 @@ private fun classifyErrorInternal(t: Throwable?, context: String?, ctx: Context?
 
     val msg = t.message.orEmpty().lowercase()
 
+    // AudioRecord native setup failure — the framework throws
+    // UnsupportedOperationException("Cannot create AudioRecord") (or the
+    // app's own IllegalStateException from the state check) when the mic
+    // can't be opened: another app holds it, our own barge-in listener is
+    // mid-teardown, or RECORD_AUDIO was revoked. The raw framework string
+    // is useless to a user, so map it to an actionable, retryable hint.
+    if ("cannot create audiorecord" in msg || "audiorecord failed to initialize" in msg) {
+        return HumanError(
+            title = ctx?.getString(R.string.error_classify_mic_busy) ?: "Microphone unavailable",
+            body = ctx?.getString(R.string.error_classify_mic_busy_body)
+                ?: "The microphone is busy or blocked. Close other apps using the mic and check Microphone permission in Settings.",
+            retryable = true,
+            actionLabel = ctx?.getString(R.string.error_classify_retry) ?: "Retry",
+        )
+    }
+
     // Upstream rejects new API work with this stable code while an intentional
     // shutdown/external drain is in progress. Keep it distinct from provider
     // 503s: the server is healthy and will accept work after the drain clears.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,8 @@
     <string name="error_classify_synthesize">Voice playback failed</string>
     <string name="error_classify_voice_config">Voice config unavailable</string>
     <string name="error_classify_record">Can\'t record</string>
+    <string name="error_classify_mic_busy">Microphone unavailable</string>
+    <string name="error_classify_mic_busy_body">The microphone is busy or blocked. Close other apps using the mic and check Microphone permission in Settings.</string>
     <string name="error_classify_pair">Pairing failed</string>
     <string name="error_classify_save_and_test">Relay check failed</string>
     <string name="error_classify_media_fetch">Couldn\'t fetch attachment</string>

--- a/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
@@ -106,4 +106,31 @@ class RelayErrorClassifierTest {
         assertEquals("Realtime provider auth unavailable", err.title)
         assertFalse(err.body.contains("server refused", ignoreCase = true))
     }
+
+    @Test
+    fun audioRecordCannotCreateMapsToMicBusyHint() {
+        // Native framework exception thrown when AudioRecord's mic can't be
+        // opened (barge-in teardown race, another app holding the mic, or
+        // permission revoked). Must surface an actionable hint, not the raw
+        // framework string.
+        val err = classifyError(
+            UnsupportedOperationException("Cannot create AudioRecord"),
+            context = "record",
+        )
+
+        assertEquals("Microphone unavailable", err.title)
+        assertTrue(err.body.contains("microphone", ignoreCase = true))
+        assertTrue(err.retryable)
+    }
+
+    @Test
+    fun audioRecordFailedToInitializeMapsToMicBusyHint() {
+        val err = classifyError(
+            IllegalStateException("AudioRecord failed to initialize"),
+            context = "record",
+        )
+
+        assertEquals("Microphone unavailable", err.title)
+        assertTrue(err.retryable)
+    }
 }


### PR DESCRIPTION
## Summary

Voice capture can fail with the raw framework exception **`Cannot create AudioRecord`** (`UnsupportedOperationException` thrown by `AudioRecord` native setup when the microphone cannot be opened). The upstream `MicrophoneOwnershipCoordinator` lease already prevents two voice features from capturing concurrently, but two gaps remain:

1. **Mic tap during barge-in teardown still fails.** `VoiceRecorder.startRecording()` acquired the `VoiceCapture` lease once and gave up immediately if it was held. The barge-in listener releases its lease asynchronously ("typically a single frame later" per `BargeInListener.stop`'s KDoc), so a tap landing in that window failed with "Microphone is in use by another voice feature" even though capture would succeed milliseconds later.
2. **External mic contention surfaces the raw framework message.** `RelayErrorClassifier` had no mapping for AudioRecord setup failures, so another app holding the mic or Android 12+ mic privacy toggle dumped the cryptic `Cannot create AudioRecord` string at the user.

## Changes

- **`VoiceRecorder.kt`** — `openRecorderWithRetry()` now retries the lease acquisition **and** the `AudioRecord` open a bounded number of times (3 attempts, 50 ms backoff), releasing the lease on each failed attempt. Absorbs the async barge-in teardown window; persistent failures still surface through the classifier.
- **`RelayErrorClassifier.kt`** — maps `Cannot create AudioRecord` / `AudioRecord failed to initialize` to an actionable, retryable "Microphone unavailable" hint instead of the raw framework string.
- **`strings.xml`** — adds `error_classify_mic_busy` + `error_classify_mic_busy_body`.
- **`RelayErrorClassifierTest.kt`** — unit tests for both new mappings.

## Test Plan

- [ ] `./gradlew :app:testSideloadDebugUnitTest --tests "com.hermesandroid.relay.util.RelayErrorClassifierTest"`
- [ ] On-device: enable barge-in, speak so TTS plays, tap the mic mid-speech — capture should start on retry instead of failing
- [ ] On-device: revoke mic permission mid-session → friendly "Microphone unavailable" message, not the raw framework error

Closes #285
