### PR TITLE
release: Desktop 0.4.0-alpha.5

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -308,6 +308,10 @@ jobs:
               throw 'installer lifecycle modified preserved profile session data'
             }
 
+            # User PATH may contain expandable %USERPROFILE% entries. Restore the
+            # runner profile before comparing the unchanged registry value.
+            $env:USERPROFILE = $oldUserProfile
+            $env:HOME = $oldHomeEnv
             $userPathAfter = Normalize-UserPath ([Environment]::GetEnvironmentVariable('Path', 'User'))
             if ($userPathAfter -ne $userPathBefore) {
               throw "uninstaller did not restore user PATH (before='$userPathBefore', after='$userPathAfter')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.4.0-alpha.5] - 2026-08-11
+
+### Fixed
+
+- **Installer cleanup validation handles expandable Windows PATH entries.** Release smoke tests restore the original profile environment before comparing user PATH, avoiding false failures when unchanged `%USERPROFILE%` entries are expanded inside an isolated test profile.
+
 ## [0.4.0-alpha.4] - 2026-08-11
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.4",
+  "version": "0.4.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-alpha.4",
+      "version": "0.4.0-alpha.5",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.4",
+  "version": "0.4.0-alpha.5",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-alpha.4" as const
+export const VERSION = "0.4.0-alpha.5" as const

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.4"
+version = "0.4.0-alpha.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.4"
+version = "0.4.0-alpha.5"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-alpha.4",
+  "version": "0.4.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-alpha.4",
+      "version": "0.4.0-alpha.5",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-alpha.4",
+  "version": "0.4.0-alpha.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-alpha.4",
+  "version": "0.4.0-alpha.5",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- publish the CLI and Windows management UI as Desktop 0.4.0-alpha.5
- validate unchanged expandable user PATH entries after restoring the runner profile environment
- retain the installer process wait and exit-code validation from alpha.4

## Verification
- desktop type-check
- desktop tests (79/79)
- desktop version synchronization
- release workflow builds and smokes the packaged NSIS lifecycle