### PR TITLE
fix(android): harden microphone capture handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Voice capture waits for the microphone to be released.** Manual recording no longer races barge-in teardown, and AudioRecord startup failures now explain how to free or permit the microphone before retrying.
 - **Windows-trusted certificates work in the desktop CLI.** The packaged Windows binary and newer Node runtimes add the Windows certificate store without dropping bundled or operator-supplied roots, while TLS verification and Relay certificate pinning remain enforced.
 
 ## [Android 1.6.0] - 2026-08-02

--- a/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
@@ -233,6 +233,16 @@ private fun classifyErrorInternal(t: Throwable?, context: String?, ctx: Context?
 
     val msg = t.message.orEmpty().lowercase()
 
+    if ("cannot create audiorecord" in msg || "audiorecord failed to initialize" in msg) {
+        return HumanError(
+            title = ctx?.getString(R.string.error_classify_mic_unavailable) ?: "Microphone unavailable",
+            body = ctx?.getString(R.string.error_classify_mic_unavailable_body)
+                ?: "The microphone is busy or blocked. Close other apps using the mic and check Microphone permission in Settings.",
+            retryable = true,
+            actionLabel = ctx?.getString(R.string.error_classify_retry) ?: "Retry",
+        )
+    }
+
     // Upstream rejects new API work with this stable code while an intentional
     // shutdown/external drain is in progress. Keep it distinct from provider
     // 503s: the server is healthy and will accept work after the drain clears.

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -57,6 +57,7 @@ import com.hermesandroid.relay.voice.createVoiceBridgeIntentHandler
 // === END PHASE3-voice-intents ===
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -830,6 +831,8 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     // Post-response audio completion retry. Continuous mode uses the same
     // finalizer as tap/hold, then re-arms listening only when explicitly armed.
     private var continuousResumeJob: Job? = null
+    private var pendingListeningStartJob: Job? = null
+    private var listeningStartEpoch: Long = 0L
     private var realtimeAmplitudeDecayJob: Job? = null
     private var firstFrameWatchdogJob: Job? = null
     private var continuousLoopArmed: Boolean = false
@@ -1882,6 +1885,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             setError("Recorder not initialized")
             return
         }
