### PR TITLE
fix(android): make connection diagnostics actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Android diagnostics explain what failed and what to try next.** Relay, route, WebSocket, and API checks distinguish the saved route from the redacted request they actually attempted, name the operation, and provide targeted guidance for connection, DNS, timeout, TLS, authentication, rate-limit, and server failures.
 - **Android chat and Voice keep one render identity through recovery.** Checkpoint restore, streamed callbacks, server-ID adoption, and replay now resolve the same owned transcript row before publication, preventing recurring Compose duplicate-key crashes.
 - **Issue area labels require maintainer review.** The unreliable keyword-based auto-labeling workflow no longer assigns ownership from ambiguous issue text.
 - **Android crash reports retain actionable release context.** Reports identify the Android surface, avoid exposing hosts and credentials, migrate earlier local crash records, and release automation retains exact Play and sideload R8 mappings for retrace.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,20 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-05 — Actionable Android connection diagnostics
+
+Android diagnostic entries now separate the configured route from the exact
+request operation and path used to test it. Relay health checks identify the
+HTTP `/health` probe that precedes a WebSocket connection, route selection
+records its Dashboard, API, or Relay probe, and WebSocket and API checks name
+their handshake or authentication stage.
+
+Known network and HTTP failure classes attach a bounded next step for refused
+listeners, DNS, routing, timeouts, TLS, credentials, rate limits, missing
+routes, and server failures. The activity list, status timeline, detail dialog,
+copy text, and GitHub issue prefill all carry the same context. Public issue
+text preserves protocol and request paths while redacting hosts, credentials,
+queries, and user information.
+
 ## 2026-08-04 — Android transcript identity ownership
 
 ChatHandler now owns one render identity for every published transcript row.

--- a/app/src/main/kotlin/com/hermesandroid/relay/diagnostics/DiagnosticsLog.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/diagnostics/DiagnosticsLog.kt
@@ -27,7 +27,16 @@ data class DiagnosticLogEntry(
     val severity: DiagnosticSeverity,
     val title: String,
     val detail: String? = null,
+    /** Human-readable action that produced this event, not merely its subsystem. */
+    val operation: String? = null,
     val endpointRole: String? = null,
+    /** User/configuration-facing route before protocol/path normalization. */
+    val configuredUrl: String? = null,
+    /** Exact sanitized URL attempted on the wire, including the diagnostic path. */
+    val requestUrl: String? = null,
+    /** Concrete next troubleshooting step for failures with a known interpretation. */
+    val suggestion: String? = null,
+    /** Legacy single-URL field retained for diagnostics that have not needed split context. */
     val url: String? = null,
     val elapsedMs: Long? = null,
     /**
@@ -36,7 +45,11 @@ data class DiagnosticLogEntry(
      * the detail view shows this. Null for non-error / manually-recorded entries.
      */
     val stacktrace: String? = null,
-)
+) {
+    /** Best route for mode inference and compact list rendering. */
+    val primaryUrl: String?
+        get() = configuredUrl ?: requestUrl ?: url
+}
 
 /**
  * Current health of a single subsystem on the Diagnostics status timeline.
@@ -83,19 +96,29 @@ object DiagnosticsLog {
         severity: DiagnosticSeverity = DiagnosticSeverity.Info,
         title: String,
         detail: String? = null,
+        operation: String? = null,
         endpointRole: String? = null,
+        configuredUrl: String? = null,
+        requestUrl: String? = null,
+        suggestion: String? = null,
         url: String? = null,
         elapsedMs: Long? = null,
         stacktrace: String? = null,
     ) {
+        val safeConfiguredUrl = sanitizeUrl(configuredUrl)
+        val safeRequestUrl = sanitizeUrl(requestUrl)
         val entry = DiagnosticLogEntry(
             timestampMs = System.currentTimeMillis(),
             category = category,
             severity = severity,
             title = clean(title) ?: title.take(MAX_TEXT_LENGTH),
             detail = clean(detail),
+            operation = clean(operation),
             endpointRole = clean(endpointRole),
-            url = sanitizeUrl(url),
+            configuredUrl = safeConfiguredUrl,
+            requestUrl = safeRequestUrl,
+            suggestion = clean(suggestion),
+            url = if (safeConfiguredUrl == null && safeRequestUrl == null) sanitizeUrl(url) else null,
             elapsedMs = elapsedMs,
             stacktrace = redactTrace(stacktrace),
         )
@@ -123,7 +146,11 @@ object DiagnosticsLog {
         title: String,
         detail: String? = null,
         throwable: Throwable? = null,
+        operation: String? = null,
         endpointRole: String? = null,
+        configuredUrl: String? = null,
+        requestUrl: String? = null,
+        suggestion: String? = null,
         url: String? = null,
         elapsedMs: Long? = null,
         reliabilityContext: String? = null,
@@ -133,7 +160,11 @@ object DiagnosticsLog {
             severity = DiagnosticSeverity.Error,
             title = title,
             detail = detail ?: throwable?.message,
+            operation = operation,
             endpointRole = endpointRole,
+            configuredUrl = configuredUrl,
+            requestUrl = requestUrl,
+            suggestion = suggestion,
             url = url,
             elapsedMs = elapsedMs,
             stacktrace = throwable?.let { stackTraceText(it) },

--- a/app/src/main/kotlin/com/hermesandroid/relay/diagnostics/NetworkDiagnosticGuidance.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/diagnostics/NetworkDiagnosticGuidance.kt
@@ -1,0 +1,42 @@
+package com.hermesandroid.relay.diagnostics
+
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+
+/**
+ * Maps network failure classes to narrow, truthful next steps.
+ *
+ * These messages are diagnostic guidance, not recovery behavior: callers still
+ * own retries, routing, and authentication. Walking the cause chain preserves
+ * useful classification when OkHttp or a coroutine boundary wraps the socket
+ * exception in a higher-level failure.
+ */
+object NetworkDiagnosticGuidance {
+    fun forThrowable(throwable: Throwable, target: String): String? {
+        val causes = generateSequence(throwable as Throwable?) { it.cause }.take(12).toList()
+        return when {
+            causes.any { it is ConnectException } ->
+                "Verify $target is running and listening on the configured host and port."
+            causes.any { it is UnknownHostException } ->
+                "Verify the configured hostname resolves from this device."
+            causes.any { it is NoRouteToHostException } ->
+                "Verify the device has a network path to the configured host."
+            causes.any { it is SocketTimeoutException } ->
+                "Check network routing or firewall rules between this device and $target."
+            causes.any { it is SSLException } ->
+                "Verify the TLS scheme, certificate, and trust configuration for $target."
+            else -> null
+        }
+    }
+
+    fun forHttpStatus(statusCode: Int, target: String): String? = when (statusCode) {
+        401, 403 -> "Verify the configured $target credentials or pair the device again."
+        404 -> "Verify this URL points to the expected $target route and version."
+        429 -> "Wait for the server's backoff period before retrying."
+        in 500..599 -> "Check the $target server logs for the failing request."
+        else -> null
+    }
+}

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/relay/ConnectionManager.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/relay/ConnectionManager.kt
@@ -15,6 +15,7 @@ import com.hermesandroid.relay.data.PairingPreferences
 import com.hermesandroid.relay.diagnostics.DiagnosticCategory
 import com.hermesandroid.relay.diagnostics.DiagnosticSeverity
 import com.hermesandroid.relay.diagnostics.DiagnosticsLog
