### PR TITLE
release: Desktop 0.4.0-alpha.4

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -256,8 +256,8 @@ jobs:
           $env:USERPROFILE = $smokeProfile
           $env:HOME = $smokeProfile
           try {
-            & $setup /S "/D=$installDir"
-            if ($LASTEXITCODE -ne 0) { throw "installer exited with code $LASTEXITCODE" }
+            $installProcess = Start-Process -FilePath $setup -ArgumentList @('/S', "/D=$installDir") -Wait -PassThru
+            if ($installProcess.ExitCode -ne 0) { throw "installer exited with code $($installProcess.ExitCode)" }
 
             $expectedFiles = @(
               'hermes-relay.exe',
@@ -287,8 +287,8 @@ jobs:
               throw 'installer removed profile session data'
             }
 
-            & $uninstaller /S
-            if ($LASTEXITCODE -ne 0) { throw "uninstaller exited with code $LASTEXITCODE" }
+            $uninstallProcess = Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait -PassThru
+            if ($uninstallProcess.ExitCode -ne 0) { throw "uninstaller exited with code $($uninstallProcess.ExitCode)" }
 
             $deadline = [DateTime]::UtcNow.AddSeconds(20)
             while ((Test-Path -LiteralPath $uninstaller) -and [DateTime]::UtcNow -lt $deadline) {
@@ -322,7 +322,7 @@ jobs:
             Get-Process -Name 'hermes-relay-tray' -ErrorAction SilentlyContinue |
               Stop-Process -Force -ErrorAction SilentlyContinue
             if (Test-Path -LiteralPath $uninstaller) {
-              & $uninstaller /S | Out-Null
+              Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait | Out-Null
             }
             $env:USERPROFILE = $oldUserProfile
             $env:HOME = $oldHomeEnv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.4.0-alpha.4] - 2026-08-11
+
+### Fixed
+
+- **Windows release validation waits for installer processes.** The packaged install/uninstall lifecycle smoke now captures GUI-subsystem process exit codes reliably before validating installed files, preserved sessions, registry state, and cleanup.
+
 ## [0.4.0-alpha.3] - 2026-08-11
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-alpha.3",
+      "version": "0.4.0-alpha.4",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-alpha.3" as const
+export const VERSION = "0.4.0-alpha.4" as const

--- a/desktop/tests/updaterInstaller.test.ts
+++ b/desktop/tests/updaterInstaller.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test'
 
 import { updateCommand } from '../src/commands/update.js'
 import { checkForUpdate, downloadAndInstall } from '../src/updater.js'
+import { VERSION } from '../src/version.js'
 
 async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
   const originalWrite = process.stdout.write
@@ -85,7 +86,7 @@ test('installer check reports a newer local preview without treating it as an er
     }))
     assert.equal(check.code, 0)
     const report = JSON.parse(check.output)
-    assert.equal(report.current, '0.4.0-alpha.3')
+    assert.equal(report.current, VERSION)
     assert.equal(report.latest_version, '0.4.0-alpha.2')
     assert.equal(report.up_to_date, true)
     assert.equal(report.ahead_of_latest, true)

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-alpha.3",
+      "version": "0.4.0-alpha.4",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- publish the CLI and Windows management UI as Desktop 0.4.0-alpha.4
- make the packaged installer lifecycle smoke wait for GUI-subsystem installer processes and capture their exit codes
- keep updater version assertions tied to generated version metadata

## Verification
- desktop type-check
- desktop tests (79/79)
- desktop version synchronization
- release workflow will build and smoke the packaged NSIS lifecycle