+        if (pendingListeningStartJob?.isActive == true) return
         if (rec.isRecording()) return
         if (_uiState.value.state == VoiceState.Listening) {
             // Listening is reserved for a live AudioRecord. Reconcile a stale
@@ -1903,7 +1907,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         // B4: user manually started a turn → tear down the barge-in
         // listener and cancel any pending resume. Normal "tap mic to
         // talk" path also lands here, so we always leave Speaking cleanly.
-        stopBargeInListener()
+        val microphoneRelease = stopBargeInListener()
         cancelStandardSpeechStream("microphone capture started")
         resumeWatchdog?.cancel(); resumeWatchdog = null
         lastInterruptedAtChunkIndex = null
@@ -1914,6 +1918,29 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         try { player?.stop() } catch (_: Exception) { /* ignore */ }
         try { realtimePcmPlayer?.stop() } catch (_: Exception) { /* ignore */ }
 
+        if (microphoneRelease == null || microphoneRelease.isCompleted) {
+            startVoiceCapture(rec)
+            return
+        }
+
+        val startEpoch = ++listeningStartEpoch
+        val pendingStart = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            try {
+                microphoneRelease.join()
+                if (listeningStartEpoch == startEpoch) {
+                    startVoiceCapture(rec)
+                }
+            } finally {
+                if (listeningStartEpoch == startEpoch) {
+                    pendingListeningStartJob = null
+                }
+            }
+        }
+        pendingListeningStartJob = pendingStart
+        pendingStart.start()
+    }
+
+    private fun startVoiceCapture(rec: VoiceRecorder) {
         try {
             rec.startRecording()
             listeningStartedAtMs = System.currentTimeMillis()
@@ -1943,6 +1970,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun stopListening() {
+        if (cancelPendingListeningStart()) return
         val rec = recorder ?: return
         if (!rec.isRecording()) {
             if (_uiState.value.state == VoiceState.Listening) {
@@ -1998,6 +2026,24 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         currentTurnJob = viewModelScope.launch {
             processVoiceInput(file, inputPcm, inputSampleRate)
         }
+    }
+
+    private fun cancelPendingListeningStart(): Boolean {
+        val pendingStart = pendingListeningStartJob
+        if (pendingStart?.isActive != true) return false
+
+        listeningStartEpoch++
+        pendingStart.cancel()
+        pendingListeningStartJob = null
+        listeningStartedAtMs = 0L
+        _uiState.update {
+            it.copy(
+                state = VoiceState.Idle,
+                amplitude = 0f,
+                outputAudioActive = false,
+            )
+        }
+        return true
     }
 
     private fun listeningDurationMs(): Long {
@@ -2188,6 +2234,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
      * new turn on the next mic tap).
      */
     fun interruptSpeaking(): Job? {
+        cancelPendingListeningStart()
         Log.i(
             TAG,
             "Interrupting speech pipeline",
@@ -6280,6 +6327,9 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         continuousLoopArmed = false
         continuousResumeJob?.cancel()
         continuousResumeJob = null
+        pendingListeningStartJob?.cancel()
+        pendingListeningStartJob = null
+        listeningStartEpoch++
         realtimeAmplitudeDecayJob?.cancel()
         realtimeAmplitudeDecayJob = null
         try { recorder?.cancel() } catch (_: Exception) { /* ignore */ }

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -238,6 +238,8 @@
     <string name="error_classify_synthesize">Falha na reprodução de voz</string>
     <string name="error_classify_voice_config">Configuração de voz indisponível</string>
     <string name="error_classify_record">Não foi possível gravar</string>
+    <string name="error_classify_mic_unavailable">Microfone indisponível</string>
+    <string name="error_classify_mic_unavailable_body">O microfone está ocupado ou bloqueado. Feche outros apps que estejam usando o microfone e verifique a permissão de microfone nas Configurações.</string>
     <string name="error_classify_pair">Falha no pareamento</string>
     <string name="error_classify_save_and_test">Falha na verificação do Relay</string>
     <string name="error_classify_media_fetch">Não foi possível buscar o anexo</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -258,6 +258,8 @@
     <string name="error_classify_synthesize">语音播放失败</string>
     <string name="error_classify_voice_config">语音配置不可用</string>
     <string name="error_classify_record">无法录音</string>
+    <string name="error_classify_mic_unavailable">麦克风不可用</string>
+    <string name="error_classify_mic_unavailable_body">麦克风正被占用或已被阻止。请关闭其他正在使用麦克风的应用，并在“设置”中检查麦克风权限。</string>
     <string name="error_classify_pair">配对失败</string>
     <string name="error_classify_save_and_test">Relay 检查失败</string>
     <string name="error_classify_media_fetch">无法获取附件</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -258,6 +258,8 @@
     <string name="error_classify_synthesize">Sprachwiedergabe fehlgeschlagen</string>
     <string name="error_classify_voice_config">Sprachkonfiguration nicht verfügbar</string>
     <string name="error_classify_record">Aufnahme nicht möglich</string>
+    <string name="error_classify_mic_unavailable">Mikrofon nicht verfügbar</string>
+    <string name="error_classify_mic_unavailable_body">Das Mikrofon ist belegt oder blockiert. Schließe andere Apps, die das Mikrofon verwenden, und überprüfe die Mikrofonberechtigung in den Einstellungen.</string>
     <string name="error_classify_pair">Kopplung fehlgeschlagen</string>
     <string name="error_classify_save_and_test">Relay-Prüfung fehlgeschlagen</string>
     <string name="error_classify_media_fetch">Anhang konnte nicht abgerufen werden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -222,6 +222,8 @@
     <string name="error_classify_synthesize">Error en la reproducción de voz</string>
     <string name="error_classify_voice_config">Configuración de voz no disponible</string>
     <string name="error_classify_record">No se puede grabar</string>
+    <string name="error_classify_mic_unavailable">Micrófono no disponible</string>
+    <string name="error_classify_mic_unavailable_body">El micrófono está ocupado o bloqueado. Cierra otras aplicaciones que estén usando el micrófono y comprueba el permiso del micrófono en Ajustes.</string>
     <string name="error_classify_pair">El emparejamiento falló</string>
     <string name="error_classify_save_and_test">Error en la comprobación de Relay</string>
     <string name="error_classify_media_fetch">No se ha podido recuperar el archivo adjunto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -258,6 +258,8 @@
     <string name="error_classify_synthesize">音声再生に失敗しました</string>
     <string name="error_classify_voice_config">音声設定が利用できません</string>
     <string name="error_classify_record">録音できません</string>
+    <string name="error_classify_mic_unavailable">マイクを使用できません</string>
+    <string name="error_classify_mic_unavailable_body">マイクが使用中かブロックされています。マイクを使用している他のアプリを閉じ、設定でマイクの権限を確認してください。</string>
     <string name="error_classify_pair">ペアリングに失敗しました</string>
     <string name="error_classify_save_and_test">Relay チェックに失敗しました</string>
     <string name="error_classify_media_fetch">添付ファイルを取得できませんでした</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -242,6 +242,8 @@
     <string name="error_classify_synthesize">Воспроизведение голоса не удалось</string>
     <string name="error_classify_voice_config">Конфигурация голоса недоступна</string>
     <string name="error_classify_record">Нельзя записать</string>
+    <string name="error_classify_mic_unavailable">Микрофон недоступен</string>
+    <string name="error_classify_mic_unavailable_body">Микрофон занят или заблокирован. Закройте другие приложения, использующие микрофон, и проверьте разрешение на доступ к микрофону в настройках.</string>
     <string name="error_classify_pair">Сопряжение не удалось</string>
     <string name="error_classify_save_and_test">Проверка Relay не удалась</string>
     <string name="error_classify_media_fetch">Не удалось получить вложение</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,8 @@
     <string name="error_classify_synthesize">Voice playback failed</string>
     <string name="error_classify_voice_config">Voice config unavailable</string>
     <string name="error_classify_record">Can\'t record</string>
+    <string name="error_classify_mic_unavailable">Microphone unavailable</string>
+    <string name="error_classify_mic_unavailable_body">The microphone is busy or blocked. Close other apps using the mic and check Microphone permission in Settings.</string>
     <string name="error_classify_pair">Pairing failed</string>
     <string name="error_classify_save_and_test">Relay check failed</string>
     <string name="error_classify_media_fetch">Couldn\'t fetch attachment</string>

--- a/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
@@ -106,4 +106,27 @@ class RelayErrorClassifierTest {
         assertEquals("Realtime provider auth unavailable", err.title)
         assertFalse(err.body.contains("server refused", ignoreCase = true))
     }
+
+    @Test
+    fun audioRecordCannotCreateMapsToMicUnavailableHint() {
+        val err = classifyError(
+            UnsupportedOperationException("Cannot create AudioRecord"),
+            context = "record",
+        )
+
+        assertEquals("Microphone unavailable", err.title)
+        assertTrue(err.body.contains("microphone", ignoreCase = true))
+        assertTrue(err.retryable)
+    }
+
+    @Test
+    fun audioRecordFailedToInitializeMapsToMicUnavailableHint() {
+        val err = classifyError(
+            IllegalStateException("AudioRecord failed to initialize"),
+            context = "record",
+        )
+
+        assertEquals("Microphone unavailable", err.title)
+        assertTrue(err.retryable)
+    }
 }

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
@@ -23,6 +23,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -231,6 +232,45 @@ class VoiceViewModelBargeInTest {
             vm.uiState.value.state,
         )
         verify(atLeast = 1) { recorder.startRecording() }
+    }
+
+    @Test
+    fun `manual mic waits for barge-in reader release before starting capture`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Hello."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        vm.startListening()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `manual mic release cancels capture waiting on barge-in shutdown`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Hello."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        vm.startListening()
+        runCurrent()
+        vm.stopListening()
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        assertEquals(VoiceState.Idle, vm.uiState.value.state)
     }
 
     // -------------------------------------------------------------------

--- a/docs/localization-status.json
+++ b/docs/localization-status.json
@@ -13,7 +13,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "ea322945453cb843adc7c77273945137ec26c46a76896f009089e6b00a240a64",
+        "main": "903cf3f6d9cbc77e044848ee56777862ef052be84668dcc46ac402242ef7b3cc",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -48,7 +48,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "ea322945453cb843adc7c77273945137ec26c46a76896f009089e6b00a240a64",
+        "main": "903cf3f6d9cbc77e044848ee56777862ef052be84668dcc46ac402242ef7b3cc",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -72,7 +72,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "ea322945453cb843adc7c77273945137ec26c46a76896f009089e6b00a240a64",
+        "main": "903cf3f6d9cbc77e044848ee56777862ef052be84668dcc46ac402242ef7b3cc",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -96,7 +96,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "ea322945453cb843adc7c77273945137ec26c46a76896f009089e6b00a240a64",
+        "main": "903cf3f6d9cbc77e044848ee56777862ef052be84668dcc46ac402242ef7b3cc",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -120,7 +120,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "ea322945453cb843adc7c77273945137ec26c46a76896f009089e6b00a240a64",
+        "main": "903cf3f6d9cbc77e044848ee56777862ef052be84668dcc46ac402242ef7b3cc",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -135,7 +135,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "ea322945453cb843adc7c77273945137ec26c46a76896f009089e6b00a240a64",
+        "main": "903cf3f6d9cbc77e044848ee56777862ef052be84668dcc46ac402242ef7b3cc",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {


### PR DESCRIPTION
## Summary
- wait for the barge-in reader to release microphone ownership before manual capture starts, without blocking the UI thread
- cancel a pending capture when the user releases or exits before teardown completes
- replace raw AudioRecord initialization failures with retryable, localized microphone guidance

## Verification
- `:app:testSideloadDebugUnitTest` for `VoiceViewModelBargeInTest`, `RelayErrorClassifierTest`, and `BargeInListenerShutdownRaceTest`
- `:app:lintGooglePlayDebug` (0 errors)
- `python scripts/check-android-locales.py`
- `python scripts/check-android-collection-apis.py`
- `git diff --check`

## Lineage
Hardens the investigation from #285 and supersedes the closed community PR #286. The contributor is retained as a co-author on the implementation commit.

## Known baseline
The broader `BargeInListenerTest` sustained-speech case currently reports three detections where it expects one; that existing listener-only assertion is outside this ViewModel/classifier change and the shutdown-race coverage passes.