### PR TITLE
fix(release): align server 1.5.1 changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android no longer mistakes optional-surface auth failures for expired Relay pairing.** Background session refreshes stay out of the global snackbar, Dashboard and API authorization errors name their owning credential, and Relay-only surfaces use consistent Optional, Ready, Reconnecting, Unavailable, and Needs re-pair states. Foreground recovery retries ordinary Relay backoff immediately while preserving server rate limits, and recovery prioritizes Dashboard or host session management while retained credentials are labeled as stored details instead of active pairing.
 - **Voice controls no longer collide with new-chat coaching.** The clean-view hint yields while Voice owns the composer so it cannot cover the expanding Voice drawer.
 
-## [Server 1.5.1] - 2026-08-03
+## [1.5.1] - 2026-08-03
 
 ### Fixed
 


### PR DESCRIPTION
The Server 1.5.1 tag validation requires an exact ## [1.5.1] changelog heading. The first tag attempt stopped before package build or publication because the release block used ## [Server 1.5.1].

This changes only that heading so the canonical release workflow can validate it.

Verification:
- python scripts/check-plugin-version-sync.py --expect 1.5.1
- exact workflow grep for ## [1.5.1] succeeds
- git diff --check