### PR TITLE
release(server): server-v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Android keeps profile management and retained automation truthful.** Custom Endpoint list and mutation routes now follow the selected Hermes profile, while completed one-shot cron jobs show their retained outcome and expose only valid Runs/Delete actions.
+- **Android and Relay recover more generated media reliably.** Android accepts upstream-valid wrapped, punctuated, adjacent, spaced, and Windows `MEDIA:` markers without consuming fenced examples, and Relay translates Docker-visible workspace, home, cache, and configured-mount paths before applying its existing credential, sandbox, and size checks.
+
 ## [0.4.0-alpha.7] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android keeps profile management and retained automation truthful.** Custom Endpoint list and mutation routes now follow the selected Hermes profile, while completed one-shot cron jobs show their retained outcome and expose only valid Runs/Delete actions.
 - **Android and Relay recover more generated media reliably.** Android accepts upstream-valid wrapped, punctuated, adjacent, spaced, and Windows `MEDIA:` markers without consuming fenced examples, and Relay translates Docker-visible workspace, home, cache, and configured-mount paths before applying its existing credential, sandbox, and size checks.
 
+## [1.6.3] - 2026-08-11
+
+### Fixed
+
+- **Relay diagnostics distinguish a prior clean stop from a crash.** Doctor and `/relay/info` expose only bounded clean, unclean, or unknown gateway-exit state with an optional suspected out-of-memory hint, without returning raw log evidence.
+- **Relay reconnects spread out after shared gateway restarts.** Ordinary exponential reconnect delays use full jitter while explicit reconnects and server-directed retry timing retain their exact behavior.
+
 ## [0.4.0-alpha.7] - 2026-08-11
 
 ### Fixed

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 **Release Date:** August 11, 2026
 
-This patch makes paired sessions easier to identify and their expiry easier to understand across Relay clients and the Dashboard.
+This patch improves gateway recovery diagnostics and prevents clients from reconnecting in lockstep after a shared restart.
 
 Standard chat, session history, and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
 
@@ -10,10 +10,8 @@ Standard chat, session history, and Vanilla Hermes voice remain upstream-owned a
 
 ### Fixed
 
