### PR TITLE
fix(android): restore focus voice controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Android Focus voice controls remain responsive.** The modal click-through guard now sits behind the voice UI instead of consuming pointer events from the mic, close, expansion, and panel controls.
 - **Android diagnostics explain what failed and what to try next.** Relay, route, WebSocket, and API checks distinguish the saved route from the redacted request they actually attempted, name the operation, and provide targeted guidance for connection, DNS, timeout, TLS, authentication, rate-limit, and server failures.
 - **Android chat and Voice keep one render identity through recovery.** Checkpoint restore, streamed callbacks, server-ID adoption, and replay now resolve the same owned transcript row before publication, preventing recurring Compose duplicate-key crashes.
 - **Issue area labels require maintainer review.** The unreliable keyword-based auto-labeling workflow no longer assigns ownership from ambiguous issue text.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,17 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-05 — Focus voice input boundary repair
+
+The Focus voice presentation remains modal without installing a consuming
+pointer handler on the full overlay ancestor. Its click-through guard is now a
+behind-content sibling: empty-space gestures cannot reach the chat or drawer,
+while the mic, close, expand/collapse, and panel controls receive their full
+pointer sequence.
+
+Host-side Compose coverage injects real touch events instead of invoking
+semantic click actions. It verifies both child callback delivery and the modal
+background boundary so the two requirements cannot regress independently.
+
 ## 2026-08-05 — Actionable Android connection diagnostics
 
 Android diagnostic entries now separate the configured route from the exact

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlay.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlay.kt
@@ -194,27 +194,29 @@ fun VoiceModeOverlay(
         modifier = modifier
             .fillMaxSize()
             .background(if (focusMode) surface.copy(alpha = 0.96f) else Color.Transparent)
-            // Click-through fix: in focus mode the overlay is a true modal.
-            // Consume any pointer event a child (mic button, transcript,
-            // chips, pill) didn't handle so stray taps/swipes don't fall
-            // through to the chat + session drawer behind it. Children run on
-            // the same Main pass leaf-first, so this only catches the gaps.
-            // In Conversation the overlay is intentionally transparent and the
-            // chat stays interactive, so no scrim is installed.
-            .then(
-                if (focusMode) {
-                    Modifier.pointerInput(Unit) {
+    ) {
+        if (focusMode) {
+            // Focus is modal, but its click-through guard must be a sibling
+            // behind the controls. A consuming pointerInput on the root is an
+            // ancestor of every button and cancels their gesture detectors on
+            // later pointer passes, leaving ripples without firing callbacks.
+            // This scrim wins hit-testing only where no foreground control did,
+            // so blank-space gestures stay off the chat underneath while mic,
+            // close, pill, and expanded-panel controls remain interactive.
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .testTag("voiceFocusInputScrim")
+                    .pointerInput(Unit) {
                         awaitPointerEventScope {
                             while (true) {
                                 awaitPointerEvent().changes.forEach { it.consume() }
                             }
                         }
-                    }
-                } else {
-                    Modifier
-                }
+                    },
             )
-    ) {
+        }
+
         if (focusMode) {
             VoiceSessionPill(
                 uiState = uiState,

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayInteractionTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayInteractionTest.kt
@@ -1,0 +1,115 @@
+package com.hermesandroid.relay.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.click
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.hermesandroid.relay.viewmodel.InteractionMode
+import com.hermesandroid.relay.viewmodel.VoiceState
+import com.hermesandroid.relay.viewmodel.VoiceUiState
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h720dp-xxhdpi")
+class VoiceModeOverlayInteractionTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun focusMode_childControlsReceiveRealPointerClicks() {
+        var micTaps = 0
+        var dismissals = 0
+        val modeChanges = mutableListOf<InteractionMode>()
+        compose.mainClock.autoAdvance = false
+
+        compose.setContent {
+            MaterialTheme {
+                VoiceModeOverlay(
+                    uiState = idleVoiceState(),
+                    onMicTap = { micTaps += 1 },
+                    onMicRelease = {},
+                    onInterrupt = {},
+                    onDismiss = { dismissals += 1 },
+                    onModeChange = { modeChanges += it },
+                    onClearError = {},
+                )
+            }
+        }
+
+        compose.onNodeWithContentDescription("Voice mic")
+            .performTouchInput { click() }
+        compose.onNodeWithContentDescription("Expand voice controls")
+            .performTouchInput { click() }
+        compose.mainClock.advanceTimeBy(500)
+        compose.onNodeWithText("Hold")
+            .performTouchInput { click() }
+        compose.onNodeWithContentDescription("Collapse voice controls")
+            .performTouchInput { click() }
+        compose.onNodeWithContentDescription("Exit voice mode")
+            .performTouchInput { click() }
+
+        compose.runOnIdle {
+            assertEquals(1, micTaps)
+            assertEquals(1, dismissals)
+            assertEquals(listOf(InteractionMode.HoldToTalk), modeChanges)
+        }
+    }
+
+    @Test
+    fun focusMode_emptySpaceDoesNotClickThroughToChat() {
+        var backgroundTaps = 0
+        compose.mainClock.autoAdvance = false
+
+        compose.setContent {
+            MaterialTheme {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .testTag("backgroundChat")
+                        .clickable { backgroundTaps += 1 },
+                )
+                VoiceModeOverlay(
+                    uiState = idleVoiceState(),
+                    onMicTap = {},
+                    onMicRelease = {},
+                    onInterrupt = {},
+                    onDismiss = {},
+                    onModeChange = {},
+                    onClearError = {},
+                )
+            }
+        }
+
+        compose.onNodeWithTag(FOCUS_INPUT_SCRIM_TAG)
+            .performTouchInput { click(Offset(1f, center.y)) }
+
+        compose.runOnIdle { assertEquals(0, backgroundTaps) }
+    }
+
+    private fun idleVoiceState() = VoiceUiState(
+        voiceMode = true,
+        state = VoiceState.Idle,
+        interactionMode = InteractionMode.TapToTalk,
+    )
+
+    private companion object {
+        const val FOCUS_INPUT_SCRIM_TAG = "voiceFocusInputScrim"
+    }
+}


### PR DESCRIPTION
## Summary
- keep Focus voice mode modal without consuming pointer events from child controls
- move the click-through guard behind the Focus UI so mic, close, expand, and panel actions remain responsive
- add real-touch Compose regression coverage for child callbacks and background click blocking

Closes #299

## Verification
- focused Focus/voice state and app chrome tests
- assembleGooglePlayDebug
- lintGooglePlayDebug
- git diff --check