+import com.hermesandroid.relay.diagnostics.NetworkDiagnosticGuidance
 import com.hermesandroid.relay.network.relay.models.Envelope
 import com.hermesandroid.relay.network.shared.EndpointResolver
 import com.hermesandroid.relay.network.shared.EndpointSurface
@@ -441,7 +442,9 @@ class ConnectionManager(
                 severity = DiagnosticSeverity.Error,
                 title = context?.getString(R.string.conn_diag_socket_blocked) ?: "Relay socket blocked",
                 detail = "ws:// is disabled",
-                url = url,
+                operation = "Open Relay WebSocket",
+                configuredUrl = url,
+                suggestion = "Use wss:// or explicitly allow plain ws:// for a trusted LAN or VPN.",
             )
             return
         }
@@ -452,7 +455,9 @@ class ConnectionManager(
                 severity = DiagnosticSeverity.Error,
                 title = context?.getString(R.string.conn_diag_url_invalid) ?: "Relay socket URL invalid",
                 detail = "URL must start with ws:// or wss://",
-                url = url,
+                operation = "Open Relay WebSocket",
+                configuredUrl = url,
+                suggestion = "Edit or re-pair the Relay route with a ws:// or wss:// URL.",
             )
             return
         }
@@ -488,14 +493,18 @@ class ConnectionManager(
                 category = DiagnosticCategory.Relay,
                 severity = DiagnosticSeverity.Warning,
                 title = context?.getString(R.string.conn_diag_opening_insecure) ?: "Opening insecure relay socket",
-                url = normalized,
+                operation = "Open Relay WebSocket",
+                configuredUrl = url,
+                requestUrl = normalized,
             )
         } else {
             DiagnosticsLog.record(
                 category = DiagnosticCategory.Relay,
                 severity = DiagnosticSeverity.Info,
                 title = context?.getString(R.string.conn_diag_opening_socket) ?: "Opening relay socket",
-                url = normalized,
+                operation = "Open Relay WebSocket",
+                configuredUrl = url,
+                requestUrl = normalized,
             )
         }
 
@@ -985,7 +994,9 @@ class ConnectionManager(
                 severity = DiagnosticSeverity.Error,
                 title = "Invalid relay URL",
                 detail = "The relay address could not be parsed; re-pair to refresh it.",
-                url = url,
+                operation = "Build Relay WebSocket request",
+                configuredUrl = url,
+                suggestion = "Edit or re-pair the Relay route to replace the invalid address.",
             )
             authenticated = false
             _connectionState.value = ConnectionState.Disconnected
@@ -1018,7 +1029,8 @@ class ConnectionManager(
                     category = DiagnosticCategory.Relay,
                     severity = DiagnosticSeverity.Info,
                     title = context?.getString(R.string.conn_diag_connected) ?: "Relay socket connected",
-                    url = url,
+                    operation = "Relay WebSocket handshake",
+                    requestUrl = url,
                 )
 
                 // TOFU: record the peer cert fingerprint if we don't have one
@@ -1079,7 +1091,9 @@ class ConnectionManager(
                     severity = DiagnosticSeverity.Warning,
                     title = context?.getString(R.string.conn_diag_closed) ?: "Relay socket closed",
                     detail = "code=$code reason=$reason",
-                    url = url,
+                    operation = "Relay WebSocket session",
+                    requestUrl = url,
+                    suggestion = if (code == 1000) null else "Check the Relay server logs for the matching close code and reason.",
                 )
                 authenticated = false
                 _connectionState.value = ConnectionState.Disconnected
@@ -1102,7 +1116,11 @@ class ConnectionManager(
                         t.message,
                         code?.let { "HTTP $it" },
                     ).joinToString(": "),
-                    url = url,
+                    operation = "Relay WebSocket handshake",
+                    requestUrl = url,
+                    suggestion = code?.let {
+                        NetworkDiagnosticGuidance.forHttpStatus(it, "Relay")
+                    } ?: NetworkDiagnosticGuidance.forThrowable(t, "Relay"),
                 )
                 lastUpgradeResponseCode = code
                 if (response == null) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClient.kt
@@ -7,6 +7,7 @@ import com.hermesandroid.relay.auth.PairedDeviceInfo
 import com.hermesandroid.relay.diagnostics.DiagnosticCategory
 import com.hermesandroid.relay.diagnostics.DiagnosticSeverity
 import com.hermesandroid.relay.diagnostics.DiagnosticsLog