-- **Recognizable device names.** Relay uses the client hostname as the primary paired-session name when available while preserving compatibility with existing clients.
-- **Persisted device details.** Model and platform metadata survive refresh, reconnect, and Relay restart and appear in the authorized-session API and Dashboard detail view.
-- **Reconnect enrichment without re-pairing.** A valid paired client can fill missing identity metadata during reconnect without changing its authentication state.
-- **Human-readable expiry.** Long paired-session lifetimes use days, weeks, or a calendar date, with the exact local deadline retained for inspection.
+- **Bounded prior-exit diagnostics.** Relay Doctor and `/relay/info` distinguish a clean stop, an unclean exit, and unknown history, with an optional suspected out-of-memory hint. Raw logs are never returned through the API.
+- **Desynchronized recovery.** Ordinary exponential reconnect delays use full jitter so multiple Relay clients do not retry in lockstep after the gateway restarts. Explicit reconnects and server-directed retry timing remain unchanged.
 
 ## Install / update
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/data/ChatMessage.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/ChatMessage.kt
@@ -366,6 +366,8 @@ data class ToolCall(
      * header can render without a separate lane registry.
      */
     val taskLabel: String? = null,
+    /** Live upstream child id used by subagent.steer while this lane runs. */
+    val subagentId: String? = null,
     /** Deterministic non-low output risk reported by upstream for this call. */
     val outputRisk: String? = null,
     /** Human-readable deterministic findings; rendered as untrusted metadata. */

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/relay/ConnectionManager.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/relay/ConnectionManager.kt
@@ -19,6 +19,7 @@ import com.hermesandroid.relay.diagnostics.NetworkDiagnosticGuidance
 import com.hermesandroid.relay.network.relay.models.Envelope
 import com.hermesandroid.relay.network.shared.EndpointResolver
 import com.hermesandroid.relay.network.shared.EndpointSurface
+import com.hermesandroid.relay.network.shared.fullJitterDelayMs
 import com.hermesandroid.relay.network.shutdownOffMainThread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -139,6 +140,8 @@ class ConnectionManager(
      * non-null — the manager falls back to the single-URL path.
      */
     private val deviceIdProvider: (suspend () -> String?)? = null,
+    /** Random source for ordinary reconnect full-jitter; exact backoffs never use it. */
+    private val reconnectJitterUnit: () -> Double = { kotlin.random.Random.nextDouble() },
 ) {
     private val supervisorJob = SupervisorJob()
     private val scope = CoroutineScope(supervisorJob + Dispatchers.IO)
@@ -1213,8 +1216,9 @@ class ConnectionManager(
                 SLOW_POLL_BACKOFF_MS
             }
             else -> {
-                val ms = (BASE_BACKOFF_MS * (1L shl minOf(reconnectAttempt - 1, 4)))
+                val capMs = (BASE_BACKOFF_MS * (1L shl minOf(reconnectAttempt - 1, 4)))
                     .coerceAtMost(MAX_BACKOFF_MS)
+                val ms = fullJitterDelayMs(capMs, reconnectJitterUnit())
                 DiagnosticsLog.record(
                     category = DiagnosticCategory.Relay,
                     severity = DiagnosticSeverity.Info,

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/shared/ReconnectBackoff.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/shared/ReconnectBackoff.kt
@@ -1,0 +1,13 @@
+package com.hermesandroid.relay.network.shared
+
+import kotlin.random.Random
+
+/** Full-jitter retry delay in the inclusive range 0..[capMs]. */
+internal fun fullJitterDelayMs(
+    capMs: Long,
+    unit: Double = Random.nextDouble(),
+): Long {
+    if (capMs <= 0L) return 0L
+    val boundedUnit = unit.coerceIn(0.0, Math.nextDown(1.0))
+    return (boundedUnit * (capMs + 1.0)).toLong().coerceAtMost(capMs)
+}

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
@@ -90,12 +90,9 @@ class ChatHandler {
         // Fallback form (no relay): `MEDIA:/absolute/path` — relay wasn't
         //   reachable when the tool fired, so we render an "unavailable"
         //   placeholder instead of attempting a fetch.
-        private val mediaRelayRegex = Regex("""MEDIA:hermes-relay://([A-Za-z0-9_-]+)""")
-        // `/.+?` (not `/\S+`) so absolute paths containing spaces — e.g.
-        // `MEDIA:/mnt/media/Coralee Adshade/undressher.jpg` — still match. The
-        // trailing `\s*$` trims any trailing whitespace; non-greedy keeps the
-        // capture to the path. OkHttp re-encodes the space for /media/by-path.
-        private val mediaBarePathRegex = Regex("""^\s*MEDIA:(/.+?)\s*$""")
+        private val mediaRelayPayloadRegex = Regex("""^hermes-relay://([A-Za-z0-9_-]+)$""")
+        private val mediaMarkerPrefixRegex = Regex("MEDIA:")
+        private val windowsAbsoluteMediaPathRegex = Regex("""^[A-Za-z]:[\\/].+""")
         // Rich card marker — single line, full JSON object payload.
         //
         // Agents emit:
@@ -188,6 +185,7 @@ class ChatHandler {
      * post-stream finalize reconciliation pass.
      */
     private var mediaLineBuffer = StringBuilder()
+    private var mediaFenceDelimiter: String? = null
     private val dispatchedMediaMarkers = mutableSetOf<String>()
 
     /**
@@ -1176,6 +1174,7 @@ class ChatHandler {
         // Drop any pending line buffers / dedupe state so a fresh session
         // doesn't inherit leftovers from the previous one.
         mediaLineBuffer.clear()
+        mediaFenceDelimiter = null
         dispatchedMediaMarkers.clear()
         annotationLineBuffer.clear()
         activeAnnotationTools.clear()
@@ -1771,7 +1770,7 @@ class ChatHandler {
         for (line in text.lines()) {
             val t = line.trim()
             if (t.isEmpty()) continue
-            if (mediaRelayRegex.containsMatchIn(t) || mediaBarePathRegex.containsMatchIn(t)) continue
+            if (parseMediaMarkerLine(t).isNotEmpty()) continue
             if (PersistedImageReferenceParser.parse(t).paths.isNotEmpty()) continue
             if (cardMarkerRegex.containsMatchIn(t)) continue
             if (sb.isNotEmpty()) sb.append('\n')
@@ -1789,6 +1788,51 @@ class ChatHandler {
     }
 
     /**
+     * Parse one marker-only line using upstream-compatible wrappers and
+     * boundaries. Prose and malformed examples remain ordinary text; a whole
+     * inline-code or emphasis wrapper is accepted, as are adjacent markers,
+     * sentence-final punctuation, POSIX paths, and Windows absolute paths.
+     */
+    private fun parseMediaMarkerLine(line: String): List<MediaMarkerHit> {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty() || trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+            return emptyList()
+        }
+        val starts = mediaMarkerPrefixRegex.findAll(trimmed).map { it.range.first }.toList()
+        if (starts.isEmpty()) return emptyList()
+        val prefix = trimmed.substring(0, starts.first())
+        if (prefix.any { !it.isWhitespace() && it !in "`*_~" }) return emptyList()
+
+        val hits = ArrayList<MediaMarkerHit>(starts.size)
+        for ((index, start) in starts.withIndex()) {
+            val payloadStart = start + "MEDIA:".length
+            val payloadEnd = starts.getOrNull(index + 1) ?: trimmed.length
+            val payload = trimmed.substring(payloadStart, payloadEnd)
+                .trim()
+                .trimEnd { it in "`*_~.,;:)}]" }
+                .trim()
+            if (payload.isEmpty()) return emptyList()
+            val relay = mediaRelayPayloadRegex.matchEntire(payload)
+            when {
+                relay != null -> hits += MediaMarkerHit.RelayToken(relay.groupValues[1])
+                payload.startsWith("/") || windowsAbsoluteMediaPathRegex.matches(payload) ->
+                    hits += MediaMarkerHit.BarePath(payload)
+                else -> return emptyList()
+            }
+        }
+        return hits
+    }
+
+    private fun fenceDelimiter(line: String): String? {
+        val trimmed = line.trimStart()
+        return when {
+            trimmed.startsWith("```") -> "```"
+            trimmed.startsWith("~~~") -> "~~~"
+            else -> null
+        }
+    }
+
+    /**
      * Scan loaded (non-streaming) message content line-by-line for media
      * markers, append hits to [out], and return the content with matched
      * lines removed. Pure function — does NOT mutate [_messages] or fire
@@ -1800,24 +1844,20 @@ class ChatHandler {
         out: MutableList<Pair<String, MediaMarkerHit>>,
     ): String {
         var cleaned = content
+        var openFence: String? = null
         for (rawLine in content.lines()) {
             val trimmed = rawLine.trim()
             if (trimmed.isEmpty()) continue
-
-            val relayMatch = mediaRelayRegex.find(trimmed)
-            if (relayMatch != null) {
-                out.add(messageId to MediaMarkerHit.RelayToken(relayMatch.groupValues[1]))
-                cleaned = cleaned
-                    .replace("\n$rawLine\n", "\n")
-                    .replace("\n$rawLine", "")
-                    .replace("$rawLine\n", "")
-                    .replace(rawLine, "")
+            val delimiter = fenceDelimiter(rawLine)
+            if (delimiter != null) {
+                openFence = if (openFence == delimiter) null else if (openFence == null) delimiter else openFence
                 continue
             }
+            if (openFence != null) continue
 
-            val bareMatch = mediaBarePathRegex.find(trimmed)
-            if (bareMatch != null) {
-                out.add(messageId to MediaMarkerHit.BarePath(bareMatch.groupValues[1]))
+            val hits = parseMediaMarkerLine(trimmed)
+            if (hits.isNotEmpty()) {
+                hits.forEach { out.add(messageId to it) }
                 cleaned = cleaned
                     .replace("\n$rawLine\n", "\n")
                     .replace("\n$rawLine", "")
@@ -2265,6 +2305,18 @@ class ChatHandler {
             val trimmed = line.trim()
             if (trimmed.isEmpty()) continue
 
+            fenceDelimiter(line)?.let { delimiter ->
+                mediaFenceDelimiter = if (mediaFenceDelimiter == delimiter) {
+                    null
+                } else if (mediaFenceDelimiter == null) {
+                    delimiter
+                } else {
+                    mediaFenceDelimiter
+                }
+                continue
+            }
+            if (mediaFenceDelimiter != null) continue
+
             if (tryDispatchMediaMarker(messageId, trimmed)) {
                 stripLineFromContent(messageId, trimmed)
             }
@@ -2394,29 +2446,26 @@ class ChatHandler {
      * Returns true when a marker was matched so the caller can strip the line.
      */
     private fun tryDispatchMediaMarker(messageId: String, line: String): Boolean {
-        val relayMatch = mediaRelayRegex.find(line)
-        if (relayMatch != null) {
-            val token = relayMatch.groupValues[1]
-            val dedupeKey = "$messageId:relay:$token"
-            if (dispatchedMediaMarkers.add(dedupeKey)) {
-                Log.d(TAG, "Media marker (relay): token=$token")
-                onMediaAttachmentRequested(messageId, token)
+        val hits = parseMediaMarkerLine(line)
+        for (hit in hits) {
+            when (hit) {
+                is MediaMarkerHit.RelayToken -> {
+                    val dedupeKey = "$messageId:relay:${hit.token}"
+                    if (dispatchedMediaMarkers.add(dedupeKey)) {
+                        Log.d(TAG, "Media marker (relay): token=${hit.token}")
+                        onMediaAttachmentRequested(messageId, hit.token)
+                    }
+                }
+                is MediaMarkerHit.BarePath -> {
+                    val dedupeKey = "$messageId:bare:${hit.path}"
+                    if (dispatchedMediaMarkers.add(dedupeKey)) {
+                        Log.d(TAG, "Media marker (bare-path): ${hit.path}")
+                        onMediaBarePathRequested(messageId, hit.path)
+                    }
+                }
             }
-            return true
         }
-
-        val bareMatch = mediaBarePathRegex.find(line)
-        if (bareMatch != null) {
-            val path = bareMatch.groupValues[1]
-            val dedupeKey = "$messageId:bare:$path"
-            if (dispatchedMediaMarkers.add(dedupeKey)) {
-                Log.d(TAG, "Media marker (bare-path, unavailable): $path")
-                onMediaBarePathRequested(messageId, path)
-            }
-            return true
-        }
-
-        return false
+        return hits.isNotEmpty()
     }
 
     /**
@@ -2555,10 +2604,11 @@ class ChatHandler {
         if (mediaLineBuffer.isNotEmpty()) {
             val remaining = mediaLineBuffer.toString().trim()
             mediaLineBuffer.clear()
-            if (remaining.isNotEmpty() && tryDispatchMediaMarker(messageId, remaining)) {
+            if (mediaFenceDelimiter == null && remaining.isNotEmpty() && tryDispatchMediaMarker(messageId, remaining)) {
                 stripLineFromContent(messageId, remaining)
             }
         }
+        mediaFenceDelimiter = null
 
         // Post-stream reconciliation: re-scan the final content for markers
         // that raced with stripLineFromContent during streaming.
@@ -2567,12 +2617,16 @@ class ChatHandler {
                 if (!msg.matchesIdentity(messageId) || msg.role != MessageRole.ASSISTANT) return@map msg
                 var cleaned = msg.content
                 var changed = false
+                var openFence: String? = null
                 for (rawLine in msg.content.lines()) {
                     val trimmed = rawLine.trim()
                     if (trimmed.isEmpty()) continue
-                    if (mediaRelayRegex.containsMatchIn(trimmed) ||
-                        mediaBarePathRegex.containsMatchIn(trimmed)
-                    ) {
+                    val delimiter = fenceDelimiter(rawLine)
+                    if (delimiter != null) {
+                        openFence = if (openFence == delimiter) null else if (openFence == null) delimiter else openFence
+                        continue
+                    }
+                    if (openFence == null && parseMediaMarkerLine(trimmed).isNotEmpty()) {
                         tryDispatchMediaMarker(messageId, trimmed)
                         cleaned = cleaned
                             .replace("\n$rawLine\n", "\n")

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
@@ -1181,6 +1181,7 @@ class ChatHandler {
         cardLineBuffer.clear()
         dispatchedCardMarkers.clear()
         subagentLabels.clear()
+        subagentIds.clear()
     }
 
     /**
@@ -2957,6 +2958,7 @@ class ChatHandler {
      * [onStreamComplete] / [clearMessages].
      */
     private val subagentLabels = mutableMapOf<Int, String>()
+    private val subagentIds = mutableMapOf<Int, String>()
 
     /**
      * Apply one gateway `subagent.*` lifecycle event to the streaming
@@ -2972,6 +2974,9 @@ class ChatHandler {
         when (event.phase) {
             GatewaySubagentEvent.Phase.START -> {
                 if (label != null) subagentLabels[event.taskIndex] = label
+                event.subagentId?.takeIf(String::isNotBlank)?.let {
+                    subagentIds[event.taskIndex] = it
+                }
             }
 
             GatewaySubagentEvent.Phase.TOOL -> {
@@ -2986,6 +2991,8 @@ class ChatHandler {
                     isComplete = false,
                     taskIndex = event.taskIndex,
                     taskLabel = laneLabel,
+                    subagentId = event.subagentId?.takeIf(String::isNotBlank)
+                        ?: subagentIds[event.taskIndex],
                 )
                 _messages.update { messages ->
                     val target = messages.findLast {
@@ -3025,6 +3032,7 @@ class ChatHandler {
                 // "interrupted" lanes never finished — not a success either.
                 val failed = event.status == "failed" || event.status == "interrupted"
                 val laneLabel = subagentLabels.remove(event.taskIndex) ?: label
+                val subagentId = subagentIds.remove(event.taskIndex) ?: event.subagentId
                 val summaryId = "subagent-${event.taskIndex}-${syntheticToolSeq++}"
                 _messages.update { messages ->
                     messages.map { msg ->
@@ -3057,6 +3065,7 @@ class ChatHandler {
                                 completedAt = System.currentTimeMillis(),
                                 taskIndex = event.taskIndex,
                                 taskLabel = laneLabel,
+                                subagentId = subagentId,
                             )
                         }
                         msg.copy(toolCalls = withSummary)
@@ -3314,6 +3323,7 @@ class ChatHandler {
             }
         }
         subagentLabels.clear()
+        subagentIds.clear()
     }
 
     fun onStreamError(message: String) {
@@ -3343,6 +3353,7 @@ class ChatHandler {
             }
         }
         subagentLabels.clear()
+        subagentIds.clear()
     }
 
     fun onThinkingDelta(messageId: String, delta: String) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
@@ -500,6 +500,7 @@ class DashboardApiClient(
         name: String,
         cloneFromDefault: Boolean = true,
         description: String? = null,
+        mcpServers: List<String> = emptyList(),
     ): Result<JsonObject> =
         postJsonObject(
             path = "/api/profiles",
@@ -507,8 +508,15 @@ class DashboardApiClient(
                 put("name", name)
                 put("clone_from_default", cloneFromDefault)
                 if (!description.isNullOrBlank()) put("description", description)
+                if (mcpServers.isNotEmpty()) {
+                    put("mcp_servers", JsonArray(mcpServers.map(::JsonPrimitive)))
+                }
             },
         )
+
+    /** Create a host-owned Hermes backup, distinct from Android settings export. */
+    suspend fun createServerBackup(): Result<JsonObject> =
+        postJsonObject("/api/ops/backup")
 
     suspend fun setProfileDescription(name: String, description: String): Result<JsonObject> =
         putJsonObject(

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
@@ -605,15 +605,16 @@ class DashboardApiClient(
         )
     }
 
-    suspend fun getCustomEndpoints(): Result<DashboardCustomEndpoints> =
-        getJsonObject("/api/providers/custom-endpoints")
+    suspend fun getCustomEndpoints(profile: String? = null): Result<DashboardCustomEndpoints> =
+        getJsonObject("/api/providers/custom-endpoints${profileQuery(profile)}")
             .mapCatching(::parseCustomEndpoints)
 
     suspend fun saveCustomEndpoint(
         draft: DashboardCustomEndpointDraft,
+        profile: String? = null,
     ): Result<DashboardCustomEndpoints> =
         postJsonObject(
-            "/api/providers/custom-endpoints",
+            "/api/providers/custom-endpoints${profileQuery(profile)}",
             customEndpointPayload(draft),
         ).mapCatching(::parseCustomEndpoints)
 
@@ -634,13 +635,19 @@ class DashboardApiClient(
 
     suspend fun activateCustomEndpoint(
         id: String,
+        profile: String? = null,
     ): Result<JsonObject> =
-        postJsonObject("/api/providers/custom-endpoints/${pathSegment(id)}/activate")
+        postJsonObject(
+            "/api/providers/custom-endpoints/${pathSegment(id)}/activate${profileQuery(profile)}",
+        )
 
     suspend fun deleteCustomEndpoint(
         id: String,
+        profile: String? = null,
     ): Result<DashboardCustomEndpoints> =
-        deleteJsonObject("/api/providers/custom-endpoints/${pathSegment(id)}")
+        deleteJsonObject(
+            "/api/providers/custom-endpoints/${pathSegment(id)}${profileQuery(profile)}",
+        )
             .mapCatching(::parseCustomEndpoints)
 
     suspend fun installMcpCatalogEntry(

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClient.kt
@@ -768,6 +768,27 @@ class DashboardApiClient(
         }
 
     /**
+     * Read the bounded, authoritative session window across every profile.
+     * Every usable row must retain its owning profile; rows without one are
+     * skipped rather than risking a cross-profile transcript or mutation.
+     */
+    suspend fun listAllProfileSessions(
+        limit: Int = SESSION_LIST_WINDOW_LIMIT,
+    ): Result<List<SessionItem>> = withContext(Dispatchers.IO) {
+        val boundedLimit = limit.coerceIn(1, SESSION_LIST_WINDOW_LIMIT)
+        getJson(
+            "/api/profiles/sessions?limit=$boundedLimit&offset=0&order=recent" +
+                "&min_messages=1&archived=include&profile=all",
+        ).mapCatching { root ->
+            val parsed = json.decodeFromJsonElement(SessionListResponse.serializer(), root)
+            (parsed.sessions ?: parsed.items ?: parsed.data ?: emptyList())
+                .filter { it.id.isNotBlank() && !it.profile.isNullOrBlank() }
+                .distinctBy { "${it.profile}:${it.id}" }
+                .take(boundedLimit)
+        }
+    }
+
+    /**
      * A session's message history, scoped to its owning profile via the dashboard
      * `GET /api/sessions/{id}/messages?profile=`. Required twin of [listSessions]:
      * a non-default profile's sessions live in that profile's own `state.db`, so

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -1488,6 +1489,26 @@ class GatewayChatClient(
                 liveSessionId?.let { put("session_id", it) }
             },
         )
+
+    /**
+     * React to the newest message for a role without guessing a transcript row
+     * id. This follows the upstream gateway contract, which resolves the row
+     * atomically inside the active session. A null emoji removes the reaction.
+     */
+    suspend fun reactToNewest(role: String, emoji: String?): Result<JsonObject> {
+        require(role == "user" || role == "assistant") { "unsupported reaction role" }
+        val sid = liveSessionId
+            ?: return Result.failure(GatewayRpcException("no live session"))
+        return rpc(
+            "message.react",
+            buildJsonObject {
+                put("session_id", sid)
+                put("newest_role", role)
+                if (emoji == null) put("emoji", JsonNull) else put("emoji", emoji)
+                put("author", "user")
+            },
+        )
+    }
 
     /** Redirect one running child agent without interrupting the parent turn. */
     suspend fun steerSubagent(subagentId: String, text: String): Result<JsonObject> {

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
@@ -1489,6 +1489,23 @@ class GatewayChatClient(
             },
         )
 
+    /** Redirect one running child agent without interrupting the parent turn. */
+    suspend fun steerSubagent(subagentId: String, text: String): Result<JsonObject> {
+        val sessionId = liveSessionId
+            ?: return Result.failure(IllegalStateException("No live gateway session"))
+        if (subagentId.isBlank() || text.isBlank()) {
+            return Result.failure(IllegalArgumentException("Subagent and instruction are required"))
+        }
+        return rpc(
+            "subagent.steer",
+            buildJsonObject {
+                put("session_id", sessionId)
+                put("subagent_id", subagentId)
+                put("text", text.trim())
+            },
+        )
+    }
+
     /** Fetch the session/global reasoning effort and display mode. */
     suspend fun getReasoningSettings(): Result<GatewayReasoningSettings> {
         if (webSocket == null || readySignal?.isCompleted != true) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import com.hermesandroid.relay.network.shared.fullJitterDelayMs
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -86,6 +87,8 @@ class GatewayChatClient(
     private val promptSubmitTimeoutMs: Long = PROMPT_SUBMIT_REQUEST_TIMEOUT_MS,
     /** Test seam — idle-progress watchdog base. Production keeps [TURN_TIMEOUT_MS]. */
     private val turnIdleTimeoutMs: Long = TURN_TIMEOUT_MS,
+    /** Random source for ordinary reconnect full-jitter. */
+    private val reconnectJitterUnit: () -> Double = { kotlin.random.Random.nextDouble() },
 ) {
     /** Existing upstream rich-chat vocabulary; do not invent a Relay-only source. */
     private val sessionSource = "webui"
@@ -2094,6 +2097,42 @@ class GatewayChatClient(
             return
         }
 
+        // Upstream emits session.reclaimed process-wide, so it is identified
+        // by payload rather than params.session_id. Retire only an exact live
+        // runtime we own; preserve the durable id so the next send resumes it.
+        if (type == "session.reclaimed") {
+            val reclaimedLiveId = payload?.stringField("session_id")
+            val reclaimedStoredId = payload?.stringField("stored_session_id")
+            val reason = payload?.stringField("reason")
+            val supportedReason = reason in setOf("idle_timeout", "lru_evict", "ws_orphan_reap")
+            if (!reclaimedLiveId.isNullOrBlank() && supportedReason) {
+                val background = backgroundTurns.remove(reclaimedLiveId)
+                if (background != null) {
+                    callbackDispatcher {
+                        unmatchedTurnCompleteListener?.invoke(
+                            GatewayBackgroundTurnCompletion(
+                                storedSessionId = reclaimedStoredId?.takeIf(String::isNotBlank)
+                                    ?: background.storedSessionId,
+                                liveSessionId = reclaimedLiveId,
+                                profile = background.profile,
+                                expectedAssistantText = null,
+                            ),
+                        )
+                    }
+                }
+                if (reclaimedLiveId == liveSessionId) {
+                    liveSessionId = null
+                    reclaimedStoredId?.takeIf(String::isNotBlank)?.let { storedSessionId = it }
+                    val turn = activeTurn
+                    if (turn != null && !turn.ended) {
+                        activeTurn = null
+                        turn.failFromTransport("Gateway reclaimed the inactive session")
+                    }
+                }
+            }
+            return
+        }
+
         // read_terminal is a renderer query, not a user decision. Android has
         // no xterm pane on the Gateway chat surface, so mirror upstream
         // desktop's no-live-pane behavior and answer with empty text instead
@@ -2412,7 +2451,7 @@ class GatewayChatClient(
                 Log.i(TAG, "Gateway socket rejoined for ${backgroundTurns.size} detached turn(s)")
                 return
             }
-            delay(backoffMs)
+            delay(fullJitterDelayMs(backoffMs, reconnectJitterUnit()))
             backoffMs = (backoffMs * 2).coerceAtMost(5_000L)
         }
     }
@@ -2505,7 +2544,7 @@ class GatewayChatClient(
                 )
                 return
             }
-            delay(backoffMs)
+            delay(fullJitterDelayMs(backoffMs, reconnectJitterUnit()))
             backoffMs = (backoffMs * 2).coerceAtMost(5_000L)
         }
         if (activeTurn === turn) activeTurn = null

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapper.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapper.kt
@@ -207,7 +207,11 @@ class GatewayEventMapper(
                     }
                     else -> syntheticToolId(name)
                 }
-                val argsPreview = payload.string("args_text")
+                val argsPreview = payload?.get("args")
+                    ?.takeUnless { it is JsonPrimitive && it.contentOrNull.isNullOrBlank() }
+                    ?.toString()
+                    ?.takeIf { it.isNotBlank() && it != "null" }
+                    ?: payload.string("args_text")
                     ?.takeIf { it.isNotBlank() }
                     ?: payload.string("context")?.takeIf { it.isNotBlank() }
                 callbacks.onToolCallStart(toolId, name, argsPreview)

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapper.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapper.kt
@@ -298,6 +298,7 @@ class GatewayEventMapper(
                         // text; thinking/progress carry text only.
                         preview = payload.string("tool_preview") ?: payload.string("text"),
                         durationSeconds = payload.double("duration_seconds"),
+                        subagentId = payload.string("subagent_id"),
                     ),
                 )
             }

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayModels.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayModels.kt
@@ -270,6 +270,7 @@ data class GatewaySubagentEvent(
     val toolName: String? = null,
     val preview: String? = null,
     val durationSeconds: Double? = null,
+    val subagentId: String? = null,
 ) {
     enum class Phase { START, THINKING, TOOL, PROGRESS, COMPLETE }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/models/SessionModels.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/models/SessionModels.kt
@@ -142,6 +142,8 @@ data class SessionItem(
     val preview: String? = null,
     val model: String? = null,
     val source: String? = null,
+    /** Owning profile on the cross-profile `/api/profiles/sessions` endpoint. */
+    val profile: String? = null,
     @SerialName("started_at")
     @Serializable(with = FlexibleTimestampSerializer::class)
     val startedAt: Double? = null,

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/CommandPalette.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/CommandPalette.kt
@@ -64,6 +64,10 @@ data class SlashCommand(
      * instead of plain text.
      */
     val source: String? = null,
+    /** Bounded server-recorded skill usage; zero for non-skill commands. */
+    val usageRank: Int = 0,
+    /** Sanitized server skill origin such as local or bundled. */
+    val origin: String? = null,
 ) {
     companion object {
         const val SOURCE_SERVER = "server"

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MessageBubble.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MessageBubble.kt
@@ -116,6 +116,8 @@ fun MessageBubble(
     onNavigateToMessage: ((String) -> Unit)? = null,
     /** Open an upstream @session:<profile>/<id> reference in app. */
     onSessionReference: ((SessionReference) -> Unit)? = null,
+    /** React to the newest message for this role; null removes the reaction. */
+    onReact: ((String?) -> Unit)? = null,
     /**
      * Reads a completed assistant response through the active voice renderer.
      * Null hides the entry; the owning screen uses that to limit the action to
@@ -453,7 +455,7 @@ fun MessageBubble(
         val showEditAction = onEditMessage != null && isUser
         val showSpeakAction = shouldShowSpeakResponseAction(message, onSpeakMessage != null)
         val showStopSpeakingAction = shouldShowStopSpeakingAction(message, onStopSpeaking != null)
-        if (onQuoteMessage != null || showEditAction || showSpeakAction || showStopSpeakingAction) {
+        if (onQuoteMessage != null || onReact != null || showEditAction || showSpeakAction || showStopSpeakingAction) {
             DropdownMenu(
                 expanded = showMessageActions,
                 onDismissRequest = { showMessageActions = false },
@@ -642,6 +644,24 @@ fun MessageBubble(
                     ) {
                         SelectionContainer { messageTextContent() }
                     }
+                }
+                if (onReact != null) {
+                    listOf("👍", "❤️", "😂").forEach { emoji ->
+                        DropdownMenuItem(
+                            text = { Text("React $emoji") },
+                            onClick = {
+                                showMessageActions = false
+                                onReact(emoji)
+                            },
+                        )
+                    }
+                    DropdownMenuItem(
+                        text = { Text("Remove reaction") },
+                        onClick = {
+                            showMessageActions = false
+                            onReact(null)
+                        },
+                    )
                 }
 
                 if (onSessionReference != null && sessionReferences.isNotEmpty()) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MessageBubble.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MessageBubble.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
@@ -113,6 +114,8 @@ fun MessageBubble(
     onQuoteMessage: ((ChatMessage) -> Unit)? = null,
     /** Navigate a rendered quote chip to its original message id. */
     onNavigateToMessage: ((String) -> Unit)? = null,
+    /** Open an upstream @session:<profile>/<id> reference in app. */
+    onSessionReference: ((SessionReference) -> Unit)? = null,
     /**
      * Reads a completed assistant response through the active voice renderer.
      * Null hides the entry; the owning screen uses that to limit the action to
@@ -170,6 +173,7 @@ fun MessageBubble(
 ) {
     val isUser = message.role == MessageRole.USER
     val isSystem = message.role == MessageRole.SYSTEM
+    val sessionReferences = remember(message.content) { parseSessionReferences(message.content) }
 
     // Phone/voice-origin action bubble marker.
     //
@@ -637,6 +641,17 @@ fun MessageBubble(
                         ),
                     ) {
                         SelectionContainer { messageTextContent() }
+                    }
+                }
+
+                if (onSessionReference != null && sessionReferences.isNotEmpty()) {
+                    sessionReferences.forEach { reference ->
+                        TextButton(
+                            onClick = { onSessionReference(reference) },
+                            modifier = Modifier.padding(top = 2.dp),
+                        ) {
+                            Text("Open ${reference.label}")
+                        }
                     }
                 }
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionDrawer.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionDrawer.kt
@@ -99,6 +99,11 @@ internal enum class SessionDrawerFilter {
 internal const val SESSION_DRAWER_LIST_TAG = "session-drawer-list"
 internal const val UNPINNED_STAR_ALPHA = 0.45f
 
+data class ProfileSessionRow(
+    val profile: String,
+    val session: ChatSession,
+)
+
 internal fun sessionPinIcon(pinned: Boolean) =
     if (pinned) Icons.Filled.Star else Icons.Outlined.StarBorder
 
@@ -149,6 +154,10 @@ fun SessionDrawerContent(
     hiddenSources: Set<String> = emptySet(),
     /** Toggle a source's visibility (persisted). Null hides the source filter. */
     onToggleSourceHidden: ((String, Boolean) -> Unit)? = null,
+    allProfileSessions: List<ProfileSessionRow> = emptyList(),
+    allProfileSessionsLoading: Boolean = false,
+    onRefreshAllProfiles: (() -> Unit)? = null,
+    onSelectProfileSession: ((String, String) -> Unit)? = null,
 ) {
     var renameDialogSession by remember { mutableStateOf<ChatSession?>(null) }
     var newThreadDialog by remember { mutableStateOf(false) }
@@ -157,6 +166,7 @@ fun SessionDrawerContent(
     var query by remember { mutableStateOf("") }
     var searchExpanded by remember { mutableStateOf(false) }
     var filter by remember { mutableStateOf(SessionDrawerFilter.All) }
+    var allProfilesOpen by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
     val trimmedQuery = query.trim()
     // Threads affordance shows when the capability is active OR there's already at least one
@@ -354,6 +364,16 @@ fun SessionDrawerContent(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
+            }
+            if (onRefreshAllProfiles != null && onSelectProfileSession != null) {
+                TextButton(
+                    onClick = {
+                        allProfilesOpen = true
+                        onRefreshAllProfiles()
+                    },
+                ) {
+                    Text(stringResource(R.string.drawer_all_profiles))
+                }
             }
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -618,6 +638,72 @@ fun SessionDrawerContent(
                     Text(stringResource(R.string.drawer_cancel))
                 }
             }
+        )
+    }
+
+    if (allProfilesOpen) {
+        var allQuery by remember { mutableStateOf("") }
+        val needle = allQuery.trim()
+        val rows = allProfileSessions.filter { row ->
+            needle.isBlank() ||
+                row.profile.contains(needle, ignoreCase = true) ||
+                row.session.title.orEmpty().contains(needle, ignoreCase = true) ||
+                row.session.sessionId.contains(needle, ignoreCase = true)
+        }
+        AlertDialog(
+            onDismissRequest = { allProfilesOpen = false },
+            title = { Text(stringResource(R.string.drawer_all_profiles)) },
+            text = {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    OutlinedTextField(
+                        value = allQuery,
+                        onValueChange = { allQuery = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+                        placeholder = { Text(stringResource(R.string.drawer_search_placeholder)) },
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    when {
+                        allProfileSessionsLoading && allProfileSessions.isEmpty() ->
+                            CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                        rows.isEmpty() -> Text(
+                            stringResource(R.string.drawer_no_profile_sessions),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        else -> LazyColumn(modifier = Modifier.height(420.dp)) {
+                            items(rows, key = { "${it.profile}:${it.session.sessionId}" }) { row ->
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            allProfilesOpen = false
+                                            onSelectProfileSession?.invoke(row.profile, row.session.sessionId)
+                                        }
+                                        .padding(vertical = 10.dp, horizontal = 4.dp),
+                                ) {
+                                    Text(
+                                        row.session.title?.takeIf { it.isNotBlank() }
+                                            ?: stringResource(R.string.drawer_untitled),
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    Text(
+                                        row.profile,
+                                        style = relayMetadataStyle(),
+                                        color = RelayRefresh.Relay,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { allProfilesOpen = false }) {
+                    Text(stringResource(R.string.drawer_close))
+                }
+            },
         )
     }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionReference.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionReference.kt
@@ -1,0 +1,41 @@
+package com.hermesandroid.relay.ui.components
+
+data class SessionReference(val profile: String, val sessionId: String) {
+    val label: String
+        get() = "$profile · ${sessionId.takeLast(10)}"
+}
+
+private val SESSION_REFERENCE = Regex("@session:([A-Za-z0-9_.-]{1,64})/([A-Za-z0-9_.:-]{1,160})")
+
+/** Find session references outside fenced and inline code. */
+internal fun parseSessionReferences(markdown: String): List<SessionReference> {
+    val visible = buildString(markdown.length) {
+        var fenced = false
+        markdown.lineSequence().forEach { line ->
+            if (line.trimStart().startsWith("```")) {
+                fenced = !fenced
+                appendLine()
+            } else if (fenced) {
+                appendLine()
+            } else {
+                var inline = false
+                line.forEach { char ->
+                    if (char == '`') inline = !inline
+                    append(if (inline || char == '`') ' ' else char)
+                }
+                appendLine()
+            }
+        }
+    }
+    return SESSION_REFERENCE.findAll(visible)
+        .map {
+            SessionReference(
+                it.groupValues[1],
+                it.groupValues[2].trimEnd('.', ',', ';', '!', '?', ')', ']', '}'),
+            )
+        }
+        .filter { it.sessionId.isNotBlank() }
+        .distinct()
+        .take(16)
+        .toList()
+}

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SubagentLane.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SubagentLane.kt
@@ -25,8 +25,11 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Icon
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -73,11 +76,13 @@ fun SubagentLane(
     taskIndex: Int,
     calls: List<ToolCall>,
     modifier: Modifier = Modifier,
+    onSteer: ((subagentId: String, instruction: String) -> Unit)? = null,
 ) {
     val anyRunning = calls.any { !it.isComplete }
     val allComplete = calls.isNotEmpty() && calls.all { it.isComplete }
     val anyFailed = calls.any { it.isComplete && it.success == false }
     val runningCount = calls.count { !it.isComplete }
+    val steerableId = calls.firstNotNullOfOrNull { it.subagentId?.takeIf(String::isNotBlank) }
 
     val laneLabel = calls.firstNotNullOfOrNull { call ->
         call.taskLabel?.takeIf { it.isNotBlank() }
@@ -106,6 +111,8 @@ fun SubagentLane(
     val failureLabel = stringResource(R.string.cd_subagent_failed)
 
     var expanded by remember { mutableStateOf(!allComplete) }
+    var showSteerDialog by remember { mutableStateOf(false) }
+    var steerText by remember { mutableStateOf("") }
 
     // Auto-collapse when the last child completes — same pattern as
     // ToolProgressCard's LaunchedEffect(toolCall.isComplete).
@@ -162,6 +169,12 @@ fun SubagentLane(
                     modifier = Modifier.weight(1f),
                 )
 
+                if (anyRunning && steerableId != null && onSteer != null) {
+                    TextButton(onClick = { showSteerDialog = true }) {
+                        Text("Redirect")
+                    }
+                }
+
                 Text(
                     text = statusMeta,
                     style = relayMetadataStyle(),
@@ -201,5 +214,34 @@ fun SubagentLane(
                 }
             }
         }
+    }
+
+    if (showSteerDialog && steerableId != null && onSteer != null) {
+        AlertDialog(
+            onDismissRequest = { showSteerDialog = false },
+            title = { Text("Redirect subagent") },
+            text = {
+                OutlinedTextField(
+                    value = steerText,
+                    onValueChange = { steerText = it },
+                    label = { Text("New instruction") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val instruction = steerText.trim()
+                        showSteerDialog = false
+                        steerText = ""
+                        onSteer(steerableId, instruction)
+                    },
+                    enabled = steerText.isNotBlank(),
+                ) { Text("Redirect") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSteerDialog = false }) { Text("Cancel") }
+            },
+        )
     }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -3023,6 +3023,23 @@ fun ChatScreen(
                                     },
                                     onCardAction = handleCardAction,
                                     onCardInput = handleCardInput,
+                                    onSessionReference = { reference ->
+                                        val target = agentProfiles.firstOrNull {
+                                            it.name.equals(reference.profile, ignoreCase = true)
+                                        }
+                                        if (target != null) {
+                                            connectionViewModel.selectProfile(target)
+                                            chatViewModel.activateGatewayProfile(target)
+                                            chatViewModel.switchSession(reference.sessionId)
+                                        } else {
+                                            scope.launch {
+                                                snackbarHostState.showSnackbar(
+                                                    message = "Profile ${reference.profile} is not available.",
+                                                    duration = SnackbarDuration.Short,
+                                                )
+                                            }
+                                        }
+                                    },
                                     onEditMessage = if (
                                         isGatewayTransport &&
                                         !isStreaming &&

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -3173,6 +3173,7 @@ fun ChatScreen(
                                     SubagentLane(
                                         taskIndex = taskIndex,
                                         calls = laneGroups.getValue(taskIndex),
+                                        onSteer = chatViewModel::steerSubagent,
                                     )
                                 }
                             }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -743,6 +743,13 @@ fun ChatScreen(
 
 
     val messages by chatViewModel.messages.collectAsState()
+    val messageReactionsSupported by chatViewModel.messageReactionsSupported.collectAsState()
+    val newestReactableMessageKeys = remember(messages) {
+        setOfNotNull(
+            messages.lastOrNull { it.role == MessageRole.USER }?.uiKey,
+            messages.lastOrNull { it.role == MessageRole.ASSISTANT }?.uiKey,
+        )
+    }
     val isStreaming by chatViewModel.isStreaming.collectAsState()
     // Keep the screen on for the two "actively engaged, hands-off-keyboard"
     // cases: voice mode is a call-like continuous session (mirrors Assistant/
@@ -3039,6 +3046,16 @@ fun ChatScreen(
                                                 )
                                             }
                                         }
+                                    },
+                                    onReact = if (
+                                        isGatewayTransport &&
+                                        messageReactionsSupported &&
+                                        !message.isStreaming &&
+                                        message.uiKey in newestReactableMessageKeys
+                                    ) {
+                                        { emoji -> chatViewModel.reactToNewest(message.role, emoji) }
+                                    } else {
+                                        null
                                     },
                                     onEditMessage = if (
                                         isGatewayTransport &&

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -231,6 +231,7 @@ import com.hermesandroid.relay.ui.components.ThinkingIndicatorStyle
 import com.hermesandroid.relay.ui.components.ThinkingMatrixColor
 import com.hermesandroid.relay.ui.components.ThinkingMatrixPattern
 import com.hermesandroid.relay.ui.components.SessionDrawerContent
+import com.hermesandroid.relay.ui.components.ProfileSessionRow
 import com.hermesandroid.relay.ui.components.ProfileDisplayManagerDialog
 import com.hermesandroid.relay.ui.components.ProfileShelf
 import com.hermesandroid.relay.ui.components.ProfileSwitcherSheet
@@ -1135,6 +1136,8 @@ fun ChatScreen(
     }
     val listState = rememberLazyListState()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
+    var allProfileSessions by remember { mutableStateOf<List<ProfileSessionRow>>(emptyList()) }
+    var allProfileSessionsLoading by remember { mutableStateOf(false) }
     PetInteractionLayer(
         owner = "chat-interaction-layer",
         active = shouldHideChatPet(
@@ -2112,6 +2115,57 @@ fun ChatScreen(
                 hiddenSources = hiddenSources,
                 onToggleSourceHidden = { source, hidden ->
                     connectionViewModel.setSourceHidden(source, hidden)
+                },
+                allProfileSessions = allProfileSessions,
+                allProfileSessionsLoading = allProfileSessionsLoading,
+                onRefreshAllProfiles = {
+                    if (!allProfileSessionsLoading) scope.launch {
+                        allProfileSessionsLoading = true
+                        val result = connectionViewModel.listAllProfileSessions()
+                        result?.fold(
+                            onSuccess = { items ->
+                                allProfileSessions = items.mapNotNull { item ->
+                                    val owner = item.profile?.takeIf { it.isNotBlank() }
+                                        ?: return@mapNotNull null
+                                    ProfileSessionRow(
+                                        profile = owner,
+                                        session = com.hermesandroid.relay.data.ChatSession(
+                                            sessionId = item.id,
+                                            title = item.title ?: item.preview,
+                                            model = item.model,
+                                            messageCount = item.messageCount ?: 0,
+                                            startedAt = ((item.startedAt ?: 0.0) * 1000).toLong(),
+                                            lastActivityAt = ((item.resolvedLastActivity ?: 0.0) * 1000).toLong(),
+                                            source = item.source,
+                                            pinned = item.pinned,
+                                            archived = item.archived,
+                                        ),
+                                    )
+                                }
+                            },
+                            onFailure = { error ->
+                                snackbarHostState.showSnackbar(
+                                    "Couldn't load all profiles: ${error.message ?: "unsupported"}",
+                                )
+                            },
+                        )
+                        allProfileSessionsLoading = false
+                    }
+                },
+                onSelectProfileSession = { profileName, sessionId ->
+                    val target = agentProfiles.firstOrNull {
+                        it.name.equals(profileName, ignoreCase = true)
+                    }
+                    if (target != null || profileName.equals("default", ignoreCase = true)) {
+                        connectionViewModel.selectProfile(target)
+                        chatViewModel.activateGatewayProfile(target)
+                        chatViewModel.switchSession(sessionId)
+                        scope.launch { drawerState.close() }
+                    } else {
+                        scope.launch {
+                            snackbarHostState.showSnackbar("Profile $profileName is not available.")
+                        }
+                    }
                 },
             )
         }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DashboardManagementScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DashboardManagementScreen.kt
@@ -183,7 +183,10 @@ private enum class DashboardManagementSection(val path: String) {
 private val managementSections: List<DashboardManagementSection> = DashboardManagementSection.entries
 
 internal fun dashboardSectionRequestPath(path: String, profile: String?): String {
-    if (profile.isNullOrBlank() || path !in setOf("/api/mcp/servers", "/api/mcp/catalog")) return path
+    if (
+        profile.isNullOrBlank() ||
+        path !in setOf("/api/mcp/servers", "/api/mcp/catalog", "/api/providers/custom-endpoints")
+    ) return path
     val encoded = java.net.URLEncoder.encode(profile, Charsets.UTF_8.name()).replace("+", "%20")
     return "$path?profile=$encoded"
 }
@@ -225,7 +228,11 @@ internal fun scopeDashboardManageItems(
     profile: String?,
     items: List<DashboardSummaryItem>,
 ): List<DashboardSummaryItem> =
-    if (sectionPath == "/api/mcp/servers" || sectionPath == "/api/mcp/catalog") {
+    if (
+        sectionPath == "/api/mcp/servers" ||
+        sectionPath == "/api/mcp/catalog" ||
+        sectionPath == "/api/providers/custom-endpoints"
+    ) {
         items.map { it.copy(profile = profile) }
     } else {
         items
@@ -1091,6 +1098,7 @@ fun DashboardManagementScreen(
     if (showCustomEndpointEditor) {
         CustomEndpointDialog(
             existing = customEndpointEditor,
+            profile = effectiveProfileName,
             clientFactory = clientFactory,
             onSaved = {
                 showCustomEndpointEditor = false
@@ -3479,6 +3487,7 @@ private fun McpOAuthDialog(
 @Composable
 private fun CustomEndpointDialog(
     existing: DashboardSummaryItem?,
+    profile: String?,
     clientFactory: () -> DashboardApiClient,
     onSaved: () -> Unit,
     onDismiss: () -> Unit,
@@ -3586,7 +3595,9 @@ private fun CustomEndpointDialog(
                     onClick = {
                         busy = true
                         scope.launch {
-                            val result = withDashboardClient(clientFactory) { it.saveCustomEndpoint(draft()) }
+                            val result = withDashboardClient(clientFactory) {
+                                it.saveCustomEndpoint(draft(), profile = profile)
+                            }
                             result.fold(onSuccess = { onSaved() }, onFailure = {
                                 busy = false
                                 message = it.message ?: context.getString(R.string.dashboard_custom_endpoint_save_failed)
@@ -3736,7 +3747,7 @@ private fun summarizeEnvVars(root: JsonElement): List<DashboardSummaryItem> {
     }.sortedWith(compareByDescending<DashboardSummaryItem> { it.meta?.startsWith("set") == true }.thenBy { it.title })
 }
 
-private fun summarizeObjectItem(
+internal fun summarizeObjectItem(
     element: JsonElement,
     fallbackTitle: String,
 ): DashboardSummaryItem {
@@ -3768,6 +3779,9 @@ private fun summarizeObjectItem(
         obj.booleanField("installed")?.let { if (it) "installed" else "not installed" },
         obj.booleanField("needs_install")?.let { if (it) "bootstrap install" else null },
         status,
+        obj.stringField("last_status")?.let { "last: $it" },
+        obj.stringField("last_error")?.let { "error: $it" },
+        obj.stringField("last_delivery_error")?.let { "delivery: $it" },
         obj.stringField("provider"),
         obj.stringField("transport"),
         obj.stringField("auth_type"),
@@ -3801,6 +3815,7 @@ internal fun dashboardActionsFor(obj: JsonObject): List<DashboardItemAction> {
     val hasSkillUsage = obj["usage"] != null || obj.stringField("category") != null
     val enabled = obj.booleanField("enabled")
     val paused = obj.booleanField("paused")
+    val completedCron = obj.stringField("state").equals("completed", ignoreCase = true)
 
     return when {
         isCatalogEntry -> buildList {
@@ -3810,12 +3825,14 @@ internal fun dashboardActionsFor(obj: JsonObject): List<DashboardItemAction> {
         }
         hasSchedule -> buildList {
             add(DashboardItemAction("Runs", DashboardActionKind.ViewCronRuns))
-            if (paused == true) {
-                add(DashboardItemAction("Resume", DashboardActionKind.ResumeCron))
-            } else {
-                add(DashboardItemAction("Pause", DashboardActionKind.PauseCron))
+            if (!completedCron) {
+                if (paused == true) {
+                    add(DashboardItemAction("Resume", DashboardActionKind.ResumeCron))
+                } else {
+                    add(DashboardItemAction("Pause", DashboardActionKind.PauseCron))
+                }
+                add(DashboardItemAction("Run now", DashboardActionKind.TriggerCron))
             }
-            add(DashboardItemAction("Run now", DashboardActionKind.TriggerCron))
             add(DashboardItemAction("Delete", DashboardActionKind.DeleteCron, destructive = true))
         }
         hasTransport -> buildList {
@@ -4107,9 +4124,10 @@ private suspend fun DashboardApiClient.runDashboardAction(
         DashboardActionKind.ViewProfileSoul -> getProfileSoul(id)
         DashboardActionKind.ActivateProfile -> setActiveProfile(id)
         DashboardActionKind.DeleteProfile -> deleteProfile(id)
-        DashboardActionKind.ActivateCustomEndpoint -> activateCustomEndpoint(id)
+        DashboardActionKind.ActivateCustomEndpoint ->
+            activateCustomEndpoint(id, profile = item.profile)
         DashboardActionKind.DeleteCustomEndpoint ->
-            deleteCustomEndpoint(id).map { JsonObject(emptyMap()) }
+            deleteCustomEndpoint(id, profile = item.profile).map { JsonObject(emptyMap()) }
         DashboardActionKind.RevealEnvKey -> revealEnvVar(id)
         DashboardActionKind.ClearEnvKey -> deleteEnvVar(id)
         // Input-backed kinds are intercepted at the onAction layer and routed

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DashboardManagementScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/DashboardManagementScreen.kt
@@ -148,6 +148,10 @@ private enum class DashboardManagementSection(val path: String) {
     Catalog("/api/mcp/catalog"),
     CustomEndpoints("/api/providers/custom-endpoints"),
     Profiles("/api/profiles"),
+    Memory("/api/memory"),
+    Learning("/api/learning/graph"),
+    Channels("/api/messaging/platforms"),
+    Operations("/api/status"),
     Models("/api/model/info"),
     Keys("/api/env"),
     Config("/api/config/schema");
@@ -160,6 +164,10 @@ private enum class DashboardManagementSection(val path: String) {
         Catalog -> stringResource(R.string.dashboard_tab_catalog)
         CustomEndpoints -> stringResource(R.string.dashboard_tab_custom_endpoints)
         Profiles -> stringResource(R.string.dashboard_tab_profiles)
+        Memory -> stringResource(R.string.dashboard_tab_memory)
+        Learning -> stringResource(R.string.dashboard_tab_learning)
+        Channels -> stringResource(R.string.dashboard_tab_channels)
+        Operations -> stringResource(R.string.dashboard_tab_operations)
         Models -> stringResource(R.string.dashboard_tab_models)
         Keys -> stringResource(R.string.dashboard_tab_keys)
         Config -> stringResource(R.string.dashboard_tab_config)
@@ -174,6 +182,10 @@ private enum class DashboardManagementSection(val path: String) {
         Catalog -> stringResource(R.string.dashboard_tab_catalog_lower)
         CustomEndpoints -> stringResource(R.string.dashboard_tab_custom_endpoints_lower)
         Profiles -> stringResource(R.string.dashboard_tab_profiles_lower)
+        Memory -> stringResource(R.string.dashboard_tab_memory_lower)
+        Learning -> stringResource(R.string.dashboard_tab_learning_lower)
+        Channels -> stringResource(R.string.dashboard_tab_channels_lower)
+        Operations -> stringResource(R.string.dashboard_tab_operations_lower)
         Models -> stringResource(R.string.dashboard_tab_models_lower)
         Keys -> stringResource(R.string.dashboard_tab_keys_lower)
         Config -> stringResource(R.string.dashboard_tab_config_lower)
@@ -185,7 +197,12 @@ private val managementSections: List<DashboardManagementSection> = DashboardMana
 internal fun dashboardSectionRequestPath(path: String, profile: String?): String {
     if (
         profile.isNullOrBlank() ||
-        path !in setOf("/api/mcp/servers", "/api/mcp/catalog", "/api/providers/custom-endpoints")
+        path !in setOf(
+            "/api/mcp/servers",
+            "/api/mcp/catalog",
+            "/api/providers/custom-endpoints",
+            "/api/learning/graph",
+        )
     ) return path
     val encoded = java.net.URLEncoder.encode(profile, Charsets.UTF_8.name()).replace("+", "%20")
     return "$path?profile=$encoded"
@@ -357,6 +374,7 @@ private enum class DashboardSectionAction {
     BrowseSkillsHub,
     UpdateSkillsHub,
     AddCustomEndpoint,
+    CreateServerBackup,
 }
 
 /** Editor session for a profile's SOUL.md — content is the FULL file from GET. */
@@ -761,7 +779,12 @@ fun DashboardManagementScreen(
         }
     }
 
-    fun submitCreateProfile(name: String, description: String, cloneFromDefault: Boolean) {
+    fun submitCreateProfile(
+        name: String,
+        description: String,
+        cloneFromDefault: Boolean,
+        mcpServers: List<String>,
+    ) {
         if (dashboardUrl.isBlank() || actionInFlight) return
         val actionPayloadKey = payloadKey
         actionInFlight = true
@@ -773,6 +796,7 @@ fun DashboardManagementScreen(
                         name = name,
                         cloneFromDefault = cloneFromDefault,
                         description = description.takeIf { it.isNotBlank() },
+                        mcpServers = mcpServers,
                     )
                 }
             } catch (e: Exception) {
@@ -787,6 +811,28 @@ fun DashboardManagementScreen(
                     context.getString(R.string.dashboard_profile_created, name)
                 },
                 onFailure = { err -> err.message ?: context.getString(R.string.dashboard_profile_create_failed) },
+            )
+            actionInFlight = false
+        }
+    }
+
+    fun runServerBackup() {
+        if (dashboardUrl.isBlank() || actionInFlight) return
+        actionInFlight = true
+        actionMessage = null
+        scope.launch {
+            val result = try {
+                withDashboardClient(clientFactory) { client -> client.createServerBackup() }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+            actionMessage = result.fold(
+                onSuccess = { root ->
+                    root.stringField("message")
+                        ?: root.stringField("filename")?.let { "Server backup ready: $it" }
+                        ?: "Server backup created."
+                },
+                onFailure = { error -> error.message ?: "Server backup failed." },
             )
             actionInFlight = false
         }
@@ -957,6 +1003,7 @@ fun DashboardManagementScreen(
     if (showCreateProfile) {
         var newProfileName by remember { mutableStateOf("") }
         var newProfileDescription by remember { mutableStateOf("") }
+        var newProfileMcpServers by remember { mutableStateOf("") }
         var cloneFromDefault by remember { mutableStateOf(true) }
         AlertDialog(
             onDismissRequest = { showCreateProfile = false },
@@ -975,6 +1022,13 @@ fun DashboardManagementScreen(
                         onValueChange = { newProfileDescription = it },
                         modifier = Modifier.fillMaxWidth(),
                         label = { Text(stringResource(R.string.dashboard_description_optional)) },
+                    )
+                    OutlinedTextField(
+                        value = newProfileMcpServers,
+                        onValueChange = { newProfileMcpServers = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(stringResource(R.string.dashboard_profile_mcp_servers_optional)) },
+                        supportingText = { Text(stringResource(R.string.dashboard_profile_mcp_servers_help)) },
                     )
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -998,6 +1052,12 @@ fun DashboardManagementScreen(
                             name = newProfileName.trim(),
                             description = newProfileDescription.trim(),
                             cloneFromDefault = cloneFromDefault,
+                            mcpServers = newProfileMcpServers
+                                .split(',', '\n')
+                                .map(String::trim)
+                                .filter(String::isNotBlank)
+                                .distinct()
+                                .take(64),
                         )
                     },
                     enabled = newProfileName.isNotBlank() && !actionInFlight,
@@ -1333,6 +1393,8 @@ fun DashboardManagementScreen(
                                                 customEndpointEditor = null
                                                 showCustomEndpointEditor = true
                                             }
+                                            DashboardSectionAction.CreateServerBackup ->
+                                                runServerBackup()
                                         }
                                     },
                                     mcpOAuthSupported = mcpOAuthStartAllowed,
@@ -1384,6 +1446,26 @@ private fun manageTileSpec(section: DashboardManagementSection): ManageTileSpec 
         icon = Icons.Filled.Person,
         title = stringResource(R.string.dashboard_tile_profiles_title),
         subtitle = stringResource(R.string.dashboard_tile_profiles_sub),
+    )
+    DashboardManagementSection.Memory -> ManageTileSpec(
+        icon = Icons.Filled.AutoAwesome,
+        title = stringResource(R.string.dashboard_tile_memory_title),
+        subtitle = stringResource(R.string.dashboard_tile_memory_sub),
+    )
+    DashboardManagementSection.Learning -> ManageTileSpec(
+        icon = Icons.Filled.AutoAwesome,
+        title = stringResource(R.string.dashboard_tile_learning_title),
+        subtitle = stringResource(R.string.dashboard_tile_learning_sub),
+    )
+    DashboardManagementSection.Channels -> ManageTileSpec(
+        icon = Icons.Filled.Link,
+        title = stringResource(R.string.dashboard_tile_channels_title),
+        subtitle = stringResource(R.string.dashboard_tile_channels_sub),
+    )
+    DashboardManagementSection.Operations -> ManageTileSpec(
+        icon = Icons.Filled.Tune,
+        title = stringResource(R.string.dashboard_tile_operations_title),
+        subtitle = stringResource(R.string.dashboard_tile_operations_sub),
     )
     DashboardManagementSection.Skills -> ManageTileSpec(
         icon = Icons.Filled.AutoAwesome,
@@ -2213,6 +2295,7 @@ private fun LoadedBody(
     val actionLabelBrowseHub = stringResource(R.string.dashboard_section_action_browse_hub)
     val actionLabelUpdateInstalled = stringResource(R.string.dashboard_section_action_update_installed)
     val actionLabelAddEndpoint = stringResource(R.string.dashboard_custom_endpoint_add)
+    val actionLabelServerBackup = stringResource(R.string.dashboard_section_action_server_backup)
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = androidx.compose.foundation.layout.PaddingValues(
@@ -2239,6 +2322,9 @@ private fun LoadedBody(
             )
             DashboardManagementSection.CustomEndpoints -> listOf(
                 DashboardSectionAction.AddCustomEndpoint to actionLabelAddEndpoint,
+            )
+            DashboardManagementSection.Operations -> listOf(
+                DashboardSectionAction.CreateServerBackup to actionLabelServerBackup,
             )
             else -> emptyList()
         }
@@ -3707,6 +3793,16 @@ private fun summarize(
                     ?.map { (name, value) -> summarizeObjectItem(value, name) }
                 ?: listOf(summarizeObjectItem(root, "Profile"))
         }
+        DashboardManagementSection.Memory -> summarizeKeyValueOrList(root, "Memory")
+        DashboardManagementSection.Learning ->
+            root.arrayItems("nodes", "items")
+                ?.mapIndexed { index, item -> summarizeObjectItem(item, "Node ${index + 1}") }
+                ?: summarizeKeyValueOrList(root, "Learning")
+        DashboardManagementSection.Channels ->
+            root.arrayItems("platforms", "channels", "items")
+                ?.mapIndexed { index, item -> summarizeObjectItem(item, "Channel ${index + 1}") }
+                ?: summarizeKeyValueOrList(root, "Channel")
+        DashboardManagementSection.Operations -> summarizeKeyValueOrList(root, "Status")
         DashboardManagementSection.Models -> summarizeKeyValueOrList(root, "Model")
         DashboardManagementSection.Keys -> summarizeEnvVars(root)
         DashboardManagementSection.Config -> summarizeKeyValueOrList(root, "Config")

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
@@ -134,6 +134,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import okhttp3.sse.EventSource
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -1229,10 +1230,16 @@ class ChatViewModel : ViewModel() {
                         // Pill update is the confirmation — no system bubble.
                         // Surface only a server warning, ephemerally.
                         warning?.let { _transientNotice.tryEmit(it) }
-                        gateway.modelOptions().onSuccess {
-                            _modelProviders.value = it.providers
-                            _gatewayCurrentModel.value = it.currentModel
-                            _gatewayCurrentProvider.value = it.currentProvider
+                        // Current upstream may defer the switch until the turn
+                        // boundary. Keep the optimistic requested identity; an
+                        // immediate model.options read still reports the old
+                        // model and would visibly snap the picker backward.
+                        if (!isDeferredConfigResult(result)) {
+                            gateway.modelOptions().onSuccess {
+                                _modelProviders.value = it.providers
+                                _gatewayCurrentModel.value = it.currentModel
+                                _gatewayCurrentProvider.value = it.currentProvider
+                            }
                         }
                     },
                     onFailure = { e ->
@@ -8626,6 +8633,19 @@ internal fun parseCommandsCatalog(catalog: JsonObject): List<SlashCommand> {
     }
     val seen = mutableSetOf<String>()
     val out = mutableListOf<SlashCommand>()
+    val skillMetadata = (catalog["skills"] as? JsonObject)
+        ?.entries
+        ?.take(MAX_CATALOG_SKILLS)
+        ?.associate { (rawName, element) ->
+            val normalized = if (rawName.startsWith("/")) rawName.lowercase() else "/${rawName.lowercase()}"
+            val metadata = element as? JsonObject
+            val usage = (metadata?.get("usage") as? JsonPrimitive)?.intOrNull
+                ?.coerceIn(0, MAX_SKILL_USAGE) ?: 0
+            val origin = metadata?.stringValue("origin")
+                ?.trim()?.take(MAX_SKILL_ORIGIN_CHARS)?.takeIf { it.isNotBlank() }
+            normalized to (usage to origin)
+        }
+        .orEmpty()
     (catalog["pairs"] as? JsonArray)?.forEach { pairElement ->
         val pair = pairElement as? JsonArray ?: return@forEach
         val rawName = (pair.getOrNull(0) as? JsonPrimitive)?.contentOrNull?.trim()
@@ -8634,15 +8654,34 @@ internal fun parseCommandsCatalog(catalog: JsonObject): List<SlashCommand> {
         if (isUnsupportedMobileCommand(name, pair)) return@forEach
         if (!seen.add(name.lowercase())) return@forEach
         val description = (pair.getOrNull(1) as? JsonPrimitive)?.contentOrNull?.trim().orEmpty()
+        val skill = skillMetadata[name.lowercase()]
         out += SlashCommand(
             command = name,
             description = description.ifBlank { "Server command" },
             category = categoryByName[name.lowercase()] ?: SlashCommand.CATEGORY_SERVER,
             source = SlashCommand.SOURCE_SERVER,
+            usageRank = skill?.first ?: 0,
+            origin = skill?.second,
         )
     }
-    return out
+    // Preserve every non-skill command's exact catalog position. Rank only
+    // entries occupying skill slots, so built-ins and quick commands do not
+    // jump around when usage changes.
+    val rankedSkills = out.filter { skillMetadata.containsKey(it.command.lowercase()) }
+        .sortedWith(compareByDescending<SlashCommand> { it.usageRank }.thenBy { it.command })
+        .iterator()
+    return out.map { command ->
+        if (skillMetadata.containsKey(command.command.lowercase())) rankedSkills.next() else command
+    }
 }
+
+private const val MAX_CATALOG_SKILLS = 512
+private const val MAX_SKILL_USAGE = 1_000_000_000
+private const val MAX_SKILL_ORIGIN_CHARS = 32
+
+internal fun isDeferredConfigResult(result: JsonObject): Boolean =
+    (result["deferred"] as? JsonPrimitive)?.contentOrNull
+        ?.trim()?.lowercase() in setOf("true", "1", "yes")
 
 /** Dashboard `/api/config` response -> the same personality catalog as API mode. */
 internal fun parseDashboardPersonalityConfig(

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
@@ -1623,6 +1623,9 @@ class ChatViewModel : ViewModel() {
     val backgroundProcessesLoading: StateFlow<Boolean> = gatewayProcessController.loading
     val stoppingProcessIds: StateFlow<Set<String>> = gatewayProcessController.stoppingProcessIds
 
+    private val _messageReactionsSupported = MutableStateFlow(true)
+    val messageReactionsSupported: StateFlow<Boolean> = _messageReactionsSupported.asStateFlow()
+
     fun refreshBackgroundProcesses() {
         gatewayProcessController.refresh()
     }
@@ -1649,6 +1652,7 @@ class ChatViewModel : ViewModel() {
         gatewayClient = client
         if (changed) {
             resetApprovalModeState()
+            _messageReactionsSupported.value = true
             gatewayProcessSource = client?.let(::GatewayChatProcessSource)
             gatewayProcessController.bind(
                 newSource = gatewayProcessSource,
@@ -2317,6 +2321,26 @@ class ChatViewModel : ViewModel() {
      */
     private val _transientNotice = MutableSharedFlow<String>(extraBufferCapacity = 8)
     val transientNotice: SharedFlow<String> = _transientNotice.asSharedFlow()
+
+    fun reactToNewest(role: MessageRole, emoji: String?) {
+        val gateway = gatewayClient ?: return
+        if (role != MessageRole.USER && role != MessageRole.ASSISTANT) return
+        viewModelScope.launch {
+            gateway.reactToNewest(role.name.lowercase(), emoji).fold(
+                onSuccess = {
+                    _transientNotice.tryEmit(if (emoji == null) "Reaction removed." else "Reaction added.")
+                },
+                onFailure = { error ->
+                    if ((error as? GatewayRpcException)?.code == -32601) {
+                        _messageReactionsSupported.value = false
+                        _transientNotice.tryEmit("Message reactions aren't supported by this gateway.")
+                    } else {
+                        _transientNotice.tryEmit("Couldn't update reaction: ${error.message ?: "unknown error"}")
+                    }
+                },
+            )
+        }
+    }
 
     fun steerSubagent(subagentId: String, instruction: String) {
         val gateway = gatewayClient ?: return

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
@@ -2318,6 +2318,25 @@ class ChatViewModel : ViewModel() {
     private val _transientNotice = MutableSharedFlow<String>(extraBufferCapacity = 8)
     val transientNotice: SharedFlow<String> = _transientNotice.asSharedFlow()
 
+    fun steerSubagent(subagentId: String, instruction: String) {
+        val gateway = gatewayClient ?: return
+        if (subagentId.isBlank() || instruction.isBlank()) return
+        viewModelScope.launch {
+            gateway.steerSubagent(subagentId, instruction).fold(
+                onSuccess = { result ->
+                    val status = result.stringValue("status") ?: "queued"
+                    _transientNotice.tryEmit(
+                        if (status == "rejected") "Subagent redirect was rejected."
+                        else "Subagent redirect queued.",
+                    )
+                },
+                onFailure = { error ->
+                    _transientNotice.tryEmit("Couldn't redirect subagent: ${error.message ?: "unknown error"}")
+                },
+            )
+        }
+    }
+
     /**
      * Composer prefill requests from server command dispatch
      * (`{type:"prefill"}` — e.g. `/undo`). ChatScreen collects and sets the

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ConnectionViewModel.kt
@@ -1493,6 +1493,9 @@ class ConnectionViewModel(application: Application) : AndroidViewModel(applicati
     suspend fun listProfileScopedSessions(limit: Int = 200): Result<List<SessionItem>>? =
         profileController.listProfileScopedSessions(limit)
 
+    suspend fun listAllProfileSessions(limit: Int = 200): Result<List<SessionItem>>? =
+        profileController.listAllProfileSessions(limit)
+
     suspend fun loadProfileScopedMessages(
         sessionId: String,
         mode: SessionMessageLoadMode = SessionMessageLoadMode.COMPLETE,

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/connection/ProfileController.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/connection/ProfileController.kt
@@ -344,6 +344,12 @@ class ProfileController(
             .listSessions(profile = profileName, limit = limit, archived = "include")
     }
 
+    suspend fun listAllProfileSessions(limit: Int = 200): Result<List<SessionItem>>? {
+        val connectionId = activeConnectionId.value ?: return null
+        val dashboardUrl = activeDashboardUrlProvider() ?: return null
+        return dashboardClientFactory(connectionId, dashboardUrl).listAllProfileSessions(limit)
+    }
+
     /**
      * A session's transcript, scoped to the active profile via the dashboard
      * `/api/sessions/{id}/messages?profile=`. Returns `null` off the dashboard

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -3825,4 +3825,26 @@
     <string name="pet_creator_step_review">Revisar e importar</string>
     <string name="pet_creator_review_desc">Inspecione primeiro a imagem ou o ZIP retornado. A importação copia os arquivos validados para o armazenamento do app; ela não os publica.</string>
     <string name="pet_creator_import">Importar pet concluído</string>
+    <string name="dashboard_tab_memory">Memória</string>
+    <string name="dashboard_tab_learning">Aprendizado</string>
+    <string name="dashboard_tab_channels">Canais</string>
+    <string name="dashboard_tab_operations">Operações</string>
+    <string name="dashboard_tab_memory_lower">memória</string>
+    <string name="dashboard_tab_learning_lower">aprendizado</string>
+    <string name="dashboard_tab_channels_lower">canais</string>
+    <string name="dashboard_tab_operations_lower">operações</string>
+    <string name="dashboard_section_action_server_backup">Criar backup do servidor</string>
+    <string name="dashboard_profile_mcp_servers_optional">Servidores MCP (opcional)</string>
+    <string name="dashboard_profile_mcp_servers_help">Nomes de servidor separados por vírgulas ou linhas. As credenciais permanecem no servidor.</string>
+    <string name="dashboard_tile_memory_title">Memória</string>
+    <string name="dashboard_tile_memory_sub">Status do provedor e configuração de memória do servidor</string>
+    <string name="dashboard_tile_learning_title">Grafo de aprendizado</string>
+    <string name="dashboard_tile_learning_sub">Inspecione os nós aprendidos do perfil ativo</string>
+    <string name="dashboard_tile_channels_title">Canais</string>
+    <string name="dashboard_tile_channels_sub">Status das plataformas de mensagens, incluindo WhatsApp</string>
+    <string name="dashboard_tile_operations_title">Operações do servidor</string>
+    <string name="dashboard_tile_operations_sub">Integridade do host e backup geral do servidor</string>
+    <string name="drawer_all_profiles">Todos os perfis</string>
+    <string name="drawer_no_profile_sessions">Nenhuma sessão de perfil correspondente.</string>
+    <string name="drawer_close">Fechar</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -3913,4 +3913,26 @@
     <string name="pet_creator_step_review">检查并导入</string>
     <string name="pet_creator_review_desc">请先检查返回的图片或 ZIP。导入会将经过验证的文件复制到应用专属存储空间，不会发布它们。</string>
     <string name="pet_creator_import">导入完成的宠物</string>
+    <string name="dashboard_tab_memory">记忆</string>
+    <string name="dashboard_tab_learning">学习</string>
+    <string name="dashboard_tab_channels">频道</string>
+    <string name="dashboard_tab_operations">运维</string>
+    <string name="dashboard_tab_memory_lower">记忆</string>
+    <string name="dashboard_tab_learning_lower">学习</string>
+    <string name="dashboard_tab_channels_lower">频道</string>
+    <string name="dashboard_tab_operations_lower">运维</string>
+    <string name="dashboard_section_action_server_backup">创建服务器备份</string>
+    <string name="dashboard_profile_mcp_servers_optional">MCP 服务器（可选）</string>
+    <string name="dashboard_profile_mcp_servers_help">用逗号或换行分隔服务器名称。凭据仍由服务器保管。</string>
+    <string name="dashboard_tile_memory_title">记忆</string>
+    <string name="dashboard_tile_memory_sub">提供商状态和服务器端记忆配置</string>
+    <string name="dashboard_tile_learning_title">学习图谱</string>
+    <string name="dashboard_tile_learning_sub">查看当前配置文件的已学习节点</string>
+    <string name="dashboard_tile_channels_title">频道</string>
+    <string name="dashboard_tile_channels_sub">消息平台状态，包括 WhatsApp</string>
+    <string name="dashboard_tile_operations_title">服务器运维</string>
+    <string name="dashboard_tile_operations_sub">主机健康状况和服务器整体备份</string>
+    <string name="drawer_all_profiles">所有配置文件</string>
+    <string name="drawer_no_profile_sessions">没有匹配的配置文件会话。</string>
+    <string name="drawer_close">关闭</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3985,4 +3985,26 @@
     <string name="pet_creator_step_review">Prüfen und importieren</string>
     <string name="pet_creator_review_desc">Prüfen Sie zuerst das zurückgegebene Bild oder ZIP. Beim Import werden die validierten Dateien in den App-Speicher kopiert; sie werden nicht veröffentlicht.</string>
     <string name="pet_creator_import">Fertiges Pet importieren</string>
+    <string name="dashboard_tab_memory">Speicher</string>
+    <string name="dashboard_tab_learning">Lernen</string>
+    <string name="dashboard_tab_channels">Kanäle</string>
+    <string name="dashboard_tab_operations">Betrieb</string>
+    <string name="dashboard_tab_memory_lower">Speicher</string>
+    <string name="dashboard_tab_learning_lower">Lernen</string>
+    <string name="dashboard_tab_channels_lower">Kanäle</string>
+    <string name="dashboard_tab_operations_lower">Betrieb</string>
+    <string name="dashboard_section_action_server_backup">Server-Sicherung erstellen</string>
+    <string name="dashboard_profile_mcp_servers_optional">MCP-Server (optional)</string>
+    <string name="dashboard_profile_mcp_servers_help">Komma- oder zeilengetrennte Servernamen. Anmeldedaten verbleiben auf dem Server.</string>
+    <string name="dashboard_tile_memory_title">Speicher</string>
+    <string name="dashboard_tile_memory_sub">Anbieterstatus und servereigene Speicherkonfiguration</string>
+    <string name="dashboard_tile_learning_title">Lerngraph</string>
+    <string name="dashboard_tile_learning_sub">Gelernte Knoten des aktiven Profils prüfen</string>
+    <string name="dashboard_tile_channels_title">Kanäle</string>
+    <string name="dashboard_tile_channels_sub">Status der Nachrichtenplattformen einschließlich WhatsApp</string>
+    <string name="dashboard_tile_operations_title">Serverbetrieb</string>
+    <string name="dashboard_tile_operations_sub">Hostzustand und serverweite Sicherung</string>
+    <string name="drawer_all_profiles">Alle Profile</string>
+    <string name="drawer_no_profile_sessions">Keine passenden Profilsitzungen.</string>
+    <string name="drawer_close">Schließen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3670,4 +3670,26 @@
     <string name="pet_creator_step_review">Revisar e importar</string>
     <string name="pet_creator_review_desc">Inspecciona primero la imagen o el ZIP recibido. Al importar se copian los archivos validados al almacenamiento de la aplicación; no se publican.</string>
     <string name="pet_creator_import">Importar mascota terminada</string>
+    <string name="dashboard_tab_memory">Memoria</string>
+    <string name="dashboard_tab_learning">Aprendizaje</string>
+    <string name="dashboard_tab_channels">Canales</string>
+    <string name="dashboard_tab_operations">Operaciones</string>
+    <string name="dashboard_tab_memory_lower">memoria</string>
+    <string name="dashboard_tab_learning_lower">aprendizaje</string>
+    <string name="dashboard_tab_channels_lower">canales</string>
+    <string name="dashboard_tab_operations_lower">operaciones</string>
+    <string name="dashboard_section_action_server_backup">Crear copia del servidor</string>
+    <string name="dashboard_profile_mcp_servers_optional">Servidores MCP (opcional)</string>
+    <string name="dashboard_profile_mcp_servers_help">Nombres de servidor separados por comas o líneas. Las credenciales permanecen en el servidor.</string>
+    <string name="dashboard_tile_memory_title">Memoria</string>
+    <string name="dashboard_tile_memory_sub">Estado del proveedor y configuración de memoria del servidor</string>
+    <string name="dashboard_tile_learning_title">Grafo de aprendizaje</string>
+    <string name="dashboard_tile_learning_sub">Inspecciona los nodos aprendidos del perfil activo</string>
+    <string name="dashboard_tile_channels_title">Canales</string>
+    <string name="dashboard_tile_channels_sub">Estado de plataformas de mensajería, incluido WhatsApp</string>
+    <string name="dashboard_tile_operations_title">Operaciones del servidor</string>
+    <string name="dashboard_tile_operations_sub">Estado del host y copia de seguridad del servidor</string>
+    <string name="drawer_all_profiles">Todos los perfiles</string>
+    <string name="drawer_no_profile_sessions">No hay sesiones de perfil coincidentes.</string>
+    <string name="drawer_close">Cerrar</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -3984,4 +3984,26 @@
     <string name="pet_creator_step_review">確認してインポート</string>
     <string name="pet_creator_review_desc">返された画像またはZIPを最初に確認してください。インポートすると検証済みファイルがアプリ専用ストレージにコピーされますが、公開はされません。</string>
     <string name="pet_creator_import">完成したペットをインポート</string>
+    <string name="dashboard_tab_memory">メモリ</string>
+    <string name="dashboard_tab_learning">学習</string>
+    <string name="dashboard_tab_channels">チャンネル</string>
+    <string name="dashboard_tab_operations">運用</string>
+    <string name="dashboard_tab_memory_lower">メモリ</string>
+    <string name="dashboard_tab_learning_lower">学習</string>
+    <string name="dashboard_tab_channels_lower">チャンネル</string>
+    <string name="dashboard_tab_operations_lower">運用</string>
+    <string name="dashboard_section_action_server_backup">サーバーバックアップを作成</string>
+    <string name="dashboard_profile_mcp_servers_optional">MCP サーバー（任意）</string>
+    <string name="dashboard_profile_mcp_servers_help">サーバー名をカンマまたは改行で区切ります。認証情報はサーバー側に保持されます。</string>
+    <string name="dashboard_tile_memory_title">メモリ</string>
+    <string name="dashboard_tile_memory_sub">プロバイダーの状態とサーバー側のメモリ設定</string>
+    <string name="dashboard_tile_learning_title">学習グラフ</string>
+    <string name="dashboard_tile_learning_sub">アクティブなプロファイルの学習済みノードを確認</string>
+    <string name="dashboard_tile_channels_title">チャンネル</string>
+    <string name="dashboard_tile_channels_sub">WhatsApp を含むメッセージプラットフォームの状態</string>
+    <string name="dashboard_tile_operations_title">サーバー運用</string>
+    <string name="dashboard_tile_operations_sub">ホストの状態とサーバー全体のバックアップ</string>
+    <string name="drawer_all_profiles">すべてのプロファイル</string>
+    <string name="drawer_no_profile_sessions">一致するプロファイルセッションはありません。</string>
+    <string name="drawer_close">閉じる</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -3706,4 +3706,26 @@
     <string name="pet_creator_step_review">Проверить и импортировать</string>
     <string name="pet_creator_review_desc">Сначала проверьте полученное изображение или ZIP. При импорте проверенные файлы копируются в хранилище приложения и не публикуются.</string>
     <string name="pet_creator_import">Импортировать готового питомца</string>
+    <string name="dashboard_tab_memory">Память</string>
+    <string name="dashboard_tab_learning">Обучение</string>
+    <string name="dashboard_tab_channels">Каналы</string>
+    <string name="dashboard_tab_operations">Операции</string>
+    <string name="dashboard_tab_memory_lower">память</string>
+    <string name="dashboard_tab_learning_lower">обучение</string>
+    <string name="dashboard_tab_channels_lower">каналы</string>
+    <string name="dashboard_tab_operations_lower">операции</string>
+    <string name="dashboard_section_action_server_backup">Создать резервную копию сервера</string>
+    <string name="dashboard_profile_mcp_servers_optional">Серверы MCP (необязательно)</string>
+    <string name="dashboard_profile_mcp_servers_help">Имена серверов через запятую или с новой строки. Учётные данные остаются на сервере.</string>
+    <string name="dashboard_tile_memory_title">Память</string>
+    <string name="dashboard_tile_memory_sub">Состояние провайдера и серверная настройка памяти</string>
+    <string name="dashboard_tile_learning_title">Граф обучения</string>
+    <string name="dashboard_tile_learning_sub">Просмотр изученных узлов активного профиля</string>
+    <string name="dashboard_tile_channels_title">Каналы</string>
+    <string name="dashboard_tile_channels_sub">Состояние платформ сообщений, включая WhatsApp</string>
+    <string name="dashboard_tile_operations_title">Операции сервера</string>
+    <string name="dashboard_tile_operations_sub">Состояние хоста и резервная копия всего сервера</string>
+    <string name="drawer_all_profiles">Все профили</string>
+    <string name="drawer_no_profile_sessions">Нет подходящих сеансов профиля.</string>
+    <string name="drawer_close">Закрыть</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4010,4 +4010,7 @@
     <string name="support_bundle_copied">Support information copied</string>
     <string name="support_bundle_no_share">Support information copied — no app found to share to</string>
     <string name="support_bundle_share_title">Share Hermes-Relay support information</string>
+    <string name="drawer_all_profiles">All profiles</string>
+    <string name="drawer_no_profile_sessions">No matching profile sessions.</string>
+    <string name="drawer_close">Close</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1862,6 +1862,10 @@
     <string name="dashboard_tab_models">Models</string>
     <string name="dashboard_tab_keys">Keys</string>
     <string name="dashboard_tab_config">Config</string>
+    <string name="dashboard_tab_memory">Memory</string>
+    <string name="dashboard_tab_learning">Learning</string>
+    <string name="dashboard_tab_channels">Channels</string>
+    <string name="dashboard_tab_operations">Operations</string>
     <!-- Lowercase tab labels for compact UI surfaces (KPI strip) -->
     <string name="dashboard_tab_skills_lower">skills</string>
     <string name="dashboard_tab_cron_lower">cron</string>
@@ -1872,6 +1876,10 @@
     <string name="dashboard_tab_models_lower">models</string>
     <string name="dashboard_tab_keys_lower">keys</string>
     <string name="dashboard_tab_config_lower">config</string>
+    <string name="dashboard_tab_memory_lower">memory</string>
+    <string name="dashboard_tab_learning_lower">learning</string>
+    <string name="dashboard_tab_channels_lower">channels</string>
+    <string name="dashboard_tab_operations_lower">operations</string>
 
     <!-- Tile titles + subtitles -->
     <string name="dashboard_tile_profiles_title">Profiles</string>
@@ -1968,6 +1976,17 @@
     <string name="dashboard_section_action_new_profile">New profile</string>
     <string name="dashboard_section_action_browse_hub">Browse hub</string>
     <string name="dashboard_section_action_update_installed">Update installed</string>
+    <string name="dashboard_section_action_server_backup">Create server backup</string>
+    <string name="dashboard_profile_mcp_servers_optional">MCP servers (optional)</string>
+    <string name="dashboard_profile_mcp_servers_help">Comma or line-separated server names. Credentials remain server-owned.</string>
+    <string name="dashboard_tile_memory_title">Memory</string>
+    <string name="dashboard_tile_memory_sub">Provider status and host-owned memory configuration</string>
+    <string name="dashboard_tile_learning_title">Learning graph</string>
+    <string name="dashboard_tile_learning_sub">Inspect learned nodes for the active profile</string>
+    <string name="dashboard_tile_channels_title">Channels</string>
+    <string name="dashboard_tile_channels_sub">Messaging platform status, including WhatsApp</string>
+    <string name="dashboard_tile_operations_title">Server operations</string>
+    <string name="dashboard_tile_operations_sub">Host health and server-wide backup</string>
 
     <!-- Action labels (rendered via kind → string) -->
     <string name="dashboard_action_set">Set</string>

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/shared/ReconnectBackoffTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/shared/ReconnectBackoffTest.kt
@@ -1,0 +1,19 @@
+package com.hermesandroid.relay.network.shared
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReconnectBackoffTest {
+    @Test
+    fun `full jitter stays within the cap`() {
+        assertEquals(0L, fullJitterDelayMs(1_000L, 0.0))
+        assertEquals(500L, fullJitterDelayMs(1_000L, 0.5))
+        assertEquals(1_000L, fullJitterDelayMs(1_000L, 1.0))
+    }
+
+    @Test
+    fun `non-positive caps are immediate`() {
+        assertEquals(0L, fullJitterDelayMs(0L, 0.5))
+        assertEquals(0L, fullJitterDelayMs(-1L, 0.5))
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ChatHandlerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ChatHandlerTest.kt
@@ -145,6 +145,43 @@ class ChatHandlerTest {
     }
 
     @Test
+    fun mediaMarkers_acceptUpstreamWrappersPunctuationAdjacentAndWindowsPaths() {
+        val paths = mutableListOf<String>()
+        handler.onMediaBarePathRequested = { _, path -> paths += path }
+
+        handler.onTextDelta("assist-1", "`MEDIA:/tmp/report.csv.`\n")
+        handler.onTextDelta(
+            "assist-1",
+            "**MEDIA:C:\\exports\\shot.png**, MEDIA:/tmp/other report.pdf\n",
+        )
+
+        assertEquals(
+            listOf(
+                "/tmp/report.csv",
+                "C:\\exports\\shot.png",
+                "/tmp/other report.pdf",
+            ),
+            paths,
+        )
+        assertEquals("", handler.messages.value.single().content)
+    }
+
+    @Test
+    fun mediaMarkers_preserveFencedAndProseExamples() {
+        val paths = mutableListOf<String>()
+        handler.onMediaBarePathRequested = { _, path -> paths += path }
+
+        handler.onTextDelta(
+            "assist-1",
+            "```text\nMEDIA:/tmp/example.png\n```\nExample: `MEDIA:/tmp/example.pdf`\n",
+        )
+
+        assertTrue(paths.isEmpty())
+        assertTrue(handler.messages.value.single().content.contains("MEDIA:/tmp/example.png"))
+        assertTrue(handler.messages.value.single().content.contains("MEDIA:/tmp/example.pdf"))
+    }
+
+    @Test
     fun onTextDelta_setsStreamingFlag() {
         handler.onTextDelta("assist-1", "delta")
 

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
@@ -865,6 +865,28 @@ class DashboardApiClientTest {
     }
 
     @Test
+    fun listAllProfileSessions_preservesOwnerAndCompositeIdentity() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"sessions":[{"id":"same","title":"A","profile":"default"},{"id":"same","title":"B","profile":"work"},{"id":"unsafe"}],"total":3}""",
+                ),
+        )
+
+        val sessions = DashboardApiClient(baseUrl = server.url("/").toString())
+            .listAllProfileSessions()
+            .getOrThrow()
+
+        val url = server.takeRequest().requestUrl!!
+        assertEquals("/api/profiles/sessions", url.encodedPath)
+        assertEquals("all", url.queryParameter("profile"))
+        assertEquals("include", url.queryParameter("archived"))
+        assertEquals(listOf("default", "work"), sessions.map { it.profile })
+        assertEquals(listOf("A", "B"), sessions.map { it.title })
+    }
+
+    @Test
     fun listSessions_pagesAtUpstreamMaximumWhilePreservingTwoHundredRowWindow() = runTest {
         val firstPage = (0 until 100).joinToString(",") { "{\"id\":\"sess-$it\"}" }
         server.enqueue(

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
@@ -740,6 +740,30 @@ class DashboardApiClientTest {
     }
 
     @Test
+    fun profileCreationCarriesMcpServersAndServerBackupIsDistinct() = runTest {
+        repeat(2) {
+            server.enqueue(
+                MockResponse().setHeader("Content-Type", "application/json").setBody("""{"ok":true}"""),
+            )
+        }
+        val client = DashboardApiClient(baseUrl = server.url("/").toString())
+
+        client.createProfile(
+            name = "research",
+            description = "Deep work",
+            mcpServers = listOf("github", "memory"),
+        ).getOrThrow()
+        client.createServerBackup().getOrThrow()
+
+        val create = server.takeRequest()
+        assertEquals("/api/profiles", create.path)
+        assertTrue(create.body.readUtf8().contains(""""mcp_servers":["github","memory"]"""))
+        val backup = server.takeRequest()
+        assertEquals("POST", backup.method)
+        assertEquals("/api/ops/backup", backup.path)
+    }
+
+    @Test
     fun getActiveProfileScope_distinguishesStickyDefaultFromDashboardProcess() = runTest {
         server.enqueue(
             MockResponse()

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/DashboardApiClientTest.kt
@@ -690,24 +690,30 @@ class DashboardApiClientTest {
             apiKey = "never-persist-this",
         )
 
-        val listed = client.getCustomEndpoints().getOrThrow()
-        client.saveCustomEndpoint(draft).getOrThrow()
+        val listed = client.getCustomEndpoints("work profile").getOrThrow()
+        client.saveCustomEndpoint(draft, "work profile").getOrThrow()
         val validation = client.validateCustomEndpoint(draft).getOrThrow()
-        client.activateCustomEndpoint("local").getOrThrow()
-        client.deleteCustomEndpoint("local").getOrThrow()
+        client.activateCustomEndpoint("local", "work profile").getOrThrow()
+        client.deleteCustomEndpoint("local", "work profile").getOrThrow()
 
         assertEquals("local", listed.currentProvider)
         assertTrue(listed.endpoints.single().hasApiKey)
         assertEquals(listOf("qwen"), validation.models)
-        assertEquals("/api/providers/custom-endpoints", server.takeRequest().path)
+        assertEquals("/api/providers/custom-endpoints?profile=work%20profile", server.takeRequest().path)
         val save = server.takeRequest()
-        assertEquals("/api/providers/custom-endpoints", save.path)
+        assertEquals("/api/providers/custom-endpoints?profile=work%20profile", save.path)
         val saveBody = save.body.readUtf8()
         assertTrue(saveBody.contains("never-persist-this"))
         assertTrue(saveBody.contains(""""models":["qwen","qwen-vl"]"""))
         assertEquals("/api/providers/custom-endpoints/validate", server.takeRequest().path)
-        assertEquals("/api/providers/custom-endpoints/local/activate", server.takeRequest().path)
-        assertEquals("/api/providers/custom-endpoints/local", server.takeRequest().path)
+        assertEquals(
+            "/api/providers/custom-endpoints/local/activate?profile=work%20profile",
+            server.takeRequest().path,
+        )
+        assertEquals(
+            "/api/providers/custom-endpoints/local?profile=work%20profile",
+            server.takeRequest().path,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
@@ -678,6 +678,55 @@ class GatewayChatClientTest {
     }
 
     @Test
+    fun `global reclaim settles active turn once and next send resumes durable session`() {
+        val first = Recorder()
+        client.sendTurn(
+            sessionId = null,
+            text = "first",
+            newSessionTitle = "first",
+            callbacks = first.callbacks,
+            onPreflightFailure = { first.preflightFailures += it },
+        )
+        val serverWs = harness.awaitServerSocket()
+        harness.awaitRpc("prompt.submit")
+        val reclaim = harness.eventFrame(
+            "session.reclaimed",
+            buildJsonObject {
+                put("session_id", "live-1")
+                put("stored_session_id", "20260612_120000_abc123")
+                put("reason", "idle_timeout")
+            },
+            null,
+        )
+        serverWs.send(reclaim)
+        serverWs.send(reclaim)
+
+        assertTrue("reclaimed turn never settled", first.completeLatch.await(5, TimeUnit.SECONDS))
+        waitUntil { first.errors.size == 1 }
+
+        val second = Recorder()
+        client.sendTurn(
+            sessionId = "20260612_120000_abc123",
+            text = "continue",
+            newSessionTitle = null,
+            callbacks = second.callbacks,
+            onPreflightFailure = { second.preflightFailures += it },
+        )
+        harness.awaitRpc("session.resume")
+        harness.awaitRpcCount("prompt.submit", 2)
+        serverWs.send(
+            harness.eventFrame(
+                "message.complete",
+                buildJsonObject { put("text", "resumed") },
+                "live-resumed",
+            ),
+        )
+
+        assertTrue("resumed turn never completed", second.completeLatch.await(5, TimeUnit.SECONDS))
+        assertTrue(second.errors.isEmpty())
+    }
+
+    @Test
     fun `unsolicited assistant turn for resumed session streams without sendTurn`() = runBlocking {
         val r = Recorder()
         val registrations = ConcurrentLinkedQueue<String>()

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
@@ -251,6 +251,7 @@ class GatewayClientHarness(
                     put("status", steerStatus)
                     put("text", (params["text"] as? JsonPrimitive)?.contentOrNull ?: "")
                 }
+                "subagent.steer" -> buildJsonObject { put("status", steerStatus) }
                 "session.compress" -> compressPayload
                 "slash.exec" -> buildJsonObject {
                     put("output", "legacy compression started")
@@ -1350,6 +1351,22 @@ class GatewayChatClientTest {
         assertEquals(SteerResult.Failed, runBlocking { client.steer("nothing running") })
         assertTrue(harness.rpcLog.none { it.first == "session.redirect" })
         assertTrue(harness.rpcLog.none { it.first == "session.steer" })
+    }
+
+    @Test
+    fun `subagent redirect carries exact parent and child identity`() = runBlocking {
+        val recorder = Recorder()
+        client.sendTurn(null, "delegate", null, recorder.callbacks) { recorder.preflightFailures += it }
+        harness.awaitServerSocket()
+        harness.awaitRpc("prompt.submit")
+
+        val result = client.steerSubagent("child-17", "focus on Android")
+
+        assertEquals("queued", (result.getOrThrow()["status"] as? JsonPrimitive)?.contentOrNull)
+        val params = harness.awaitRpc("subagent.steer")
+        assertEquals("live-1", (params["session_id"] as? JsonPrimitive)?.contentOrNull)
+        assertEquals("child-17", (params["subagent_id"] as? JsonPrimitive)?.contentOrNull)
+        assertEquals("focus on Android", (params["text"] as? JsonPrimitive)?.contentOrNull)
     }
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClientTest.kt
@@ -252,6 +252,7 @@ class GatewayClientHarness(
                     put("text", (params["text"] as? JsonPrimitive)?.contentOrNull ?: "")
                 }
                 "subagent.steer" -> buildJsonObject { put("status", steerStatus) }
+                "message.react" -> buildJsonObject { put("row_id", 17) }
                 "session.compress" -> compressPayload
                 "slash.exec" -> buildJsonObject {
                     put("output", "legacy compression started")
@@ -1818,6 +1819,23 @@ class GatewayChatClientTest {
     }
 
     // --- Pet thumbnails ---
+
+    @Test
+    fun `message reaction targets newest role without guessing a row id`() {
+        client.sendTurn("stored-1", "hi", null, Recorder().callbacks) {}
+        harness.awaitRpc("session.resume")
+        harness.awaitRpc("prompt.submit")
+
+        val result = runBlocking { client.reactToNewest("assistant", "👍") }
+
+        assertTrue(result.isSuccess)
+        val params = harness.awaitRpc("message.react")
+        assertEquals("live-resumed", (params["session_id"] as? JsonPrimitive)?.contentOrNull)
+        assertEquals("assistant", (params["newest_role"] as? JsonPrimitive)?.contentOrNull)
+        assertEquals("👍", (params["emoji"] as? JsonPrimitive)?.contentOrNull)
+        assertEquals("user", (params["author"] as? JsonPrimitive)?.contentOrNull)
+        assertFalse("row_id" in params)
+    }
 
     @Test
     fun `pet thumbnail connects on demand and sends upstream params`() {

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapperTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapperTest.kt
@@ -591,7 +591,7 @@ class GatewayEventMapperTest {
     fun `subagent lifecycle maps phases and fields`() {
         val r = Recorder()
         val mapper = mapperWith(r)
-        mapper.onEvent("subagent.start", obj("""{"goal":"research topic","task_index":1,"task_count":3}"""))
+        mapper.onEvent("subagent.start", obj("""{"goal":"research topic","task_index":1,"task_count":3,"subagent_id":"child-17"}"""))
         mapper.onEvent("subagent.thinking", obj("""{"goal":"research topic","task_index":1,"task_count":3,"text":"hmm"}"""))
         mapper.onEvent(
             "subagent.tool",
@@ -617,6 +617,7 @@ class GatewayEventMapperTest {
         assertEquals(1, start.taskIndex)
         assertEquals(3, start.taskCount)
         assertEquals("research topic", start.goal)
+        assertEquals("child-17", start.subagentId)
         assertEquals("hmm", r.subagentEvents[1].preview)
         val tool = r.subagentEvents[2]
         assertEquals("web_search", tool.toolName)

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapperTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/GatewayEventMapperTest.kt
@@ -484,6 +484,23 @@ class GatewayEventMapperTest {
     }
 
     @Test
+    fun `structured tool arguments win over legacy previews`() {
+        val recorder = Recorder()
+        val mapper = mapperWith(recorder)
+        mapper.onEvent(
+            "tool.start",
+            obj(
+                """{"tool_id":"t3","name":"terminal","args":{"command":"echo live","timeout":30},"args_text":"stale","context":"older"}""",
+            ),
+        )
+
+        assertEquals(
+            listOf("t3" to "{\"command\":\"echo live\",\"timeout\":30}"),
+            recorder.toolStartArgs,
+        )
+    }
+
+    @Test
     fun `tool complete with error routes to failed`() {
         val r = Recorder()
         val mapper = mapperWith(r)

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/SessionReferenceTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/SessionReferenceTest.kt
@@ -1,0 +1,26 @@
+package com.hermesandroid.relay.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionReferenceTest {
+    @Test
+    fun `references outside code are bounded and parsed`() {
+        val text = """
+            Open @session:research/20260811_abc123.
+            `@session:hidden/inline`
+            ```text
+            @session:hidden/fenced
+            ```
+            Also @session:default/session-2
+        """.trimIndent()
+
+        assertEquals(
+            listOf(
+                SessionReference("research", "20260811_abc123"),
+                SessionReference("default", "session-2"),
+            ),
+            parseSessionReferences(text),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/DashboardManageParityTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/DashboardManageParityTest.kt
@@ -89,6 +89,10 @@ class DashboardManageParityTest {
             "/api/providers/custom-endpoints?profile=work%20profile",
             dashboardSectionRequestPath("/api/providers/custom-endpoints", "work profile"),
         )
+        assertEquals(
+            "/api/learning/graph?profile=work%20profile",
+            dashboardSectionRequestPath("/api/learning/graph", "work profile"),
+        )
         val scoped = scopeDashboardManageItems(
             "/api/mcp/servers",
             "work profile",

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/DashboardManageParityTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/DashboardManageParityTest.kt
@@ -63,13 +63,30 @@ class DashboardManageParityTest {
     }
 
     @Test
-    fun mcpManagePlumbing_usesEffectiveProfileForListAndRowActions() {
+    fun completedOneShotCron_showsOutcomeAndOnlyOffersRunsAndDelete() {
+        val root = Json.parseToJsonElement(
+            """{"id":"once","name":"One shot","schedule":"@once","state":"completed","enabled":false,"last_status":"error","last_error":"model timeout","last_delivery_error":"phone offline"}""",
+        ).jsonObject
+
+        val row = summarizeObjectItem(root, "once")
+
+        assertTrue(row.meta.orEmpty().contains("last: error"))
+        assertTrue(row.meta.orEmpty().contains("error: model timeout"))
+        assertTrue(row.meta.orEmpty().contains("delivery: phone offline"))
+        assertEquals(
+            listOf(DashboardActionKind.ViewCronRuns, DashboardActionKind.DeleteCron),
+            row.actions.map(DashboardItemAction::kind),
+        )
+    }
+
+    @Test
+    fun profileScopedManagePlumbing_usesEffectiveProfileForListAndRowActions() {
         assertEquals(
             "/api/mcp/servers?profile=work%20profile",
             dashboardSectionRequestPath("/api/mcp/servers", "work profile"),
         )
         assertEquals(
-            "/api/providers/custom-endpoints",
+            "/api/providers/custom-endpoints?profile=work%20profile",
             dashboardSectionRequestPath("/api/providers/custom-endpoints", "work profile"),
         )
         val scoped = scopeDashboardManageItems(
@@ -78,6 +95,12 @@ class DashboardManageParityTest {
             listOf(DashboardSummaryItem(id = "hosted", title = "Hosted")),
         )
         assertEquals("work profile", scoped.single().profile)
+        val endpoint = scopeDashboardManageItems(
+            "/api/providers/custom-endpoints",
+            "work profile",
+            listOf(DashboardSummaryItem(id = "local", title = "Local")),
+        )
+        assertEquals("work profile", endpoint.single().profile)
     }
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModelCommandCatalogTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModelCommandCatalogTest.kt
@@ -59,6 +59,48 @@ class ChatViewModelCommandCatalogTest {
     }
 
     @Test
+    fun parseCommandsCatalog_ranksOnlySkillSlotsAndBoundsMetadata() {
+        val catalog = buildJsonObject {
+            put(
+                "pairs",
+                JsonArray(
+                    listOf(
+                        commandPair("status", "Show status"),
+                        commandPair("research", "Research"),
+                        commandPair("help", "Show help"),
+                        commandPair("work", "Worktree"),
+                    ),
+                ),
+            )
+            put("skills", buildJsonObject {
+                put("/research", buildJsonObject {
+                    put("usage", 60)
+                    put("origin", "bundled")
+                })
+                put("/work", buildJsonObject {
+                    put("usage", 172)
+                    put("origin", "local")
+                })
+            })
+        }
+
+        val commands = parseCommandsCatalog(catalog)
+
+        assertEquals(listOf("/status", "/work", "/help", "/research"), commands.map { it.command })
+        assertEquals(172, commands[1].usageRank)
+        assertEquals("local", commands[1].origin)
+        assertEquals(listOf("/status", "/help"), commands.filter { it.usageRank == 0 }.map { it.command })
+    }
+
+    @Test
+    fun deferredConfigResult_acceptsCurrentBooleanShapes() {
+        assertTrue(isDeferredConfigResult(buildJsonObject { put("deferred", true) }))
+        assertTrue(isDeferredConfigResult(buildJsonObject { put("deferred", "1") }))
+        assertFalse(isDeferredConfigResult(buildJsonObject { put("deferred", false) }))
+        assertFalse(isDeferredConfigResult(buildJsonObject { }))
+    }
+
+    @Test
     fun parseDashboardPersonalityConfig_readsWrappedAndDirectConfig() {
         val config = buildJsonObject {
             put("model", "gpt-test")

--- a/docs/localization-status.json
+++ b/docs/localization-status.json
@@ -13,7 +13,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "6f0ae11279c01cb70b21a7908ffe71bc60a5bf37d000dc41b6c664a86612f311",
+        "main": "54a759f3416a8ad19e1fc4d557c42d6aeca10e2091482a173777e016f7398057",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -48,7 +48,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "6f0ae11279c01cb70b21a7908ffe71bc60a5bf37d000dc41b6c664a86612f311",
+        "main": "54a759f3416a8ad19e1fc4d557c42d6aeca10e2091482a173777e016f7398057",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -72,7 +72,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "6f0ae11279c01cb70b21a7908ffe71bc60a5bf37d000dc41b6c664a86612f311",
+        "main": "54a759f3416a8ad19e1fc4d557c42d6aeca10e2091482a173777e016f7398057",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -96,7 +96,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "6f0ae11279c01cb70b21a7908ffe71bc60a5bf37d000dc41b6c664a86612f311",
+        "main": "54a759f3416a8ad19e1fc4d557c42d6aeca10e2091482a173777e016f7398057",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -120,7 +120,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "6f0ae11279c01cb70b21a7908ffe71bc60a5bf37d000dc41b6c664a86612f311",
+        "main": "54a759f3416a8ad19e1fc4d557c42d6aeca10e2091482a173777e016f7398057",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -135,7 +135,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "6f0ae11279c01cb70b21a7908ffe71bc60a5bf37d000dc41b6c664a86612f311",
+        "main": "54a759f3416a8ad19e1fc4d557c42d6aeca10e2091482a173777e016f7398057",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Relay",
   "description": "Paired devices, bridge activity, media inspection, and remote access for hermes-relay",
   "icon": "Activity",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/doctor.py
+++ b/plugin/doctor.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from .compat import collect_compat_status
-from .gateway_diagnostics import assess_gateway_heartbeat
+from .gateway_diagnostics import assess_gateway_heartbeat, assess_gateway_prior_exit
 
 PLUGIN_DIR = Path(__file__).resolve().parent
 PLUGIN_NAME = "hermes-relay"
@@ -466,6 +466,7 @@ def collect_doctor_report(
     bootstrap = _bootstrap_status(site_dirs)
     relay_import = _relay_import_chain()
     gateway_heartbeat = assess_gateway_heartbeat()
+    gateway_prior_exit = assess_gateway_prior_exit()
     checks: list[dict[str, str]] = []
 
     _check(
@@ -562,6 +563,20 @@ def collect_doctor_report(
         "missing": "gateway event-loop heartbeat is not present",
     }[heartbeat_status]
     _check(checks, "gateway-heartbeat", heartbeat_check_status, heartbeat_summary)
+    prior_exit = gateway_prior_exit["prior_exit"]
+    prior_exit_summary = {
+        "clean": "previous gateway life reached a recorded exit path",
+        "unclean": "previous gateway life ended without reaching an exit path",
+        "unknown": "previous gateway exit could not be classified from bounded evidence",
+    }[prior_exit]
+    if gateway_prior_exit.get("suspected_oom") is True:
+        prior_exit_summary += "; low-memory evidence suggests a possible OOM kill"
+    _check(
+        checks,
+        "gateway-prior-exit",
+        "warn" if prior_exit == "unclean" else "ok",
+        prior_exit_summary,
+    )
     _check(
         checks,
         "dashboard-manage-surface",
@@ -657,6 +672,7 @@ def collect_doctor_report(
             "import_chain": relay_import,
         },
         "gateway_heartbeat": gateway_heartbeat,
+        "gateway_prior_exit": gateway_prior_exit,
         "bootstrap": bootstrap,
         "lifecycle": {
             "upstream_plugin_remove_cleans_external_artifacts": False,

--- a/plugin/gateway_diagnostics.py
+++ b/plugin/gateway_diagnostics.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 DEFAULT_STALE_AFTER_S = 90.0
+MAX_EXIT_DIAG_BYTES = 256 * 1024
 
 
 def hermes_home() -> Path:
@@ -110,3 +111,54 @@ def assess_gateway_heartbeat(
         "supported": True,
         "age_seconds": int(age),
     }
+
+
+def assess_gateway_prior_exit(*, home: Path | None = None) -> dict[str, Any]:
+    """Return a bounded label for the gateway life before the current start.
+
+    The upstream exit log can include argv, paths, process details, and memory
+    evidence. Relay deliberately emits only the classification and optional
+    OOM hint; raw records never cross this boundary.
+    """
+    root = home if home is not None else hermes_home()
+    path = root / "logs" / "gateway-exit-diag.log"
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            handle.seek(max(0, size - MAX_EXIT_DIAG_BYTES))
+            raw = handle.read(MAX_EXIT_DIAG_BYTES)
+    except OSError:
+        return {"prior_exit": "unknown"}
+
+    records: list[dict[str, Any]] = []
+    for line in raw.decode("utf-8", errors="replace").splitlines():
+        try:
+            value = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(value, dict) and isinstance(value.get("tag"), str):
+            records.append(value)
+
+    starts = [index for index, record in enumerate(records) if record.get("tag") == "gateway.start"]
+    if not starts:
+        return {"prior_exit": "unknown"}
+    current_start = starts[-1]
+    if current_start == 0:
+        return {"prior_exit": "unknown"}
+
+    previous = records[current_start - 1]
+    if previous.get("tag") == "gateway.previous_unclean_exit":
+        result: dict[str, Any] = {"prior_exit": "unclean"}
+        if previous.get("suspected_oom") is True:
+            result["suspected_oom"] = True
+        return result
+
+    clean_exit_tags = {
+        "atexit.hook",
+        "asyncio.run.return",
+        "asyncio.run.SystemExit",
+        "asyncio.run.KeyboardInterrupt",
+    }
+    if previous.get("tag") in clean_exit_tags:
+        return {"prior_exit": "clean"}
+    return {"prior_exit": "unknown"}

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,6 +1,6 @@
 name: hermes-relay
 manifest_version: 1
-version: 1.6.2
+version: 1.6.3
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 # All three are OPTIONAL — only needed if you use the relay's extra /

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # Desktop releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/plugin/relay/media.py
+++ b/plugin/relay/media.py
@@ -33,6 +33,7 @@ obvious for any future multi-worker or background-cleanup refactor.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import secrets
@@ -40,7 +41,7 @@ import tempfile
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable
 
 logger = logging.getLogger("hermes_relay.media")
@@ -52,6 +53,147 @@ class MediaRegistrationError(ValueError):
     Subclass of :class:`ValueError` so aiohttp handlers can distinguish
     "bad input" from "server bug" cleanly.
     """
+
+
+def _translate_with_upstream(path: str) -> str | None:
+    """Use Hermes' canonical Docker media translator when it is available."""
+    try:
+        from gateway.platforms.base import _translate_docker_container_media_path
+
+        translated = _translate_docker_container_media_path(Path(path))
+    except (ImportError, OSError, RuntimeError, ValueError):
+        return None
+    except Exception:
+        logger.debug("Upstream Docker media translation failed", exc_info=True)
+        return None
+    return str(translated) if translated is not None else None
+
+
+def _configured_docker_mounts() -> list[tuple[Path, PurePosixPath]]:
+    """Return resolvable ``(host, container)`` mounts for compatibility mode."""
+    raw = os.environ.get("TERMINAL_DOCKER_VOLUMES", "").strip()
+    if not raw:
+        return []
+    try:
+        specs = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(specs, list):
+        return []
+
+    mounts: list[tuple[Path, PurePosixPath]] = []
+    for entry in specs:
+        if not isinstance(entry, str):
+            continue
+        # A Windows host path has its own drive colon (``C:\\...``); start
+        # after it so the delimiter we find is the container's ``:/``.
+        search_start = 2 if len(entry) > 1 and entry[1] == ":" else 0
+        separator = entry.find(":/", search_start)
+        if separator <= 0:
+            continue
+        host_raw = os.path.expanduser(entry[:separator])
+        container_raw = entry[separator + 1 :].split(":", 1)[0]
+        if not container_raw.startswith("/"):
+            continue
+        if not (host_raw.startswith("/") or (len(host_raw) > 1 and host_raw[1] == ":")):
+            continue
+        try:
+            mounts.append((Path(host_raw).resolve(strict=False), PurePosixPath(container_raw)))
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return mounts
+
+
+def _fallback_docker_mounts() -> list[tuple[Path, PurePosixPath]]:
+    """Reconstruct Hermes' standard Docker mounts on older installations."""
+    if os.environ.get("TERMINAL_ENV", "").strip().lower() != "docker":
+        return []
+
+    mounts = _configured_docker_mounts()
+    try:
+        from tools.credential_files import get_cache_directory_mounts
+
+        mounts.extend(
+            (Path(item["host_path"]), PurePosixPath(item["container_path"]))
+            for item in get_cache_directory_mounts()
+        )
+    except Exception:
+        pass
+
+    persistent = os.environ.get("TERMINAL_CONTAINER_PERSISTENT", "true").strip().lower()
+    if persistent not in {"1", "true", "yes", "on"}:
+        return mounts
+
+    try:
+        from tools.environments.base import get_sandbox_dir
+
+        sandbox = get_sandbox_dir() / "docker" / "default"
+    except Exception:
+        sandbox = None
+
+    if not any(container.as_posix() == "/workspace" for _, container in mounts):
+        mount_cwd = os.environ.get(
+            "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+            "false",
+        ).strip().lower() in {"1", "true", "yes", "on"}
+        workspace = (
+            Path(os.path.expanduser(os.environ.get("TERMINAL_CWD") or os.getcwd()))
+            if mount_cwd
+            else (sandbox / "workspace" if sandbox is not None else None)
+        )
+        if workspace is not None:
+            mounts.append((workspace.resolve(strict=False), PurePosixPath("/workspace")))
+
+    if sandbox is not None and not any(container.as_posix() == "/root" for _, container in mounts):
+        mounts.append(((sandbox / "home").resolve(strict=False), PurePosixPath("/root")))
+    return mounts
+
+
+def translate_container_media_path(path: str) -> str:
+    """Translate an agent-visible Docker path before Relay validates it.
+
+    Current Hermes supplies the canonical translator. The bounded fallback
+    keeps Relay compatible with older Hermes versions using the same explicit,
+    cache, workspace, and persistent-home mount model. Unmatched paths are
+    returned unchanged so the existing validator produces its normal error.
+    """
+    if not path or not (path.startswith("/") or os.path.isabs(path)):
+        return path
+
+    translated = _translate_with_upstream(path)
+    if translated is not None:
+        return translated
+
+    try:
+        candidate = PurePosixPath(path) if path.startswith("/") else Path(path)
+    except (OSError, RuntimeError, ValueError):
+        return path
+
+    # Never reinterpret the container credential tree through the broad /root
+    # home mount. Canonical cache mounts above may still translate safe cache
+    # artifacts through a longer, explicit prefix.
+    protected_container_home = candidate.as_posix().startswith("/root/.hermes")
+    best: tuple[Path, PurePosixPath, int] | None = None
+    for host_root, container_root in _fallback_docker_mounts():
+        container_prefix = container_root.as_posix().rstrip("/") or "/"
+        if protected_container_home and container_prefix == "/root":
+            continue
+        candidate_posix = candidate.as_posix()
+        if candidate_posix != container_prefix and not candidate_posix.startswith(container_prefix + "/"):
+            continue
+        score = len(container_prefix)
+        if best is None or score > best[2]:
+            best = (host_root, container_root, score)
+    if best is None:
+        return path
+
+    host_root, container_root, _ = best
+    try:
+        translated_path = (host_root / candidate.relative_to(container_root)).resolve(strict=False)
+        translated_path.relative_to(host_root.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return path
+    return str(translated_path)
 
 
 @dataclass

--- a/plugin/relay/media.py
+++ b/plugin/relay/media.py
@@ -36,6 +36,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import secrets
 import tempfile
 import time
@@ -189,7 +190,18 @@ def translate_container_media_path(path: str) -> str:
 
     host_root, container_root, _ = best
     try:
-        translated_path = (host_root / candidate.relative_to(container_root)).resolve(strict=False)
+        relative_parts = candidate.relative_to(container_root).parts
+        # This compatibility path consumes model-supplied text. Validate each
+        # component before it reaches a host filesystem expression; the later
+        # resolve+relative_to check remains the symlink/containment authority.
+        # Generated Hermes media names fit this intentionally conservative set.
+        if not relative_parts or any(
+            part in {".", ".."} or
+            re.fullmatch(r"[A-Za-z0-9._ @()+,=-]{1,255}", part) is None
+            for part in relative_parts
+        ):
+            return path
+        translated_path = host_root.joinpath(*relative_parts).resolve(strict=False)
         translated_path.relative_to(host_root.resolve(strict=False))
     except (OSError, RuntimeError, ValueError):
         return path

--- a/plugin/relay/server.py
+++ b/plugin/relay/server.py
@@ -2182,7 +2182,7 @@ async def handle_relay_info(request: web.Request) -> web.Response:
     else:
         server, _session = _require_bearer_session(request)
 
-    from ..gateway_diagnostics import assess_gateway_heartbeat
+    from ..gateway_diagnostics import assess_gateway_heartbeat, assess_gateway_prior_exit
     from ..profiles import discover_profile_configs, relay_state
 
     profiles = [
@@ -2220,6 +2220,7 @@ async def handle_relay_info(request: web.Request) -> web.Response:
             # Read-only upstream signal. It is intentionally separate from
             # Relay's own health and never drives restart/fallback behavior.
             "gateway_heartbeat": assess_gateway_heartbeat(),
+            "gateway_prior_exit": assess_gateway_prior_exit(),
         }
     )
 

--- a/plugin/relay/server.py
+++ b/plugin/relay/server.py
@@ -60,7 +60,12 @@ from .channels.terminal import TerminalHandler
 from .channels.tui import TuiHandler
 from .config import RelayConfig
 from .image_activity import read_image_activity
-from .media import MediaRegistrationError, MediaRegistry, validate_media_path
+from .media import (
+    MediaRegistrationError,
+    MediaRegistry,
+    translate_container_media_path,
+    validate_media_path,
+)
 from .model_capabilities import (
     CONTRACT_VERSION as MODEL_CAPABILITIES_CONTRACT_VERSION,
     MAX_MODEL_PAIRS,
@@ -1656,7 +1661,7 @@ async def handle_media_by_path(request: web.Request) -> web.StreamResponse:
     )
     try:
         real_path, size = validate_media_path(
-            path,
+            translate_container_media_path(path),
             roots_for_check,
             server.media.max_size_bytes,
         )

--- a/plugin/tests/test_gateway_diagnostics.py
+++ b/plugin/tests/test_gateway_diagnostics.py
@@ -7,7 +7,7 @@ import time
 import unittest
 from pathlib import Path
 
-from plugin.gateway_diagnostics import assess_gateway_heartbeat
+from plugin.gateway_diagnostics import assess_gateway_heartbeat, assess_gateway_prior_exit
 
 
 class GatewayHeartbeatTests(unittest.TestCase):
@@ -55,8 +55,65 @@ class GatewayHeartbeatTests(unittest.TestCase):
                 home=home, now=1784462410.0, process_started_at=lambda _pid: 99.0
             )
             self.assertEqual(result, {"status": "start_mismatch", "supported": True})
-            self.assertNotIn("pid", result)
-            self.assertNotIn("path", result)
+
+
+class GatewayPriorExitTests(unittest.TestCase):
+    def write_heartbeat(self, home: Path, payload: object, *, mtime: float) -> None:
+        path = home / "state" / "gateway.heartbeat"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        os.utime(path, (mtime, mtime))
+
+    def write_records(self, home: Path, *records: object) -> None:
+        path = home / "logs" / "gateway-exit-diag.log"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(json.dumps(record) for record in records), encoding="utf-8")
+
+    def test_missing_or_first_start_is_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            home = Path(raw)
+            self.assertEqual(assess_gateway_prior_exit(home=home), {"prior_exit": "unknown"})
+            self.write_records(home, {"tag": "gateway.start", "argv": ["secret"]})
+            self.assertEqual(assess_gateway_prior_exit(home=home), {"prior_exit": "unknown"})
+
+    def test_clean_exit_is_sanitized(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            home = Path(raw)
+            self.write_records(
+                home,
+                {"tag": "gateway.start"},
+                {"tag": "asyncio.run.SystemExit", "traceback": "private"},
+                {"tag": "atexit.hook", "path": "/private"},
+                {"tag": "gateway.start", "argv": ["private"]},
+            )
+            self.assertEqual(assess_gateway_prior_exit(home=home), {"prior_exit": "clean"})
+
+    def test_unclean_exit_exposes_only_bounded_oom_hint(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            home = Path(raw)
+            self.write_records(
+                home,
+                {"tag": "gateway.start"},
+                {
+                    "tag": "gateway.previous_unclean_exit",
+                    "prior_pid": 42,
+                    "last_heartbeat_mem": {"mem_available_kib": 1},
+                    "suspected_oom": True,
+                },
+                {"tag": "gateway.start"},
+            )
+            self.assertEqual(
+                assess_gateway_prior_exit(home=home),
+                {"prior_exit": "unclean", "suspected_oom": True},
+            )
+
+    def test_malformed_tail_does_not_crash_or_leak(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            home = Path(raw)
+            path = home / "logs" / "gateway-exit-diag.log"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("not-json\n{}\n", encoding="utf-8")
+            self.assertEqual(assess_gateway_prior_exit(home=home), {"prior_exit": "unknown"})
 
     def test_runner_start_after_process_start_is_not_a_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as raw:

--- a/plugin/tests/test_media_path_translation.py
+++ b/plugin/tests/test_media_path_translation.py
@@ -1,0 +1,60 @@
+"""Docker media-path translation compatibility tests (HRUI-128)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+from plugin.relay.media import translate_container_media_path
+
+
+def _fallback_only():
+    return mock.patch("plugin.relay.media._translate_with_upstream", return_value=None)
+
+
+def test_explicit_workspace_mount_translates_to_host(tmp_path: Path) -> None:
+    artifact = tmp_path / "result.png"
+    artifact.write_bytes(b"png")
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": json.dumps([f"{tmp_path}:/workspace:rw"]),
+    }
+    with _fallback_only(), mock.patch.dict(os.environ, env, clear=False):
+        assert translate_container_media_path("/workspace/result.png") == str(artifact)
+
+
+def test_longest_container_prefix_wins(tmp_path: Path) -> None:
+    broad = tmp_path / "broad"
+    narrow = tmp_path / "narrow"
+    (broad / "exports").mkdir(parents=True)
+    narrow.mkdir()
+    artifact = narrow / "result.pdf"
+    artifact.write_bytes(b"pdf")
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": json.dumps(
+            [f"{broad}:/workspace:rw", f"{narrow}:/workspace/exports:rw"],
+        ),
+    }
+    with _fallback_only(), mock.patch.dict(os.environ, env, clear=False):
+        assert translate_container_media_path("/workspace/exports/result.pdf") == str(artifact)
+
+
+def test_unmatched_path_is_left_for_existing_validator() -> None:
+    with _fallback_only(), mock.patch.dict(
+        os.environ,
+        {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_VOLUMES": "[]"},
+        clear=False,
+    ):
+        assert translate_container_media_path("/outside/result.png") == "/outside/result.png"
+
+
+def test_root_hermes_tree_does_not_use_broad_home_mount(tmp_path: Path) -> None:
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": json.dumps([f"{tmp_path}:/root:rw"]),
+    }
+    with _fallback_only(), mock.patch.dict(os.environ, env, clear=False):
+        assert translate_container_media_path("/root/.hermes/auth.json") == "/root/.hermes/auth.json"

--- a/plugin/tests/test_media_path_translation.py
+++ b/plugin/tests/test_media_path_translation.py
@@ -51,6 +51,16 @@ def test_unmatched_path_is_left_for_existing_validator() -> None:
         assert translate_container_media_path("/outside/result.png") == "/outside/result.png"
 
 
+def test_unsafe_relative_component_is_not_joined_to_host(tmp_path: Path) -> None:
+    env = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_VOLUMES": json.dumps([f"{tmp_path}:/workspace:rw"]),
+    }
+    source = "/workspace/report∕secret.png"
+    with _fallback_only(), mock.patch.dict(os.environ, env, clear=False):
+        assert translate_container_media_path(source) == source
+
+
 def test_root_hermes_tree_does_not_use_broad_home_mount(tmp_path: Path) -> None:
     env = {
         "TERMINAL_ENV": "docker",

--- a/plugin/tests/test_relay_info.py
+++ b/plugin/tests/test_relay_info.py
@@ -38,6 +38,7 @@ class RelayInfoRouteTests(AioHTTPTestCase):
             "media_entry_count",
             "health",
             "gateway_heartbeat",
+            "gateway_prior_exit",
         }
         self.assertTrue(required.issubset(set(body.keys())))
 
@@ -54,6 +55,7 @@ class RelayInfoRouteTests(AioHTTPTestCase):
         self.assertNotIn("pid", body["gateway_heartbeat"])
         self.assertNotIn("path", body["gateway_heartbeat"])
         self.assertNotIn("updated_at", body["gateway_heartbeat"])
+        self.assertLessEqual(set(body["gateway_prior_exit"]), {"prior_exit", "suspected_oom"})
 
         for counter in (
             "uptime_seconds",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.6.2"
+version = "1.6.3"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- release Hermes-Relay-Server 1.6.3
- expose bounded prior gateway exit diagnostics
- desynchronize ordinary Relay and Gateway reconnect backoff
- include the verified Android upstream contract and continuity batch already merged to dev

## Verification
- plugin version metadata sync: 1.6.3
- Python syntax checks passed
- focused plugin suite: 82 passed
- Android sideload APK assembled
- new Android gateway reaction and all-profile ownership tests passed
- broad Android suite: 2076 tests, 4 unrelated timing-sensitive baseline failures