### PR TITLE
release(server): server-v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android session history follows the upstream page-size contract.** The drawer keeps its 200-session window through bounded 100-row requests, avoiding HTTP 422 errors from current dashboard servers while preserving active-profile isolation.
 - **Windows-trusted certificates work in the desktop CLI.** The packaged Windows binary and newer Node runtimes add the Windows certificate store without dropping bundled or operator-supplied roots, while TLS verification and Relay certificate pinning remain enforced.
 - **Android no longer mistakes optional-surface auth failures for expired Relay pairing.** Background session refreshes stay out of the global snackbar, Dashboard and API authorization errors name their owning credential, and Relay-only surfaces use consistent Optional, Ready, Reconnecting, Unavailable, and Needs re-pair states. Foreground recovery retries ordinary Relay backoff immediately while preserving server rate limits, and recovery prioritizes Dashboard or host session management while retained credentials are labeled as stored details instead of active pairing.
+
+## [Server 1.5.1] - 2026-08-03
+
+### Fixed
+
 - **Re-pairing repairs one device instead of accumulating duplicate sessions.** An explicit host-approved pair replaces older sessions and refresh credentials for the same device, while the Dashboard and `/relay revoke <token-prefix>` remain available for operator cleanup.
 
 ## [Android 1.6.0] - 2026-08-02

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,17 +1,17 @@
 # Hermes-Relay-Server v__VERSION__
 
-**Release Date:** August 2, 2026
+**Release Date:** August 3, 2026
 
-This release adds Realtime Agent final-answer-only speech and Relay-hosted declarative plugin pages for Android.
+This patch makes intentional re-pairing repair the existing device record instead of accumulating duplicate Relay sessions.
 
-Android clients can keep voice progress visual until the settled answer and review agent-created native plugin pages before keeping them. Standard chat and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
+Standard chat, session history, and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
 
 ## What's changed
 
-### Added
+### Fixed
 
-- **Realtime Agent final-answer-only speech.** Session creation accepts an optional `final_answer_only` flag. When enabled, the provider skips routine acknowledgements, spoken progress, service updates, and intermediate commentary, then speaks the settled Hermes answer. Approval and confirmation prompts, along with blocking failures, remain audible so required user action is not hidden.
-- **Agent-created declarative Android plugin pages.** New Relay tools create bounded JSON-only drafts and expose them through authenticated plugin routes. Android owns enablement, write grants, exact-revision approval, publication, and persistent removal. Generated pages reject executable code, arbitrary network requests, Android intents, traversal, symlink entries, oversized documents, and backend action requests.
+- **Re-pairing replaces stale credentials for the same device.** After the host approves a new pair, Relay revokes older sessions and refresh credentials that belong to that device before issuing the replacement.
+- **Existing and unrelated sessions remain operator-controlled.** The Dashboard and `/relay revoke <token-prefix>` continue to provide explicit cleanup without treating optional Relay pairing as a requirement.
 
 ## Install / update
 

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Relay",
   "description": "Paired devices, bridge activity, media inspection, and remote access for hermes-relay",
   "icon": "Activity",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,6 +1,6 @@
 name: hermes-relay
 manifest_version: 1
-version: 1.5.0
+version: 1.5.1
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 # All three are OPTIONAL — only needed if you use the relay's extra /

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # Desktop releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.5.0"
+version = "1.5.1"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- bump the Relay plugin and dashboard to 1.5.1
- document same-device re-pair replacement and operator cleanup
- prepare the server patch release notes

## Verification
- python scripts/check-plugin-version-sync.py --expect 1.5.1
- python scripts/check-version-tracks.py
- python -m unittest plugin.tests.test_session_persistence plugin.tests.test_slash
- python -m py_compile plugin/relay/auth.py plugin/slash.py plugin/relay/server.py
- git diff --check