+import com.hermesandroid.relay.diagnostics.NetworkDiagnosticGuidance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
@@ -1139,6 +1140,7 @@ class RelayHttpClient(
         logSuccess: Boolean = true,
     ): Result<RelayHealth> = withContext(Dispatchers.IO) {
         val trimmed = relayUrl.trim()
+        val operation = "Relay health probe before WebSocket connection"
         if (trimmed.isEmpty()) {
             return@withContext Result.failure(
                 IllegalArgumentException("Relay URL is empty")
@@ -1159,7 +1161,9 @@ class RelayHttpClient(
                 severity = DiagnosticSeverity.Error,
                 title = context?.getString(R.string.http_diag_url_invalid) ?: "Relay URL invalid",
                 detail = e.message,
-                url = relayUrl,
+                operation = operation,
+                configuredUrl = relayUrl,
+                suggestion = "Enter a Relay URL beginning with ws:// or wss://.",
             )
             return@withContext Result.failure(
                 IOException("Invalid relay URL: ${e.message}")
@@ -1180,6 +1184,7 @@ class RelayHttpClient(
             .get()
             .header("Accept", "application/json")
             .build()
+        val requestUrl = request.url.toString()
 
         try {
             fastClient.newCall(request).execute().use { response ->
@@ -1189,8 +1194,11 @@ class RelayHttpClient(
                         severity = DiagnosticSeverity.Warning,
                         title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                         detail = "HTTP ${response.code}",
-                        url = httpBase,
+                        operation = operation,
+                        configuredUrl = trimmed,
+                        requestUrl = requestUrl,
                         elapsedMs = System.currentTimeMillis() - startedAtMs,
+                        suggestion = NetworkDiagnosticGuidance.forHttpStatus(response.code, "Relay"),
                     )
                     return@withContext Result.failure(
                         IOException("Relay responded HTTP ${response.code}")
@@ -1203,8 +1211,11 @@ class RelayHttpClient(
                         severity = DiagnosticSeverity.Warning,
                         title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                         detail = "Empty response",
-                        url = httpBase,
+                        operation = operation,
+                        configuredUrl = trimmed,
+                        requestUrl = requestUrl,
                         elapsedMs = System.currentTimeMillis() - startedAtMs,
+                        suggestion = "Verify this route points to a Hermes-Relay server and inspect its logs.",
                     )
                     return@withContext Result.failure(
                         IOException("Relay returned an empty response")
@@ -1220,8 +1231,11 @@ class RelayHttpClient(
                         severity = DiagnosticSeverity.Warning,
                         title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                         detail = "Non-JSON response",
-                        url = httpBase,
+                        operation = operation,
+                        configuredUrl = trimmed,
+                        requestUrl = requestUrl,
                         elapsedMs = System.currentTimeMillis() - startedAtMs,
+                        suggestion = "Verify this route points to a Hermes-Relay server rather than another HTTP service.",
                     )
                     return@withContext Result.failure(
                         IOException("Relay returned non-JSON: ${e.message ?: "parse error"}")
@@ -1234,8 +1248,11 @@ class RelayHttpClient(
                         severity = DiagnosticSeverity.Warning,
                         title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                         detail = "status=${status ?: "missing"}",
-                        url = httpBase,
+                        operation = operation,
+                        configuredUrl = trimmed,
+                        requestUrl = requestUrl,
                         elapsedMs = System.currentTimeMillis() - startedAtMs,
+                        suggestion = "Check the Relay service health and server logs.",
                     )
                     return@withContext Result.failure(
                         IOException("Relay reports status=${status ?: "missing"} (expected 'ok')")
@@ -1248,8 +1265,11 @@ class RelayHttpClient(
                         severity = DiagnosticSeverity.Warning,
                         title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                         detail = "Missing version field",
-                        url = httpBase,
+                        operation = operation,
+                        configuredUrl = trimmed,
+                        requestUrl = requestUrl,
                         elapsedMs = System.currentTimeMillis() - startedAtMs,
+                        suggestion = "Verify this route points to a current Hermes-Relay server.",
                     )
                     return@withContext Result.failure(
                         IOException("Response doesn't look like a hermes-relay — missing 'version' field")
@@ -1265,7 +1285,9 @@ class RelayHttpClient(
                         severity = DiagnosticSeverity.Info,
                         title = context?.getString(R.string.http_diag_health_ok) ?: "Relay health ok",
                         detail = "version=$version clients=$clients sessions=$sessions",
-                        url = httpBase,
+                        operation = operation,
+                        configuredUrl = trimmed,
+                        requestUrl = requestUrl,
                         elapsedMs = System.currentTimeMillis() - startedAtMs,
                     )
                 }
@@ -1278,8 +1300,11 @@ class RelayHttpClient(
                 severity = DiagnosticSeverity.Warning,
                 title = context?.getString(R.string.http_diag_health_timeout) ?: "Relay health timeout",
                 detail = "No HTTP response in 3s",
-                url = httpBase,
+                operation = operation,
+                configuredUrl = trimmed,
+                requestUrl = requestUrl,
                 elapsedMs = System.currentTimeMillis() - startedAtMs,
+                suggestion = NetworkDiagnosticGuidance.forThrowable(e, "Relay"),
             )
             Result.failure(IOException("Relay is not responding (3s timeout)"))
         } catch (e: java.net.ConnectException) {
@@ -1289,8 +1314,11 @@ class RelayHttpClient(
                 severity = DiagnosticSeverity.Error,
                 title = context?.getString(R.string.http_diag_conn_refused) ?: "Relay connection refused",
                 detail = e.message,
-                url = httpBase,
+                operation = operation,
+                configuredUrl = trimmed,
+                requestUrl = requestUrl,
                 elapsedMs = System.currentTimeMillis() - startedAtMs,
+                suggestion = NetworkDiagnosticGuidance.forThrowable(e, "Relay"),
             )
             Result.failure(IOException("Connection refused — is the relay running on this URL?"))
         } catch (e: IOException) {
@@ -1300,8 +1328,11 @@ class RelayHttpClient(
                 severity = DiagnosticSeverity.Warning,
                 title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                 detail = e.message ?: "Network error",
-                url = httpBase,
+                operation = operation,
+                configuredUrl = trimmed,
+                requestUrl = requestUrl,
                 elapsedMs = System.currentTimeMillis() - startedAtMs,
+                suggestion = NetworkDiagnosticGuidance.forThrowable(e, "Relay"),
             )
             Result.failure(IOException("Network error: ${e.message ?: "unreachable"}"))
         } catch (e: Exception) {
@@ -1311,8 +1342,11 @@ class RelayHttpClient(
                 severity = DiagnosticSeverity.Error,
                 title = context?.getString(R.string.http_diag_health_failed) ?: "Relay health failed",
                 detail = e.message ?: e.javaClass.simpleName,
-                url = httpBase,
+                operation = operation,
+                configuredUrl = trimmed,
+                requestUrl = requestUrl,
                 elapsedMs = System.currentTimeMillis() - startedAtMs,
+                suggestion = NetworkDiagnosticGuidance.forThrowable(e, "Relay"),
             )
             Result.failure(e)
         }

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/shared/EndpointResolver.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/shared/EndpointResolver.kt
@@ -9,6 +9,7 @@ import com.hermesandroid.relay.data.routeAuthority
 import com.hermesandroid.relay.diagnostics.DiagnosticCategory
 import com.hermesandroid.relay.diagnostics.DiagnosticSeverity
 import com.hermesandroid.relay.diagnostics.DiagnosticsLog
+import com.hermesandroid.relay.diagnostics.NetworkDiagnosticGuidance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
@@ -353,6 +354,10 @@ class EndpointResolver(
         surface: EndpointSurface,
     ): Boolean {
         val startedAtMs = clock()
+        val operation = when (surface) {
+            EndpointSurface.Standard -> "Dashboard or API route health probe"
+            EndpointSurface.Relay -> "Relay route health probe"
+        }
         val target = probeTarget(candidate, surface)
         val url = target?.requestUrl?.toHttpUrlOrNull()
             ?: run {
@@ -362,8 +367,10 @@ class EndpointResolver(
                     severity = DiagnosticSeverity.Error,
                     title = context?.getString(R.string.endpoint_diag_probe_invalid) ?: "Endpoint probe invalid",
                     detail = "No valid Dashboard, API, or Relay URL",
+                    operation = operation,
                     endpointRole = candidate.role,
-                    url = candidate.primaryRouteUrl(),
+                    configuredUrl = candidate.primaryRouteUrl(),
+                    suggestion = "Edit or re-pair this route so it contains a valid service URL.",
                 )
                 recordOutcome(candidate, surface, reachable = false, detail = "Invalid route URL")
                 return false
@@ -397,9 +404,16 @@ class EndpointResolver(
                             severity = if (ok) DiagnosticSeverity.Info else DiagnosticSeverity.Warning,
                             title = probeTitle,
                             detail = if (ok) null else "HTTP ${resp.code}",
+                            operation = operation,
                             endpointRole = candidate.role,
-                            url = target.baseUrl,
+                            configuredUrl = target.baseUrl,
+                            requestUrl = target.requestUrl,
                             elapsedMs = clock() - startedAtMs,
+                            suggestion = if (ok) {
+                                null
+                            } else {
+                                NetworkDiagnosticGuidance.forHttpStatus(resp.code, surface.diagnosticTarget())
+                            },
                         )
                         recordOutcome(
                             candidate,
@@ -415,9 +429,12 @@ class EndpointResolver(
                         severity = DiagnosticSeverity.Warning,
                         title = context?.getString(R.string.endpoint_diag_probe_timeout) ?: "Endpoint probe timeout",
                         detail = "No ${target.path} response in ${PROBE_TIMEOUT_MS}ms",
+                        operation = operation,
                         endpointRole = candidate.role,
-                        url = target.baseUrl,
+                        configuredUrl = target.baseUrl,
+                        requestUrl = target.requestUrl,
                         elapsedMs = clock() - startedAtMs,
+                        suggestion = "Check network routing or firewall rules between this device and ${surface.diagnosticTarget()}.",
                     )
                     recordOutcome(candidate, surface, reachable = false, detail = PROBE_TIMEOUT_DETAIL)
                     false
@@ -428,9 +445,12 @@ class EndpointResolver(
                     severity = DiagnosticSeverity.Warning,
                     title = context?.getString(R.string.endpoint_diag_probe_timeout) ?: "Endpoint probe timeout",
                     detail = "No ${target.path} response in ${PROBE_TIMEOUT_MS}ms",
+                    operation = operation,
                     endpointRole = candidate.role,
-                    url = target.baseUrl,
+                    configuredUrl = target.baseUrl,
+                    requestUrl = target.requestUrl,
                     elapsedMs = clock() - startedAtMs,
+                    suggestion = "Check network routing or firewall rules between this device and ${surface.diagnosticTarget()}.",
                 )
                 recordOutcome(candidate, surface, reachable = false, detail = PROBE_TIMEOUT_DETAIL)
                 false
@@ -441,10 +461,13 @@ class EndpointResolver(
                     category = DiagnosticCategory.Endpoint,
                     severity = DiagnosticSeverity.Warning,
                     title = context?.getString(R.string.endpoint_diag_probe_failed) ?: "Endpoint probe failed",
-                    detail = e.javaClass.simpleName,
+                    detail = humanProbeFailure(e),
+                    operation = operation,
                     endpointRole = candidate.role,
-                    url = target.baseUrl,
+                    configuredUrl = target.baseUrl,
+                    requestUrl = target.requestUrl,
                     elapsedMs = clock() - startedAtMs,
+                    suggestion = NetworkDiagnosticGuidance.forThrowable(e, surface.diagnosticTarget()),
                 )
                 recordOutcome(candidate, surface, reachable = false, detail = humanProbeFailure(e))
                 false
@@ -519,6 +542,11 @@ class EndpointResolver(
         is SocketTimeoutException -> PROBE_TIMEOUT_DETAIL
         is NoRouteToHostException -> "No route to host"
         else -> e.javaClass.simpleName
+    }
+
+    private fun EndpointSurface.diagnosticTarget(): String = when (this) {
+        EndpointSurface.Standard -> "Dashboard or API server"
+        EndpointSurface.Relay -> "Relay"
     }
 
     /**

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/DiagnosticDetailDialog.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/DiagnosticDetailDialog.kt
@@ -106,9 +106,27 @@ fun DiagnosticDetailDialog(entry: DiagnosticLogEntry, onDismiss: () -> Unit) {
                 MetaRow("When", DateFormat.format("yyyy-MM-dd HH:mm:ss", entry.timestampMs).toString())
                 MetaRow("Severity", severityName)
                 MetaRow("Category", entry.category.label)
+                entry.operation?.let { MetaRow("Operation", it) }
                 entry.endpointRole?.let { MetaRow("Route", it) }
-                entry.url?.let { MetaRow("URL", it) }
+                entry.configuredUrl?.let { MetaRow("Configured URL", it) }
+                entry.requestUrl?.let { MetaRow("Request", it) }
+                if (entry.configuredUrl == null && entry.requestUrl == null) {
+                    entry.url?.let { MetaRow("URL", it) }
+                }
                 entry.elapsedMs?.let { MetaRow("Elapsed", "${it}ms") }
+                entry.suggestion?.let { suggestion ->
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        text = "Suggested next step",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = suggestion,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
 
                 Spacer(Modifier.height(14.dp))
                 val body = entry.stacktrace ?: entry.detail
@@ -269,9 +287,15 @@ private fun DiagnosticLogEntry.toPlainText(): String = buildString {
     appendLine("Severity: ${severity.name}")
     appendLine("Time:     ${DateFormat.format("yyyy-MM-dd HH:mm:ss", timestampMs)}")
     appendLine("App:      ${BuildConfig.VERSION_NAME} (code ${BuildConfig.VERSION_CODE}) ${BuildConfig.FLAVOR}")
+    operation?.let { appendLine("Operation: $it") }
     endpointRole?.let { appendLine("Route:    $it") }
-    url?.let { appendLine("URL:      $it") }
+    configuredUrl?.let { appendLine("Configured URL: $it") }
+    requestUrl?.let { appendLine("Request:  $it") }
+    if (configuredUrl == null && requestUrl == null) {
+        url?.let { appendLine("URL:      $it") }
+    }
     elapsedMs?.let { appendLine("Elapsed:  ${it}ms") }
+    suggestion?.let { appendLine("Suggested next step: $it") }
     detail?.let {
         appendLine()
         appendLine("Detail:")

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/DiagnosticsLogPanel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/DiagnosticsLogPanel.kt
@@ -218,8 +218,10 @@ private fun severityColor(severity: DiagnosticSeverity): Color = when (severity)
 private fun DiagnosticLogEntry.detailLine(): String? {
     val pieces = listOfNotNull(
         detail,
+        suggestion,
+        operation,
         endpointRole?.let { "route=$it" },
-        url,
+        primaryUrl,
         elapsedMs?.let { "${it}ms" },
     )
     return pieces.joinToString(" - ").takeIf { it.isNotBlank() }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DiagnosticsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DiagnosticsScreen.kt
@@ -323,7 +323,7 @@ internal fun buildStatusChecks(
             it.category == category && it.severity == DiagnosticSeverity.Error
         }
 
-    fun DiagnosticLogEntry.message(): String = detail ?: title
+    fun DiagnosticLogEntry.message(): String = suggestion ?: detail ?: title
 
     val checks = mutableListOf<StatusCheck>()
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/util/DiagnosticIssuePrefill.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/util/DiagnosticIssuePrefill.kt
@@ -28,6 +28,9 @@ object DiagnosticIssuePrefill {
     private const val MAX_TRACE_FOR_URL = 3000
 
     private const val DEFAULT_WHAT_HAPPENED = "Captured diagnostic from the in-app activity log."
+    private const val CONFIGURED_URL_MARKER = "[diagnostic-configured-url]"
+    private const val REQUEST_URL_MARKER = "[diagnostic-request-url]"
+    private const val LEGACY_URL_MARKER = "[diagnostic-url]"
 
     /** `[Bug]:` for Error entries, `[Diagnostic]:` for Info/Warning. */
     fun issueTitle(entry: DiagnosticLogEntry): String = when (entry.severity) {
@@ -53,7 +56,7 @@ object DiagnosticIssuePrefill {
      */
     fun connectionMode(entry: DiagnosticLogEntry): String =
         entry.endpointRole
-            ?: entry.url?.let { Connection.inferRouteRole(it) }
+            ?: entry.primaryUrl?.let { Connection.inferRouteRole(it) }
             ?: "unknown"
 
     /**
@@ -77,6 +80,9 @@ object DiagnosticIssuePrefill {
         val whatHappened = DiagnosticsLog.redactReportText(expectation)
             ?.takeIf { it.isNotBlank() }
             ?: DEFAULT_WHAT_HAPPENED
+        val configuredUrl = reportSafeUrl(entry.configuredUrl)
+        val requestUrl = reportSafeUrl(entry.requestUrl)
+        val legacyUrl = reportSafeUrl(entry.url)
         val body = buildString {
             appendLine(
                 "> ⚠️ Before submitting: remove any secrets, tokens, real hostnames/IPs, " +
@@ -100,9 +106,15 @@ object DiagnosticIssuePrefill {
             appendLine("- Title: ${entry.title}")
             appendLine("- Category: ${entry.category.label}")
             appendLine("- Severity: ${entry.severity.name}")
+            entry.operation?.let { appendLine("- Operation: $it") }
             entry.endpointRole?.let { appendLine("- Route: $it") }
-            entry.url?.let { appendLine("- URL: $it") }
+            configuredUrl?.let { appendLine("- Configured URL: $CONFIGURED_URL_MARKER") }
+            requestUrl?.let { appendLine("- Request: $REQUEST_URL_MARKER") }
+            if (configuredUrl == null && requestUrl == null) {
+                legacyUrl?.let { appendLine("- URL: $LEGACY_URL_MARKER") }
+            }
             entry.elapsedMs?.let { appendLine("- Elapsed: ${it}ms") }
+            entry.suggestion?.let { appendLine("- Suggested next step: $it") }
             if (trace.isNotBlank()) {
                 appendLine()
                 appendLine("```")
@@ -113,5 +125,17 @@ object DiagnosticIssuePrefill {
             append("<sub>Captured by the Hermes-Relay in-app diagnostics log</sub>")
         }
         return DiagnosticsLog.redactReportText(body).orEmpty()
+            .replace(CONFIGURED_URL_MARKER, configuredUrl.orEmpty())
+            .replace(REQUEST_URL_MARKER, requestUrl.orEmpty())
+            .replace(LEGACY_URL_MARKER, legacyUrl.orEmpty())
+    }
+
+    private fun reportSafeUrl(value: String?): String? {
+        val sanitized = DiagnosticsLog.sanitizeUrl(value) ?: return null
+        return if (sanitized.contains("://")) {
+            sanitized
+        } else {
+            DiagnosticsLog.redactReportText(sanitized)
+        }
     }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.diagnostics.DiagnosticCategory
 import com.hermesandroid.relay.diagnostics.DiagnosticsLog
+import com.hermesandroid.relay.diagnostics.NetworkDiagnosticGuidance
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
@@ -226,17 +227,30 @@ fun classifyError(t: Throwable?, context: String? = null, ctx: Context? = null):
         // Record after classification so the clean title and the raw trace both
         // reach the log. Defensive: never let logging turn a handled error fatal.
         runCatching {
+            val category = categoryForContext(context)
             DiagnosticsLog.recordError(
-                category = categoryForContext(context),
+                category = category,
                 title = human.title,
                 detail = human.body,
                 throwable = t,
+                operation = context?.diagnosticOperation(),
+                suggestion = NetworkDiagnosticGuidance.forThrowable(t, category.label),
                 reliabilityContext = context,
             )
         }
     }
     return human
 }
+
+private fun String.diagnosticOperation(): String =
+    trim()
+        .split('_', '-', ' ')
+        .filter { it.isNotBlank() }
+        .joinToString(" ") { word ->
+            word.replaceFirstChar { character ->
+                if (character.isLowerCase()) character.titlecase() else character.toString()
+            }
+        }
 
 private fun classifyErrorInternal(t: Throwable?, context: String?, ctx: Context?): HumanError {
     if (t == null) return nullFallback(context, ctx)

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
@@ -5267,12 +5267,15 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                 return@launch
             }
 
+            val diagnosticApiUrl = effectiveApiServerUrlSnapshot()
             _apiServerHealth.value = HealthStatus.Probing
             DiagnosticsLog.record(
                 category = DiagnosticCategory.Api,
                 severity = DiagnosticSeverity.Info,
                 title = ctx.getString(R.string.conn_status_testing_standard),
-                url = effectiveApiServerUrlSnapshot(),
+                operation = "Hermes API health check",
+                configuredUrl = diagnosticApiUrl,
+                requestUrl = "${diagnosticApiUrl.trimEnd('/')}/health",
             )
 
             val health = client.checkHealthDetailed()
@@ -5284,7 +5287,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                     severity = DiagnosticSeverity.Error,
                     title = ctx.getString(R.string.conn_status_setup_health_failed),
                     detail = health.message,
-                    url = effectiveApiServerUrlSnapshot(),
+                    operation = "Hermes API health check",
+                    configuredUrl = diagnosticApiUrl,
+                    requestUrl = "${diagnosticApiUrl.trimEnd('/')}/health",
                 )
                 onResult(
                     StandardApiSetupResult(
@@ -5365,7 +5370,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                 severity = if (reachable) DiagnosticSeverity.Info else DiagnosticSeverity.Error,
                 title = if (reachable) ctx.getString(R.string.conn_status_hermes_ok) else ctx.getString(R.string.conn_status_auth_failed),
                 detail = message,
-                url = effectiveApiServerUrlSnapshot(),
+                operation = "Hermes API sessions authentication check",
+                configuredUrl = diagnosticApiUrl,
+                requestUrl = "${diagnosticApiUrl.trimEnd('/')}/api/sessions",
             )
             onResult(
                 StandardApiSetupResult(
@@ -5587,12 +5594,15 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                 return@launch
             }
 
+            val diagnosticApiUrl = effectiveApiServerUrlSnapshot()
             _apiServerHealth.value = HealthStatus.Probing
             DiagnosticsLog.record(
                 category = DiagnosticCategory.Api,
                 severity = DiagnosticSeverity.Info,
                 title = ctx.getString(R.string.conn_status_testing_api),
-                url = effectiveApiServerUrlSnapshot(),
+                operation = "Hermes API health check",
+                configuredUrl = diagnosticApiUrl,
+                requestUrl = "${diagnosticApiUrl.trimEnd('/')}/health",
             )
             val health = client.checkHealthDetailed()
             if (health is com.hermesandroid.relay.network.upstream.HealthCheckResult.Unhealthy) {
@@ -5603,7 +5613,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                     severity = DiagnosticSeverity.Error,
                     title = ctx.getString(R.string.conn_status_api_health_failed),
                     detail = health.message,
-                    url = effectiveApiServerUrlSnapshot(),
+                    operation = "Hermes API health check",
+                    configuredUrl = diagnosticApiUrl,
+                    requestUrl = "${diagnosticApiUrl.trimEnd('/')}/health",
                 )
                 onResult(false, health.message)
                 return@launch
@@ -5624,7 +5636,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
                 severity = if (reachable) DiagnosticSeverity.Info else DiagnosticSeverity.Error,
                 title = if (reachable) ctx.getString(R.string.conn_status_api_test_ok) else ctx.getString(R.string.conn_status_api_test_failed),
                 detail = message,
-                url = effectiveApiServerUrlSnapshot(),
+                operation = "Hermes API sessions authentication check",
+                configuredUrl = diagnosticApiUrl,
+                requestUrl = "${diagnosticApiUrl.trimEnd('/')}/api/sessions",
             )
             onResult(reachable, message)
         }

--- a/app/src/test/kotlin/com/hermesandroid/relay/diagnostics/NetworkDiagnosticGuidanceTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/diagnostics/NetworkDiagnosticGuidanceTest.kt
@@ -1,0 +1,62 @@
+package com.hermesandroid.relay.diagnostics
+
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkDiagnosticGuidanceTest {
+
+    @Test
+    fun connectionRefusalPointsToTheOwningListener() {
+        val guidance = NetworkDiagnosticGuidance.forThrowable(
+            ConnectException("Failed to connect"),
+            target = "Relay",
+        )
+
+        assertEquals(
+            "Verify Relay is running and listening on the configured host and port.",
+            guidance,
+        )
+    }
+
+    @Test
+    fun wrappedNetworkFailuresUseTheRootCause() {
+        val guidance = NetworkDiagnosticGuidance.forThrowable(
+            IllegalStateException("probe failed", UnknownHostException("missing.example")),
+            target = "Dashboard",
+        )
+
+        assertTrue(guidance.orEmpty().contains("hostname"))
+    }
+
+    @Test
+    fun transportFailuresHaveDistinctNextSteps() {
+        assertTrue(
+            NetworkDiagnosticGuidance.forThrowable(SocketTimeoutException(), "API")
+                .orEmpty().contains("routing or firewall"),
+        )
+        assertTrue(
+            NetworkDiagnosticGuidance.forThrowable(NoRouteToHostException(), "API")
+                .orEmpty().contains("network path"),
+        )
+        assertTrue(
+            NetworkDiagnosticGuidance.forThrowable(SSLHandshakeException("bad cert"), "Relay")
+                .orEmpty().contains("TLS"),
+        )
+    }
+
+    @Test
+    fun httpStatusGuidanceIsSpecificAndUnknownSuccessHasNone() {
+        assertTrue(NetworkDiagnosticGuidance.forHttpStatus(401, "API").orEmpty().contains("credentials"))
+        assertTrue(NetworkDiagnosticGuidance.forHttpStatus(404, "Relay").orEmpty().contains("route"))
+        assertTrue(NetworkDiagnosticGuidance.forHttpStatus(429, "Relay").orEmpty().contains("backoff"))
+        assertTrue(NetworkDiagnosticGuidance.forHttpStatus(503, "API").orEmpty().contains("server logs"))
+        assertNull(NetworkDiagnosticGuidance.forHttpStatus(204, "API"))
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClientDiagnosticsTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClientDiagnosticsTest.kt
@@ -1,0 +1,49 @@
+package com.hermesandroid.relay.network.relay
+
+import com.hermesandroid.relay.diagnostics.DiagnosticCategory
+import com.hermesandroid.relay.diagnostics.DiagnosticsLog
+import java.net.ServerSocket
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RelayHttpClientDiagnosticsTest {
+    @Before
+    fun setUp() {
+        DiagnosticsLog.clear()
+    }
+
+    @After
+    fun tearDown() {
+        DiagnosticsLog.clear()
+    }
+
+    @Test
+    fun refusedHealthProbeExplainsProtocolConversionAndOwningListener() = runTest {
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        val configuredRelay = "ws://127.0.0.1:$unusedPort"
+        val client = RelayHttpClient(
+            okHttpClient = OkHttpClient(),
+            relayUrlProvider = { configuredRelay },
+            sessionTokenProvider = { null },
+        )
+
+        val result = client.probeHealth(configuredRelay)
+
+        assertTrue(result.isFailure)
+        val entry = DiagnosticsLog.recent(setOf(DiagnosticCategory.Relay)).first()
+        assertEquals("Relay health probe before WebSocket connection", entry.operation)
+        assertEquals("ws://[host]", entry.configuredUrl)
+        assertEquals("http://[host]/health", entry.requestUrl)
+        assertEquals(
+            "Verify Relay is running and listening on the configured host and port.",
+            entry.suggestion,
+        )
+        assertFalse(entry.detail.orEmpty().contains(unusedPort.toString()))
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/shared/EndpointResolverTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/shared/EndpointResolverTest.kt
@@ -4,6 +4,8 @@ import com.hermesandroid.relay.data.ApiEndpoint
 import com.hermesandroid.relay.data.DashboardEndpoint
 import com.hermesandroid.relay.data.EndpointCandidate
 import com.hermesandroid.relay.data.RelayEndpoint
+import com.hermesandroid.relay.diagnostics.DiagnosticCategory
+import com.hermesandroid.relay.diagnostics.DiagnosticsLog
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.Dispatcher
@@ -40,6 +42,7 @@ class EndpointResolverTest {
 
     @Before
     fun setUp() {
+        DiagnosticsLog.clear()
         clockMillis.set(0L)
         reachableServer = MockWebServer().apply {
             dispatcher = healthDispatcher(statusCode = 200)
@@ -61,6 +64,7 @@ class EndpointResolverTest {
 
     @After
     fun tearDown() {
+        DiagnosticsLog.clear()
         runCatching { reachableServer.shutdown() }
         runCatching { secondReachableServer.shutdown() }
     }
@@ -370,6 +374,11 @@ class EndpointResolverTest {
         assertNotNull(request)
         assertEquals("GET", request!!.method)
         assertEquals("/api/status", request.path)
+        val diagnostic = DiagnosticsLog.recent(setOf(DiagnosticCategory.Endpoint))
+            .first { it.operation != null }
+        assertEquals("Dashboard or API route health probe", diagnostic.operation)
+        assertEquals("http://[host]", diagnostic.configuredUrl)
+        assertEquals("http://[host]/api/status", diagnostic.requestUrl)
     }
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/DiagnosticsScreenTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/DiagnosticsScreenTest.kt
@@ -5,6 +5,9 @@ import androidx.test.core.app.ApplicationProvider
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.auth.AuthState
 import com.hermesandroid.relay.diagnostics.CheckStatus
+import com.hermesandroid.relay.diagnostics.DiagnosticCategory
+import com.hermesandroid.relay.diagnostics.DiagnosticLogEntry
+import com.hermesandroid.relay.diagnostics.DiagnosticSeverity
 import com.hermesandroid.relay.network.shared.ConnectivityObserver
 import com.hermesandroid.relay.network.upstream.GatewayAvailability
 import com.hermesandroid.relay.network.upstream.ServerCapabilities
@@ -67,5 +70,44 @@ class DiagnosticsScreenTest {
                     it.status == CheckStatus.Fail
             },
         )
+    }
+
+    @Test
+    fun failedStatusCheckLeadsWithActionableSuggestion() {
+        val suggestion = "Verify Relay is running and listening on the configured host and port."
+        val entry = DiagnosticLogEntry(
+            timestampMs = 123L,
+            category = DiagnosticCategory.Relay,
+            severity = DiagnosticSeverity.Error,
+            title = "Relay connection refused",
+            detail = "Failed to connect",
+            suggestion = suggestion,
+        )
+
+        val checks = buildStatusChecks(
+            network = ConnectivityObserver.Status.Available,
+            dashboardUrl = "https://hermes.example.com",
+            gatewayAvailability = GatewayAvailability.Ready,
+            apiConfigured = false,
+            apiHealth = ConnectionViewModel.HealthStatus.Unknown,
+            apiUrl = "",
+            capabilities = ServerCapabilities.DISCONNECTED,
+            authState = AuthState.Unpaired,
+            relayConfigured = true,
+            relayHealth = ConnectionViewModel.HealthStatus.Unreachable,
+            relayReady = false,
+            relayUpdateInfo = null,
+            voiceReady = true,
+            relayVoiceReady = false,
+            recentEntries = listOf(entry),
+            context = context,
+        )
+
+        val relay = checks.single {
+            it.name == context.getString(R.string.active_section_optional_relay)
+        }
+        assertEquals(CheckStatus.Fail, relay.status)
+        assertEquals(suggestion, relay.reason)
+        assertEquals(123L, relay.timestampMs)
     }
 }

--- a/app/src/test/kotlin/com/hermesandroid/relay/util/IssueReportAndDiagnosticsTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/util/IssueReportAndDiagnosticsTest.kt
@@ -9,6 +9,7 @@ import java.net.URLDecoder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -101,6 +102,10 @@ class IssueReportAndDiagnosticsTest {
         endpointRole: String? = null,
         url: String? = null,
         detail: String? = null,
+        operation: String? = null,
+        configuredUrl: String? = null,
+        requestUrl: String? = null,
+        suggestion: String? = null,
     ) = DiagnosticLogEntry(
         timestampMs = 0L,
         category = DiagnosticCategory.Api,
@@ -109,6 +114,10 @@ class IssueReportAndDiagnosticsTest {
         detail = detail,
         endpointRole = endpointRole,
         url = url,
+        operation = operation,
+        configuredUrl = configuredUrl,
+        requestUrl = requestUrl,
+        suggestion = suggestion,
     )
 
     @Test
@@ -181,6 +190,65 @@ class IssueReportAndDiagnosticsTest {
     fun connectionModeIsUnknownWithoutRouteOrUrl() {
         val body = DiagnosticIssuePrefill.issueBody(sampleEntry(DiagnosticSeverity.Warning))
         assertTrue(body.contains("- Connection mode: unknown"))
+    }
+
+    @Test
+    fun bodyExplainsConfiguredRouteActualRequestAndNextStep() {
+        val body = DiagnosticIssuePrefill.issueBody(
+            sampleEntry(
+                severity = DiagnosticSeverity.Error,
+                title = "Relay connection refused",
+                operation = "Relay health probe before WebSocket connection",
+                configuredUrl = "ws://10.3.0.5:8767",
+                requestUrl = "http://10.3.0.5:8767/health",
+                suggestion = "Verify Relay is running and listening on the configured host and port.",
+            ),
+        )
+
+        assertTrue(body.contains("- Operation: Relay health probe before WebSocket connection"))
+        assertTrue(body.contains("- Configured URL: ws://[host]"))
+        assertTrue(body.contains("- Request: http://[host]/health"))
+        assertTrue(
+            body.contains(
+                "- Suggested next step: Verify Relay is running and listening on the configured host and port.",
+            ),
+        )
+        assertFalse(body.contains("10.3.0.5"))
+        assertFalse(body.lineSequence().any { it.startsWith("- URL:") })
+    }
+
+    @Test
+    fun connectionModePrefersConfiguredRouteOverConvertedProbeRequest() {
+        val entry = sampleEntry(
+            severity = DiagnosticSeverity.Error,
+            configuredUrl = "wss://100.80.1.2:8767",
+            requestUrl = "https://relay.example.com:8767/health",
+        )
+
+        assertEquals("tailscale", DiagnosticIssuePrefill.connectionMode(entry))
+    }
+
+    @Test
+    fun recordSanitizesStructuredDiagnosticContext() {
+        DiagnosticsLog.clear()
+
+        DiagnosticsLog.record(
+            category = DiagnosticCategory.Relay,
+            severity = DiagnosticSeverity.Error,
+            title = "Relay failed",
+            operation = " Relay health probe ",
+            configuredUrl = "ws://token=secret@relay.example.com:8767?token=secret",
+            requestUrl = "http://relay.example.com:8767/health?api_key=secret",
+            suggestion = " Retry with token=secret after checking the service. ",
+            url = "http://legacy.example.com:8767",
+        )
+
+        val entry = DiagnosticsLog.recent(limit = 1).single()
+        assertEquals("Relay health probe", entry.operation)
+        assertEquals("ws://[host]", entry.configuredUrl)
+        assertEquals("http://[host]/health", entry.requestUrl)
+        assertEquals("Retry with token=[hidden] after checking the service.", entry.suggestion)
+        assertNull(entry.url)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- distinguish configured connection routes from the exact redacted requests used for health, route, WebSocket, and API checks
- attach operation-specific guidance for network, TLS, HTTP, authentication, and server failures
- carry actionable context through Android diagnostics UI, copied logs, and privacy-safe GitHub issue reports

## Verification
- focused diagnostic and connection unit tests
- assembleGooglePlayDebug
- Android pre-push checks
- lintGooglePlayDebug
- git diff --check