### PR TITLE
release(desktop): desktop-v0.4.0-alpha.6

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -231,6 +231,20 @@ jobs:
             return (@($Value -split ';' | Where-Object { $_ }) -join ';')
           }
 
+          function Get-RawUserPath {
+            $environmentKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment')
+            if ($null -eq $environmentKey) { return '' }
+            try {
+              return [string]$environmentKey.GetValue(
+                'Path',
+                '',
+                [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+              )
+            } finally {
+              $environmentKey.Dispose()
+            }
+          }
+
           $setup = (Resolve-Path 'dist/tray/hermes-relay-windows-x64-setup.exe').Path
           $smokeRoot = Join-Path $env:RUNNER_TEMP 'hermes-installer-lifecycle-smoke'
           $smokeProfile = Join-Path $smokeRoot 'profile'
@@ -244,7 +258,7 @@ jobs:
           $startMenuDir = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Hermes-Relay CLI'
           $oldUserProfile = $env:USERPROFILE
           $oldHomeEnv = $env:HOME
-          $userPathBefore = Normalize-UserPath ([Environment]::GetEnvironmentVariable('Path', 'User'))
+          $userPathBefore = Normalize-UserPath (Get-RawUserPath)
           $startupBefore = (Get-ItemProperty -Path $startupKey -Name HermesRelayTray -ErrorAction SilentlyContinue).HermesRelayTray
 
           if (Test-Path $uninstallKey) { throw 'installer smoke requires a clean HermesRelay uninstall registry key' }
@@ -308,11 +322,9 @@ jobs:
               throw 'installer lifecycle modified preserved profile session data'
             }
 
-            # User PATH may contain expandable %USERPROFILE% entries. Restore the
-            # runner profile before comparing the unchanged registry value.
-            $env:USERPROFILE = $oldUserProfile
-            $env:HOME = $oldHomeEnv
-            $userPathAfter = Normalize-UserPath ([Environment]::GetEnvironmentVariable('Path', 'User'))
+            # Compare the raw registry value so expandable entries such as
+            # %USERPROFILE% are not resolved against the isolated smoke profile.
+            $userPathAfter = Normalize-UserPath (Get-RawUserPath)
             if ($userPathAfter -ne $userPathBefore) {
               throw "uninstaller did not restore user PATH (before='$userPathBefore', after='$userPathAfter')"
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.4.0-alpha.6] - 2026-08-11
+
+### Fixed
+
+- **Installer cleanup validation compares the unexpanded Windows PATH.** Release smoke tests now read the raw user registry value, ensuring `%USERPROFILE%` entries are verified without temporary-profile expansion changing their apparent value.
+
 ## [0.4.0-alpha.5] - 2026-08-11
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.5",
+  "version": "0.4.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-alpha.5",
+      "version": "0.4.0-alpha.6",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.5",
+  "version": "0.4.0-alpha.6",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-alpha.5" as const
+export const VERSION = "0.4.0-alpha.6" as const

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.5"
+version = "0.4.0-alpha.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.5"
+version = "0.4.0-alpha.6"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-alpha.5",
+  "version": "0.4.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-alpha.5",
+      "version": "0.4.0-alpha.6",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-alpha.5",
+  "version": "0.4.0-alpha.6",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-alpha.5",
+  "version": "0.4.0-alpha.6",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- publish the verified Hermes-Relay CLI UI bundle as desktop 0.4.0-alpha.6
- validate installer PATH cleanup against the unexpanded user registry value
- retain the CLI/UI upgrade, cleanup, daemon restoration, and session-preservation contract

## Verification
- npm run check:version-sync
- npm run type-check
- npm test (79 passed)
- npm run tray:fmt
- npm run tray:lint
- npm run tray:test (12 passed)
- git diff --check