### PR TITLE
fix(server): release targeted multi-desktop routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android keeps profile management and retained automation truthful.** Custom Endpoint list and mutation routes now follow the selected Hermes profile, while completed one-shot cron jobs show their retained outcome and expose only valid Runs/Delete actions.
 - **Android and Relay recover more generated media reliably.** Android accepts upstream-valid wrapped, punctuated, adjacent, spaced, and Windows `MEDIA:` markers without consuming fenced examples, and Relay translates Docker-visible workspace, home, cache, and configured-mount paths before applying its existing credential, sandbox, and size checks.
 
+## [1.6.4] - 2026-08-12
+
+### Added
+
+- **Desktop tools support explicit host targeting.** Every client-routed desktop tool accepts a stable device ID or unambiguous computer name, and `/desktop/health` enumerates connected targets and their advertised tools.
+- **USB operations retain both routing scopes.** Raw USB and ADB tools use `device` to select the desktop PC, while ADB operations continue to use `serial` to select hardware attached to that PC.
+
+### Fixed
+
+- **Multiple desktop clients remain connected simultaneously.** The Relay no longer replaces the previous desktop when another heartbeat arrives; concurrent requests are bound to their selected WebSockets, responses from another PC are ignored, and an untargeted call fails closed when several desktops are online.
+- **Pairing another desktop preserves existing credentials.** Legacy placeholder device identifiers are treated as absent instead of shared ownership, preventing an unrelated PC from revoking the first desktop's session.
+
 ## [1.6.3] - 2026-08-11
 
 ### Fixed

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 # Hermes-Relay-Server v__VERSION__
 
-**Release Date:** August 11, 2026
+**Release Date:** August 12, 2026
 
-This patch improves gateway recovery diagnostics and prevents clients from reconnecting in lockstep after a shared restart.
+This patch adds safe simultaneous routing for multiple connected desktop PCs and makes host selection explicit across command, file, screen, USB, and ADB operations.
 
 Standard chat, session history, and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
 
@@ -10,8 +10,14 @@ Standard chat, session history, and Vanilla Hermes voice remain upstream-owned a
 
 ### Fixed
 
-- **Bounded prior-exit diagnostics.** Relay Doctor and `/relay/info` distinguish a clean stop, an unclean exit, and unknown history, with an optional suspected out-of-memory hint. Raw logs are never returned through the API.
-- **Desynchronized recovery.** Ordinary exponential reconnect delays use full jitter so multiple Relay clients do not retry in lockstep after the gateway restarts. Explicit reconnects and server-directed retry timing remain unchanged.
+- **No more latest-client-wins routing.** Connecting a second desktop no longer evicts the first. Requests are bound to the selected desktop WebSocket, and a response from another PC cannot satisfy them.
+- **Ambiguous calls fail closed.** With more than one desktop online, client-routed tools require a stable device ID or unambiguous computer name instead of silently choosing the latest heartbeat.
+- **Pairing preserves existing PCs.** Placeholder legacy device identifiers no longer collide and revoke another desktop's session.
+
+### Added
+
+- **Target discovery.** `desktop_health` lists every connected desktop with its stable ID, name, and advertised tools.
+- **Two-level USB targeting.** USB and ADB tools use `device` for the host PC; ADB operations retain `serial` for the attached Android device.
 
 ## Install / update
 
@@ -26,6 +32,7 @@ Standard chat, session history, and Vanilla Hermes voice remain upstream-owned a
 ## Verify
 
     hermes relay doctor
+    # Agent/tool callers can use desktop_health to list desktop targets.
     python scripts/check-plugin-version-sync.py --expect __VERSION__
 
 ---

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2812,3 +2812,54 @@ empty transcript.
 longer operate on a silent latest-500 subset. Recovery stays cheap for ordinary
 sessions without allowing a bounded window to replace the complete visible
 history. Older Hermes releases remain compatible.
+
+---
+
+## ADR 51 — Desktop RPC is explicitly device-targeted and capability-honest
+
+**Status:** Accepted (2026-08-12).
+
+**Context.** A Relay can retain several authorized desktop sessions, but the
+desktop channel historically latched one latest WebSocket. Pairing two PCs could
+therefore make an agent command change targets implicitly. The desktop surface
+also mixes typed file/process/screen operations with unrestricted terminal and
+PowerShell execution. Camera, microphone, and attached-device toggles cannot be
+claimed as security boundaries while unrestricted code still runs as the same
+Windows user.
+
+**Decision.** Every desktop advertises a stable installation `device_id` and
+display name. The Relay keeps all connected desktop WebSockets, accepts a
+`device` selector on every client-routed tool, binds pending responses to that
+WebSocket, and fails closed when more than one desktop is connected without an
+explicit target. Health reports enumerate valid targets, and successful RPCs
+identify the resolved target.
+
+Typed tools are the preferred automation surface and declare a capability such
+as `files.read`, `files.write`, `process.manage`, `screen.observe`, or
+`input.control`. `desktop_terminal`, `desktop_powershell`, detached processes,
+and background command jobs declare `system.execute`. This capability is an
+escape hatch: at user privilege it can transitively reach files, processes,
+USB devices, camera, or microphone through operating-system APIs. The UI must
+not present independent hardware-deny toggles as enforceable while
+`system.execute` remains enabled.
+
+Existing local policy remains authoritative on each target PC: Ask does not
+start the headless tool router without consent; Structured withholds
+`desktop_terminal`, `desktop_powershell`, detached process launch, and command
+job start; Trusted permits typed and execution tools but retains task grants for
+screen/input; Full Access bypasses those task grants for that Relay host.
+
+Hardware policy is separate and per host. USB defaults Disabled and exposes
+only typed, serial-bound ADB list, shell, push, pull, install, and bounded
+logcat operations. Ask raises the dedicated local approval card for every
+operation; Allow requires explicit confirmation. Full Access does not override
+the USB policy. Disabled or unavailable backends are omitted from advertised
+tools. Microphone and camera remain visibly unavailable until bounded
+brokers, active-use indication, and cancellation exist.
+
+**Consequences.** Agents cannot accidentally execute against whichever PC most
+recently sent a heartbeat, and a response from another PC cannot satisfy a
+targeted request. Common operations remain typed and auditable while raw shell
+power is labeled honestly. Structured mode makes the USB policy enforceable,
+and device operations appear as their own local Activity category. Microphone
+and camera controls are not shipped as cosmetic switches.

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -389,11 +389,27 @@ Sources: `plugin/relay/channels/notifications.py`, `app/src/main/kotlin/.../noti
 |------|-----------|---------|
 | `desktop.command` | Server → Client | `{request_id, tool, args}` |
 | `desktop.response` | Client → Server | `{request_id, ok: true, result}` or `{request_id, ok: false, error}` |
-| `desktop.status` | Client → Server | `{advertised_tools, host, platform, version, computer_use?}` |
+| `desktop.status` | Client → Server | `{advertised_tools, device_id, host, platform, version, computer_use?}` |
 | `desktop.workspace` | Client → Server | Workspace context snapshot |
 | `desktop.active_editor` | Client → Server | Active editor hint |
 
 Experimental computer-use tools use the same channel but are advertised by the desktop client only when the experimental computer-use feature flag is enabled (`--experimental-computer-use` or `HERMES_RELAY_EXPERIMENTAL_COMPUTER_USE=1`) after normal desktop-tool consent. The relay still treats `desktop_computer_*` names as strict-advertise tools so older or unflagged clients fail closed. Screenshots require an in-memory observe/assist/control grant. Host input currently uses a Windows-only CLI approval path: desktop-tool consent plus one visible local `yes` prompt for a task-scoped assist/control grant. Actions then run without per-action prompts until that grant expires or is canceled. Headless/non-interactive clients advertise blocked grant state and reject assist/control grant requests with structured failures.
+
+Every desktop heartbeat includes its stable installation `device_id` and
+display name. Tool HTTP bodies accept a relay-only `device` selector. With one
+connected desktop the selector is optional; with several it is required and may
+be an exact device ID or an unambiguous host/device name. The Relay binds each
+pending request to the selected WebSocket, ignores responses from other PCs,
+and includes resolved target metadata in the response. `/desktop/health` lists
+the connected targets.
+
+Per-host Structured access withholds `desktop_terminal`,
+`desktop_powershell`, `desktop_spawn_detached`, and `desktop_job_start` from
+`advertised_tools`. Brokered USB tools use the same request/response envelope:
+`desktop_adb_devices`, `_shell`, `_push`, `_pull`, `_install`, and `_logcat`.
+Every device operation other than enumeration requires an explicit ADB serial;
+local USB policy independently disables, prompts for, or allows each call.
+Disabled or unavailable ADB backends omit all six names from advertisement.
 
 ### 3.8 TUI *(new, being added — see `docs/plans/2026-04-22-desktop-tui-mvp.md`)*
 

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Relay",
   "description": "Paired devices, bridge activity, media inspection, and remote access for hermes-relay",
   "icon": "Activity",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,6 +1,6 @@
 name: hermes-relay
 manifest_version: 1
-version: 1.6.3
+version: 1.6.4
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 # All three are OPTIONAL — only needed if you use the relay's extra /

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # Desktop releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/plugin/relay/auth.py
+++ b/plugin/relay/auth.py
@@ -937,6 +937,12 @@ class SessionManager:
             # Keep different devices independent and leave legacy clients with
             # no device_id alone because an empty id cannot identify ownership.
             normalized_device_id = device_id.strip()
+            # Legacy desktop clients omitted device_id, which the wire layer
+            # represented as the shared sentinel "unknown". Treat sentinels as
+            # absent ownership, otherwise pairing any second PC revokes every
+            # other legacy desktop session as if they were one installation.
+            if normalized_device_id.casefold() in {"unknown", "none", "null"}:
+                normalized_device_id = ""
             if normalized_device_id:
                 replaced_sessions = [
                     token
@@ -1077,14 +1083,30 @@ class SessionManager:
         if trusted.is_expired:
             self._save_to_disk()
             return None
-        if device_id and trusted.device_id != device_id:
+        normalized_device_id = device_id.strip()
+        legacy_desktop_identity = (
+            trusted.client_surface in {"desktop", "unknown"}
+            and trusted.device_id.strip().casefold() in {"unknown", "none", "null"}
+            and normalized_device_id.casefold() not in {"", "unknown", "none", "null"}
+        )
+        if (
+            normalized_device_id
+            and trusted.device_id != normalized_device_id
+            and not legacy_desktop_identity
+        ):
             logger.info(
                 "Refresh rejected for device_id mismatch: stored=%s attempted=%s",
                 trusted.device_id,
-                device_id,
+                normalized_device_id,
             )
             self._trusted_devices[refresh_hash] = trusted
             return None
+        if legacy_desktop_identity:
+            # The refresh secret proves continuity for desktop clients created
+            # before they persisted an installation UUID. Upgrade that one
+            # trusted record in place without weakening normal ID mismatch
+            # rejection or conflating separate legacy PCs during pairing.
+            trusted.device_id = normalized_device_id
 
         now = time.time()
         new_refresh_token = _generate_refresh_token()

--- a/plugin/relay/channels/desktop.py
+++ b/plugin/relay/channels/desktop.py
@@ -6,11 +6,12 @@ Two jobs over the same WSS ``desktop`` envelope stream:
    channel for the Node thin-client CLI / future TUI. Agent-side
    Python tools in ``plugin/tools/desktop_tool.py`` POST to
    ``/desktop/*`` HTTP routes; the relay forwards them over the
-   ``desktop.command`` envelope; the connected client services them
-   locally and returns ``desktop.response``, which bubbles back as the
-   HTTP response. Single-client MVP — the most recent client wins
-   ``self.client_ws``. ``self.pending`` is asyncio-locked so concurrent
-   add/remove can't drop futures. Normal desktop tools keep the bridge-like
+   ``desktop.command`` envelope; the explicitly selected client services
+   them locally and returns ``desktop.response``, which bubbles back as the
+   HTTP response. Multiple clients are keyed by stable device identity;
+   untargeted dispatch fails closed when more than one is connected.
+   ``self.pending`` is asyncio-locked so concurrent add/remove can't drop
+   futures. Normal desktop tools keep the bridge-like
    30 s timeout; computer-use calls get a longer timeout because they may
    wait on a visible human approval prompt.
 
@@ -49,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 RESPONSE_TIMEOUT = 30.0  # seconds — matches bridge.RESPONSE_TIMEOUT
 COMPUTER_USE_RESPONSE_TIMEOUT = 180.0  # seconds — allows human approval prompts
+ADB_RESPONSE_TIMEOUT = 300.0  # seconds — approval plus a bounded 120 s operation
 
 # Keys whose values must never appear in the ring buffer. Matched
 # case-insensitively against the full key name.
@@ -98,10 +100,11 @@ class DesktopSession:
     """Per-WebSocket scratch space.
 
     Holds BOTH:
-      * The single-client tool-routing latch fields (``advertised_tools``
-        / ``client_status`` / ``last_seen_at``) — these are mirrored on
-        the outer :class:`DesktopHandler` for the latched client and
-        kept here per-WS for diagnostics + future multi-client support.
+      * The routing identity and capability fields (``device_id``,
+        ``advertised_tools``, ``client_status``, and ``last_seen_at``).
+        These are authoritative for targeted multi-client dispatch; the
+        outer :class:`DesktopHandler` mirrors the most recent status only
+        for backward-compatible diagnostics.
       * The workspace + active-editor snapshots advertised by the
         desktop CLI (alpha.6).
 
@@ -112,6 +115,8 @@ class DesktopSession:
     """
 
     def __init__(self) -> None:
+        self.device_id: str = ""
+        self.device_name: str = ""
         # Latest ``desktop.workspace`` payload as-sent. Opaque dict — we
         # don't parse fields here because the wire schema is owned by
         # the client (versioned as ``version: 1``); future versions
@@ -124,10 +129,9 @@ class DesktopSession:
         self.active_editor: dict[str, Any] | None = None
         self.active_editor_received_at: float | None = None
 
-        # Per-WS view of the latest ``desktop.status`` envelope. The
-        # outer handler also keeps a flattened copy for the latched
-        # client; storing it here makes future multi-client diagnostics
-        # straightforward.
+        # Per-WS view of the latest ``desktop.status`` envelope. The outer
+        # handler also keeps a flattened compatibility snapshot, while all
+        # routing decisions use this per-client state.
         self.advertised_tools: set[str] = set()
         self.client_status: dict[str, Any] = {}
         self.last_seen_at: float | None = None
@@ -154,13 +158,10 @@ class DesktopHandler:
     """
 
     def __init__(self) -> None:
-        # The currently-connected desktop client's WebSocket. Assigned
-        # when a client sends its first desktop envelope and cleared via
-        # :meth:`detach_ws` when the client disconnects.
-        #
-        # TODO(multi-client): graduate to a dict keyed by session_id +
-        # per-tool routing. For the MVP the latest-wins model matches
-        # bridge.py exactly.
+        # Backward-compatible pointer to the most recently active desktop.
+        # It is never used to choose among multiple connected clients;
+        # targeted routing uses ``_sessions`` and fails closed if the caller
+        # omits a selector while multiple desktops are online.
         self.client_ws: web.WebSocketResponse | None = None
 
         # Tools advertised by the currently-attached client. Populated
@@ -177,6 +178,7 @@ class DesktopHandler:
         # command is sent; resolved by handle_response; cancelled with
         # ConnectionError on detach.
         self.pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self.pending_ws: dict[str, web.WebSocketResponse] = {}
         self._lock = asyncio.Lock()
 
         # Bounded ring buffer of recent commands.
@@ -184,10 +186,9 @@ class DesktopHandler:
             maxlen=RECENT_COMMANDS_MAX
         )
 
-        # ws → DesktopSession. Cleared per-ws in :meth:`detach_ws` so
-        # disconnected clients don't leak session structs. Lives
-        # alongside the single-client tool-routing fields above; the
-        # latched client always has an entry here too.
+        # ws → DesktopSession. This is the authoritative connected-target
+        # registry. Cleared per-ws in :meth:`detach_ws` so disconnected
+        # clients don't leak session structs.
         self._sessions: dict[web.WebSocketResponse, DesktopSession] = {}
 
     # ── Envelope dispatch ────────────────────────────────────────────────
@@ -196,6 +197,7 @@ class DesktopHandler:
         self,
         ws: web.WebSocketResponse,
         envelope: dict[str, Any],
+        auth_session: Any | None = None,
     ) -> None:
         """Route an incoming desktop-channel envelope from the client.
 
@@ -238,10 +240,14 @@ class DesktopHandler:
         if session is None:
             session = DesktopSession()
             self._sessions[ws] = session
+        if auth_session is not None:
+            auth_device_id = str(getattr(auth_session, "device_id", "") or "").strip()
+            if auth_device_id.casefold() not in {"", "unknown", "none", "null"}:
+                session.device_id = auth_device_id
+            session.device_name = str(getattr(auth_session, "device_name", "") or "").strip()
 
         if msg_type == "response":
             # Tool routing — client is replying to a pending command.
-            await self._latch_client_ws(ws)
             await self.handle_response(ws, envelope)
             return
 
@@ -286,24 +292,95 @@ class DesktopHandler:
         self,
         ws: web.WebSocketResponse,
         envelope: dict[str, Any],
+        session: Any | None = None,
     ) -> None:
-        await self.handle_envelope(ws, envelope)
+        await self.handle_envelope(ws, envelope, auth_session=session)
 
     async def _latch_client_ws(self, ws: web.WebSocketResponse) -> None:
-        """Opportunistically latch ``ws`` as the active tool-routing client.
+        """Refresh the legacy most-recent-client diagnostics pointer.
 
-        Mirrors alpha.1's behaviour: the first envelope wins, but a new
-        ws can take over and any pending futures bound to the old ws are
-        failed with a ``replaced by new client`` error.
+        Existing clients and their in-flight requests remain attached.
+        Actual dispatch is resolved from the complete per-WebSocket session
+        registry, never from this compatibility pointer when several targets
+        are connected.
         """
         if self.client_ws is ws:
             return
-        if self.client_ws is not None and not self.client_ws.closed:
-            logger.info(
-                "desktop: replacing previous client ws — new client took over"
-            )
-            await self._fail_pending("replaced by new client")
+        # Keep the compatibility/default pointer, but do not evict another
+        # connected PC or fail its in-flight requests. Explicit routing uses
+        # the per-WebSocket session registry below.
         self.client_ws = ws
+
+    def _connected_targets(self) -> list[tuple[web.WebSocketResponse, DesktopSession]]:
+        return [(ws, session) for ws, session in self._sessions.items() if not ws.closed]
+
+    @staticmethod
+    def _normalized_selector(value: str) -> str:
+        return "".join(ch for ch in value.casefold() if ch.isalnum())
+
+    def _resolve_target(
+        self,
+        selector: str | None,
+    ) -> tuple[web.WebSocketResponse, DesktopSession | None]:
+        targets = self._connected_targets()
+        if selector and selector.strip():
+            raw = selector.strip()
+            normalized = self._normalized_selector(raw)
+            matches: list[tuple[web.WebSocketResponse, DesktopSession]] = []
+            for ws, session in targets:
+                status = session.client_status
+                candidates = {
+                    session.device_id,
+                    session.device_name,
+                    str(status.get("device_id", "")),
+                    str(status.get("device_name", "")),
+                    str(status.get("host", "")),
+                }
+                if any(
+                    candidate
+                    and (
+                        candidate.casefold() == raw.casefold()
+                        or self._normalized_selector(candidate) == normalized
+                    )
+                    for candidate in candidates
+                ):
+                    matches.append((ws, session))
+            if not matches:
+                available = [
+                    session.device_name
+                    or str(session.client_status.get("host", ""))
+                    or session.device_id
+                    for _, session in targets
+                ]
+                raise DesktopError(
+                    f"Unknown desktop device selector {raw!r}. Available: "
+                    f"{', '.join(filter(None, available)) or 'none'}"
+                )
+            if len(matches) > 1:
+                raise DesktopError(f"Ambiguous desktop device selector {raw!r}; use its device_id")
+            return matches[0]
+
+        if len(targets) == 1:
+            return targets[0]
+        if len(targets) > 1:
+            available = [
+                (
+                    f"{session.device_name or session.client_status.get('host') or 'desktop'} "
+                    f"({session.device_id or session.client_status.get('device_id') or 'legacy'})"
+                )
+                for _, session in targets
+            ]
+            raise DesktopError(
+                "Multiple desktop clients are connected; pass device or device_id explicitly. "
+                + "Available: "
+                + ", ".join(available)
+            )
+        ws = self.client_ws
+        if ws is not None and not ws.closed:
+            return ws, self._sessions.get(ws)
+        raise DesktopError(
+            "No desktop client connected. Start the Hermes desktop CLI and pair it."
+        )
 
     # ── Outbound commands (called from HTTP handlers) ────────────────────
 
@@ -311,6 +388,7 @@ class DesktopHandler:
         self,
         method: str,
         args: dict[str, Any] | None = None,
+        device: str | None = None,
     ) -> dict[str, Any]:
         """Dispatch a ``desktop_*`` tool call to the connected client.
 
@@ -319,20 +397,21 @@ class DesktopHandler:
         no client is connected, the send fails, or the client doesn't
         respond within the tool-specific response timeout.
         """
-        ws = self.client_ws
-        if ws is None or ws.closed:
-            raise DesktopError(
-                "No desktop client connected. Start the Hermes desktop CLI and pair it."
-            )
+        ws, target_session = self._resolve_target(device)
+        target_tools = (
+            target_session.advertised_tools
+            if target_session is not None
+            else self.advertised_tools
+        )
 
         # Fail-closed on tools the client hasn't advertised. This is what
         # lets the agent side's ``check_fn`` tell Hermes "this tool isn't
         # available right now" without even attempting a round-trip.
-        if method.startswith("desktop_computer_") and not self.advertised_tools:
+        if method.startswith("desktop_computer_") and not target_tools:
             raise DesktopError(
                 f"Desktop client has not advertised experimental computer-use tool {method!r}"
             )
-        if self.advertised_tools and method not in self.advertised_tools:
+        if target_tools and method not in target_tools:
             raise DesktopError(
                 f"Desktop client does not advertise tool {method!r}"
             )
@@ -342,11 +421,17 @@ class DesktopHandler:
 
         async with self._lock:
             self.pending[request_id] = future
+            self.pending_ws[request_id] = ws
 
         command_payload = {
             "request_id": request_id,
             "tool": method,
             "args": args or {},
+            "target_device_id": (
+                target_session.device_id
+                if target_session is not None
+                else None
+            ),
         }
         logger.info(
             "desktop >>> %s args=%s",
@@ -368,21 +453,41 @@ class DesktopHandler:
         except Exception as exc:
             async with self._lock:
                 self.pending.pop(request_id, None)
+                self.pending_ws.pop(request_id, None)
             record.decision = "error"
             record.error = f"Failed to send command to client: {exc}"
             logger.error("desktop: failed to send command: %s", exc)
             raise DesktopError(f"Failed to send command to client: {exc}") from exc
 
         timeout = (
-            COMPUTER_USE_RESPONSE_TIMEOUT
+            ADB_RESPONSE_TIMEOUT
+            if method.startswith("desktop_adb_")
+            else COMPUTER_USE_RESPONSE_TIMEOUT
             if method.startswith("desktop_computer_")
             else RESPONSE_TIMEOUT
         )
         try:
-            return await asyncio.wait_for(future, timeout=timeout)
+            response = await asyncio.wait_for(future, timeout=timeout)
+            response.setdefault(
+                "target",
+                {
+                    "device_id": (
+                        target_session.device_id
+                        if target_session is not None
+                        else None
+                    ),
+                    "device_name": (
+                        target_session.device_name
+                        if target_session is not None
+                        else None
+                    ),
+                },
+            )
+            return response
         except asyncio.TimeoutError:
             async with self._lock:
                 self.pending.pop(request_id, None)
+                self.pending_ws.pop(request_id, None)
             record.decision = "timeout"
             record.error = f"Desktop client did not respond within {timeout:.0f}s"
             logger.warning(
@@ -393,6 +498,11 @@ class DesktopHandler:
             raise DesktopError(
                 f"Desktop client did not respond within {timeout:.0f}s"
             ) from None
+        except asyncio.CancelledError:
+            async with self._lock:
+                self.pending.pop(request_id, None)
+                self.pending_ws.pop(request_id, None)
+            raise
 
     # ── Inbound response routing ────────────────────────────────────────
 
@@ -409,7 +519,15 @@ class DesktopHandler:
             return
 
         async with self._lock:
+            expected_ws = self.pending_ws.get(request_id)
+            if expected_ws is not None and expected_ws is not ws:
+                logger.warning(
+                    "desktop: ignored response from wrong target request_id=%s",
+                    request_id,
+                )
+                return
             future = self.pending.pop(request_id, None)
+            self.pending_ws.pop(request_id, None)
 
         self._update_record_from_response(request_id, payload)
 
@@ -473,11 +591,15 @@ class DesktopHandler:
                 name for name in advertised if isinstance(name, str) and name
             }
 
-        # Mirror onto the per-WS session so future multi-client
-        # diagnostics can see exactly what each client advertised.
+        # Mirror onto the authoritative per-WS session used for targeted
+        # routing and multi-client diagnostics.
         if session is None:
             session = self._sessions.get(ws)
         if session is not None:
+            session.device_id = session.device_id or str(payload.get("device_id", "") or "").strip()
+            session.device_name = session.device_name or str(
+                payload.get("device_name", "") or payload.get("host", "")
+            ).strip()
             session.client_status = dict(self.client_status)
             session.last_seen_at = self.last_seen_at
             session.advertised_tools = set(self.advertised_tools)
@@ -491,10 +613,9 @@ class DesktopHandler:
     # ── Public API for HTTP + tool handlers ─────────────────────────────
 
     def is_client_connected(self) -> bool:
-        ws = self.client_ws
-        return ws is not None and not ws.closed
+        return bool(self._connected_targets())
 
-    def has_client_for(self, tool_name: str) -> bool:
+    def has_client_for(self, tool_name: str, device: str | None = None) -> bool:
         """True if a client is connected AND advertises ``tool_name``.
 
         If the client never sent a ``desktop.status`` (empty advertised
@@ -502,14 +623,26 @@ class DesktopHandler:
         clients that don't advertise still work. Clients that DO
         advertise take the strict path.
         """
-        if not self.is_client_connected():
+        if device is None:
+            targets = self._connected_targets()
+            if not targets:
+                return False
+            return any(
+                bool(session.advertised_tools)
+                and tool_name in session.advertised_tools
+                for _, session in targets
+            ) or (
+                not tool_name.startswith("desktop_computer_")
+                and any(not session.advertised_tools for _, session in targets)
+            )
+        try:
+            _, session = self._resolve_target(device)
+        except DesktopError:
             return False
-        if tool_name.startswith("desktop_computer_") and not self.advertised_tools:
+        tools = session.advertised_tools if session is not None else self.advertised_tools
+        if tool_name.startswith("desktop_computer_") and not tools:
             return False
-        if not self.advertised_tools:
-            # Client hasn't advertised yet — assume it can handle the call.
-            return True
-        return tool_name in self.advertised_tools
+        return not tools or tool_name in tools
 
     def status_snapshot(self) -> dict[str, Any]:
         """Dict suitable for ``/desktop/_ping`` and diagnostics."""
@@ -519,6 +652,19 @@ class DesktopHandler:
             "client_status": dict(self.client_status),
             "last_seen_at": self.last_seen_at,
             "pending_commands": len(self.pending),
+            "clients": [
+                {
+                    "device_id": session.device_id or session.client_status.get("device_id"),
+                    "device_name": (
+                        session.device_name
+                        or session.client_status.get("device_name")
+                        or session.client_status.get("host")
+                    ),
+                    "advertised_tools": sorted(session.advertised_tools),
+                    "last_seen_at": session.last_seen_at,
+                }
+                for _, session in self._connected_targets()
+            ],
         }
 
     # ── Workspace / editor accessors (alpha.6) ──────────────────────────
@@ -533,10 +679,7 @@ class DesktopHandler:
         return self._sessions.get(ws)
 
     def all_sessions(self) -> list[DesktopSession]:
-        """Snapshot every known session. Useful for a future
-        ``/desktop/sessions`` debug route that lists what every
-        connected client has advertised.
-        """
+        """Snapshot every known desktop session."""
         return list(self._sessions.values())
 
     # ── Activity feed ───────────────────────────────────────────────────
@@ -557,6 +700,7 @@ class DesktopHandler:
         async with self._lock:
             pending = dict(self.pending)
             self.pending.clear()
+            self.pending_ws.clear()
         if pending:
             err = ConnectionError(
                 f"Desktop client disconnected ({reason})" if reason else
@@ -578,11 +722,9 @@ class DesktopHandler:
     ) -> None:
         """Drop per-ws state when a client disconnects.
 
-        Cleans up BOTH:
-          * Tool-routing state — if ``ws`` is the latched client, clear
-            the latch and fail any in-flight futures with a
-            "client disconnected" ConnectionError.
-          * Workspace state — pop the per-ws DesktopSession entry.
+        Cleans up BOTH the per-client routing/workspace state and only the
+        pending futures bound to this WebSocket. Other connected desktops and
+        their concurrent commands remain intact.
 
         Called from the main ``_on_disconnect`` path in ``server.py``.
         """
@@ -597,11 +739,33 @@ class DesktopHandler:
 
         # Tool-routing cleanup — only if this ws was the latched client.
         if self.client_ws is ws:
-            self.client_ws = None
-            self.advertised_tools = set()
+            remaining = self._connected_targets()
+            self.client_ws = remaining[-1][0] if remaining else None
+            if remaining:
+                replacement = remaining[-1][1]
+                self.advertised_tools = set(replacement.advertised_tools)
+                self.client_status = dict(replacement.client_status)
+                self.last_seen_at = replacement.last_seen_at
+            else:
+                self.advertised_tools = set()
             # keep client_status around for post-mortem diagnostics —
             # it's small and the next connect overwrites it anyway.
-            await self._fail_pending(reason)
+        async with self._lock:
+            request_ids = [
+                request_id
+                for request_id, target in self.pending_ws.items()
+                if target is ws
+            ]
+            futures = [
+                self.pending.pop(request_id)
+                for request_id in request_ids
+                if request_id in self.pending
+            ]
+            for request_id in request_ids:
+                self.pending_ws.pop(request_id, None)
+        for future in futures:
+            if not future.done():
+                future.set_exception(ConnectionError(f"Desktop client disconnected ({reason})"))
 
     async def close(self) -> None:
         """Server shutdown — cancel all pending commands, drop the

--- a/plugin/relay/server.py
+++ b/plugin/relay/server.py
@@ -966,12 +966,13 @@ async def handle_desktop_ping(request: web.Request) -> web.Response:
     _require_loopback(request)
     server: RelayServer = request.app["server"]
     tool = request.query.get("tool", "").strip()
+    device = request.query.get("device", "").strip() or None
     if not server.desktop.is_client_connected():
         return web.json_response(
             {"ok": False, "error": "no desktop client connected"},
             status=503,
         )
-    if tool and not server.desktop.has_client_for(tool):
+    if tool and not server.desktop.has_client_for(tool, device=device):
         return web.json_response(
             {"ok": False, "error": f"client connected but does not advertise tool {tool!r}"},
             status=503,
@@ -1022,6 +1023,7 @@ async def handle_desktop_health(request: web.Request) -> web.Response:
         "interactive": cs.get("interactive"),
         "last_error": cs.get("last_error"),
         "computer_use": cs.get("computer_use"),
+        "clients": snap.get("clients") or [],
         "recent_commands": server.desktop.get_recent(limit=20),
     }
     return web.json_response(out)
@@ -1045,8 +1047,11 @@ async def handle_desktop_dispatch(request: web.Request) -> web.Response:
             args = {}
     except Exception:  # noqa: BLE001
         args = {}
+    device = args.pop("device", None) or args.pop("device_id", None)
+    if not isinstance(device, str):
+        device = None
     try:
-        result = await server.desktop.handle_command(tool_name, args)
+        result = await server.desktop.handle_command(tool_name, args, device=device)
         return web.json_response(result)
     except Exception as exc:  # DesktopError or asyncio.TimeoutError
         msg = str(exc) or exc.__class__.__name__
@@ -4197,7 +4202,9 @@ async def _on_message(
         # on the session; never replied to. Dispatching as a tracked task
         # keeps it consistent with other channels so disconnect-cancel
         # works uniformly.
-        task = asyncio.create_task(server.desktop.handle(ws, envelope))
+        token = server._clients.get(ws)
+        session = server.sessions.get_session(token) if token else None
+        task = asyncio.create_task(server.desktop.handle(ws, envelope, session=session))
         _track_task(server, ws, task)
     else:
         logger.warning("Unknown channel: %s", channel)

--- a/plugin/tests/test_desktop_multidevice.py
+++ b/plugin/tests/test_desktop_multidevice.py
@@ -1,0 +1,263 @@
+"""Targeted multi-PC routing for the desktop RPC channel."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+from plugin.relay.channels.desktop import DesktopError, DesktopHandler
+from plugin.relay.server import handle_desktop_dispatch
+from plugin.tools import desktop_tool
+
+
+class _FakeWs:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def send_str(self, payload: str) -> None:
+        self.sent.append(json.loads(payload))
+
+
+@dataclass
+class _FakeSession:
+    device_id: str
+    device_name: str
+
+
+def _status(host: str) -> dict[str, Any]:
+    return {
+        "channel": "desktop",
+        "type": "desktop.status",
+        "payload": {
+            "host": host,
+            "advertised_tools": ["desktop_powershell", "desktop_read_file"],
+        },
+    }
+
+
+async def _register_two() -> tuple[DesktopHandler, _FakeWs, _FakeWs]:
+    handler = DesktopHandler()
+    office = _FakeWs()
+    laptop = _FakeWs()
+    await handler.handle(
+        office,  # type: ignore[arg-type]
+        _status("AXIOM-DESKTOP"),
+        session=_FakeSession("desktop-1", "AXIOM-DESKTOP"),
+    )
+    await handler.handle(
+        laptop,  # type: ignore[arg-type]
+        _status("Axiom-Latitude"),
+        session=_FakeSession("desktop-2", "Axiom-Latitude"),
+    )
+    return handler, office, laptop
+
+
+class DesktopMultiDeviceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_tool_schema_exposes_script_and_device_selector(self) -> None:
+        parameters = desktop_tool._SCHEMAS["desktop_powershell"]["parameters"]
+        self.assertEqual(parameters["required"], ["script"])
+        self.assertIn("script", parameters["properties"])
+        self.assertIn("device", parameters["properties"])
+        self.assertEqual(
+            desktop_tool._SCHEMAS["desktop_powershell"]["x-hermes-capability"],
+            "system.execute",
+        )
+
+    async def test_adb_schemas_are_serial_bound_and_capability_labeled(self) -> None:
+        names = {
+            "desktop_adb_devices",
+            "desktop_adb_shell",
+            "desktop_adb_push",
+            "desktop_adb_pull",
+            "desktop_adb_install",
+            "desktop_adb_logcat",
+        }
+        for name in names:
+            schema = desktop_tool._SCHEMAS[name]
+            self.assertEqual(schema["x-hermes-capability"], "devices.usb")
+            self.assertIn("device", schema["parameters"]["properties"])
+        self.assertEqual(
+            desktop_tool._SCHEMAS["desktop_adb_shell"]["parameters"]["required"],
+            ["serial", "command"],
+        )
+
+    async def test_raw_usb_schemas_are_host_gated_and_direct_spawn(self) -> None:
+        for name in {"desktop_usb_devices", "desktop_usb_run"}:
+            schema = desktop_tool._SCHEMAS[name]
+            self.assertEqual(schema["x-hermes-capability"], "devices.usb")
+            self.assertIn("device", schema["parameters"]["properties"])
+        run = desktop_tool._SCHEMAS["desktop_usb_run"]["parameters"]
+        self.assertEqual(run["required"], ["executable"])
+        self.assertEqual(run["properties"]["arguments"]["type"], "array")
+
+        response = Mock(status_code=200)
+        response.json.return_value = {"ok": True, "result": {"exit_code": 0}}
+        with patch.object(desktop_tool.requests, "post", return_value=response) as post:
+            desktop_tool.desktop_usb_run("fastboot", ["devices"], timeout=40)
+        self.assertEqual(post.call_args.kwargs["json"]["executable"], "fastboot")
+        self.assertEqual(post.call_args.kwargs["json"]["arguments"], ["devices"])
+
+    async def test_adb_http_timeout_covers_approval_and_operation(self) -> None:
+        response = Mock(status_code=200)
+        response.json.return_value = {"ok": True, "result": {"exit_code": 0}}
+        with patch.object(desktop_tool.requests, "post", return_value=response) as post:
+            desktop_tool.desktop_adb_install("serial-1", "app.apk", timeout=120)
+        self.assertGreaterEqual(post.call_args.kwargs["timeout"], 250)
+
+    async def test_tool_dispatch_forwards_device_as_relay_only_selector(self) -> None:
+        response = Mock(status_code=200)
+        response.json.return_value = {"ok": True, "result": {"stdout": "ok"}}
+        with patch.object(desktop_tool.requests, "post", return_value=response) as post:
+            desktop_tool._HANDLERS["desktop_powershell"](
+                {"script": "'ok'", "device": "desktop-1"}
+            )
+        self.assertEqual(post.call_args.kwargs["json"]["device"], "desktop-1")
+        self.assertEqual(post.call_args.kwargs["json"]["script"], "'ok'")
+
+    async def test_http_dispatch_strips_selector_before_client_forwarding(self) -> None:
+        desktop = Mock()
+        desktop.handle_command = AsyncMock(return_value={"ok": True, "result": {}})
+        request = Mock(
+            remote="127.0.0.1",
+            app={"server": Mock(desktop=desktop)},
+            match_info={"tool_name": "desktop_powershell"},
+        )
+        request.json = AsyncMock(
+            return_value={"script": "'ok'", "device": "desktop-1"}
+        )
+
+        response = await handle_desktop_dispatch(request)
+
+        self.assertEqual(response.status, 200)
+        desktop.handle_command.assert_awaited_once_with(
+            "desktop_powershell",
+            {"script": "'ok'"},
+            device="desktop-1",
+        )
+
+    async def test_untargeted_command_fails_closed_with_multiple_pcs(self) -> None:
+        handler, _office, _laptop = await _register_two()
+        with self.assertRaisesRegex(DesktopError, "pass device or device_id explicitly"):
+            await handler.handle_command("desktop_powershell", {"script": "pwd"})
+
+    async def test_name_target_routes_only_to_the_selected_pc(self) -> None:
+        handler, office, laptop = await _register_two()
+        task = asyncio.create_task(
+            handler.handle_command(
+                "desktop_powershell",
+                {"script": "pwd"},
+                device="axiom desktop",
+            )
+        )
+        await asyncio.sleep(0)
+        self.assertEqual(len(office.sent), 1)
+        self.assertEqual(laptop.sent, [])
+
+        request_id = office.sent[0]["payload"]["request_id"]
+        await handler.handle(
+            office,  # type: ignore[arg-type]
+            {
+                "channel": "desktop",
+                "type": "desktop.response",
+                "payload": {
+                    "request_id": request_id,
+                    "ok": True,
+                    "result": {"stdout": "office", "exit_code": 0},
+                },
+            },
+        )
+        result = await asyncio.wait_for(task, timeout=1)
+        self.assertEqual(result["result"]["stdout"], "office")
+
+    async def test_wrong_pc_cannot_satisfy_targeted_pending_request(self) -> None:
+        handler, office, laptop = await _register_two()
+        task = asyncio.create_task(
+            handler.handle_command(
+                "desktop_read_file",
+                {"path": "C:/marker.txt"},
+                device="desktop-2",
+            )
+        )
+        await asyncio.sleep(0)
+        request_id = laptop.sent[0]["payload"]["request_id"]
+        response = {
+            "channel": "desktop",
+            "type": "desktop.response",
+            "payload": {"request_id": request_id, "ok": True, "result": {"content": "x"}},
+        }
+        await handler.handle(office, response)  # type: ignore[arg-type]
+        self.assertFalse(task.done())
+        await handler.handle(laptop, response)  # type: ignore[arg-type]
+        result = await asyncio.wait_for(task, timeout=1)
+        self.assertEqual(result["result"]["content"], "x")
+
+    async def test_two_pcs_can_execute_concurrently_without_cross_talk(self) -> None:
+        handler, office, laptop = await _register_two()
+        office_task = asyncio.create_task(
+            handler.handle_command(
+                "desktop_powershell",
+                {"script": "'office'"},
+                device="desktop-1",
+            )
+        )
+        laptop_task = asyncio.create_task(
+            handler.handle_command(
+                "desktop_powershell",
+                {"script": "'laptop'"},
+                device="desktop-2",
+            )
+        )
+        await asyncio.sleep(0)
+
+        self.assertEqual(len(office.sent), 1)
+        self.assertEqual(len(laptop.sent), 1)
+        office_request_id = office.sent[0]["payload"]["request_id"]
+        laptop_request_id = laptop.sent[0]["payload"]["request_id"]
+        self.assertNotEqual(office_request_id, laptop_request_id)
+
+        # Complete them in reverse order to prove correlation is by request
+        # and target WebSocket, not by the latest status or response.
+        await handler.handle(
+            laptop,  # type: ignore[arg-type]
+            {
+                "channel": "desktop",
+                "type": "desktop.response",
+                "payload": {
+                    "request_id": laptop_request_id,
+                    "ok": True,
+                    "result": {"stdout": "laptop", "exit_code": 0},
+                },
+            },
+        )
+        self.assertFalse(office_task.done())
+        await handler.handle(
+            office,  # type: ignore[arg-type]
+            {
+                "channel": "desktop",
+                "type": "desktop.response",
+                "payload": {
+                    "request_id": office_request_id,
+                    "ok": True,
+                    "result": {"stdout": "office", "exit_code": 0},
+                },
+            },
+        )
+
+        office_result, laptop_result = await asyncio.gather(
+            office_task,
+            laptop_task,
+        )
+        self.assertEqual(office_result["result"]["stdout"], "office")
+        self.assertEqual(laptop_result["result"]["stdout"], "laptop")
+        self.assertEqual(office_result["target"]["device_id"], "desktop-1")
+        self.assertEqual(laptop_result["target"]["device_id"], "desktop-2")
+
+    async def test_health_snapshot_lists_connected_desktops(self) -> None:
+        handler, _office, _laptop = await _register_two()
+        clients = handler.status_snapshot()["clients"]
+        self.assertEqual({client["device_id"] for client in clients}, {"desktop-1", "desktop-2"})

--- a/plugin/tests/test_session_persistence.py
+++ b/plugin/tests/test_session_persistence.py
@@ -207,6 +207,48 @@ class SessionPersistenceRoundtripTests(unittest.TestCase):
             )
         )
 
+    def test_legacy_unknown_desktop_ids_do_not_replace_other_pcs(self) -> None:
+        mgr = SessionManager(persistence_path=self.path)
+        desktop_a = mgr.create_session(
+            "Office PC",
+            "unknown",
+            issue_refresh_token=True,
+            client_surface="desktop",
+        )
+        desktop_b = mgr.create_session(
+            "Laptop",
+            "unknown",
+            issue_refresh_token=True,
+            client_surface="desktop",
+        )
+
+        self.assertIsNotNone(mgr.get_session(desktop_a.token))
+        self.assertIsNotNone(mgr.get_session(desktop_b.token))
+        self.assertEqual(len(mgr.list_sessions()), 2)
+
+    def test_legacy_desktop_refresh_upgrades_to_stable_installation_id(self) -> None:
+        mgr = SessionManager(persistence_path=self.path)
+        legacy = mgr.create_session(
+            "Office PC",
+            "unknown",
+            issue_refresh_token=True,
+            client_surface="desktop",
+        )
+        assert legacy.refresh_token is not None
+        stable_id = "8e751a5a-b562-4c8b-8a81-88b1b5962fbb"
+
+        refreshed = mgr.refresh_session(
+            legacy.refresh_token,
+            device_name="Office PC",
+            device_id=stable_id,
+            client_surface="desktop",
+        )
+
+        self.assertIsNotNone(refreshed)
+        assert refreshed is not None
+        self.assertEqual(refreshed.device_id, stable_id)
+        self.assertTrue(mgr.has_trusted_device(stable_id))
+
     def test_explicit_pair_keeps_other_devices(self) -> None:
         mgr = SessionManager(persistence_path=self.path)
         phone_a = mgr.create_session(

--- a/plugin/tools/desktop_tool.py
+++ b/plugin/tools/desktop_tool.py
@@ -11,7 +11,7 @@ Tools registered (Phase B + remote-PC ergonomics, alpha.7):
 
   Shell:
     - desktop_terminal         run a shell command (bash/cmd) — bounded 30s
-    - desktop_powershell       run a PowerShell script via stdin (no quote-mangling)
+    - desktop_powershell       run a private PowerShell script (no quote-mangling)
 
   Process management:
     - desktop_spawn_detached   fire-and-forget process; returns pid + log path
@@ -34,6 +34,11 @@ Tools registered (Phase B + remote-PC ergonomics, alpha.7):
   Diagnostics:
     - desktop_health           connected client name, uptime, advertised tools,
                                 last error — answered by the relay (no client RTT)
+
+  USB:
+    - desktop_usb_devices      enumerate host-visible USB devices
+    - desktop_usb_run          direct-spawn a native/vendor USB utility
+    - desktop_adb_*            serial-bound Android Debug Bridge conveniences
 
   Experimental computer-use (observe-first):
     - desktop_computer_status          local display/grant/permission summary
@@ -66,9 +71,13 @@ from __future__ import annotations
 
 import json
 import os
+from contextvars import ContextVar
 from typing import Any, Optional
 
 import requests
+
+
+_DESKTOP_TARGET: ContextVar[str | None] = ContextVar("desktop_target", default=None)
 
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -96,18 +105,22 @@ def _auth_headers() -> dict:
     return {}
 
 
-def _post(path: str, payload: dict) -> dict:
+def _post(path: str, payload: dict, *, timeout: Optional[float] = None) -> dict:
     """POST ``payload`` to ``<relay>/desktop/<path>`` and return the JSON body.
 
     Surface network / HTTP failures as structured ``{"error": ...}`` dicts
     so the tool handlers can always return JSON to Hermes.
     """
+    payload = dict(payload)
+    target = _DESKTOP_TARGET.get()
+    if target:
+        payload["device"] = target
     try:
         r = requests.post(
             f"{_relay_url()}{path}",
             json=payload,
             headers=_auth_headers(),
-            timeout=_timeout(),
+            timeout=_timeout() if timeout is None else timeout,
         )
     except requests.RequestException as exc:
         return {"error": f"Relay unreachable: {exc}"}
@@ -251,6 +264,120 @@ def desktop_powershell(
         payload["prefer"] = prefer
     data = _post("/desktop/desktop_powershell", payload)
     return json.dumps(data)
+
+
+# ── Host-gated raw USB + ADB services ───────────────────────────────────────
+
+
+def desktop_usb_devices(reason: Optional[str] = None) -> str:
+    """List USB devices visible to the targeted desktop host."""
+    payload: dict[str, Any] = {}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post("/desktop/desktop_usb_devices", payload, timeout=_adb_http_timeout())
+    )
+
+
+def desktop_usb_run(
+    executable: str,
+    arguments: Optional[list[str]] = None,
+    cwd: Optional[str] = None,
+    timeout: int = 30,
+    reason: Optional[str] = None,
+) -> str:
+    """Direct-spawn a native or vendor USB utility without a shell."""
+    payload: dict[str, Any] = {
+        "executable": executable,
+        "arguments": list(arguments or []),
+        "timeout": int(timeout),
+    }
+    if cwd is not None:
+        payload["cwd"] = cwd
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post("/desktop/desktop_usb_run", payload, timeout=_adb_http_timeout(timeout))
+    )
+
+
+def _adb_http_timeout(operation_timeout: int = 30) -> float:
+    """Cover the local approval window plus the bounded ADB operation."""
+    return max(_timeout(), min(max(int(operation_timeout), 1), 120) + 130.0)
+
+
+def desktop_adb_devices(reason: Optional[str] = None) -> str:
+    payload: dict[str, Any] = {}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post("/desktop/desktop_adb_devices", payload, timeout=_adb_http_timeout())
+    )
+
+
+def desktop_adb_shell(serial: str, command: str, timeout: int = 30, reason: Optional[str] = None) -> str:
+    payload: dict[str, Any] = {"serial": serial, "command": command, "timeout": int(timeout)}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post(
+            "/desktop/desktop_adb_shell",
+            payload,
+            timeout=_adb_http_timeout(timeout),
+        )
+    )
+
+
+def desktop_adb_push(serial: str, source: str, destination: str, timeout: int = 60, reason: Optional[str] = None) -> str:
+    payload: dict[str, Any] = {"serial": serial, "source": source, "destination": destination, "timeout": int(timeout)}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post(
+            "/desktop/desktop_adb_push",
+            payload,
+            timeout=_adb_http_timeout(timeout),
+        )
+    )
+
+
+def desktop_adb_pull(serial: str, source: str, destination: str, timeout: int = 60, reason: Optional[str] = None) -> str:
+    payload: dict[str, Any] = {"serial": serial, "source": source, "destination": destination, "timeout": int(timeout)}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post(
+            "/desktop/desktop_adb_pull",
+            payload,
+            timeout=_adb_http_timeout(timeout),
+        )
+    )
+
+
+def desktop_adb_install(serial: str, apk: str, replace: bool = True, timeout: int = 120, reason: Optional[str] = None) -> str:
+    payload: dict[str, Any] = {"serial": serial, "apk": apk, "replace": bool(replace), "timeout": int(timeout)}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post(
+            "/desktop/desktop_adb_install",
+            payload,
+            timeout=_adb_http_timeout(timeout),
+        )
+    )
+
+
+def desktop_adb_logcat(serial: str, lines: int = 500, timeout: int = 30, reason: Optional[str] = None) -> str:
+    payload: dict[str, Any] = {"serial": serial, "lines": int(lines), "timeout": int(timeout)}
+    if reason is not None:
+        payload["reason"] = reason
+    return json.dumps(
+        _post(
+            "/desktop/desktop_adb_logcat",
+            payload,
+            timeout=_adb_http_timeout(timeout),
+        )
+    )
 
 
 # ── Process management ────────────────────────────────────────────────────────
@@ -627,12 +754,13 @@ _SCHEMAS: dict[str, dict[str, Any]] = {
     "desktop_powershell": {
         "name": "desktop_powershell",
         "description": (
-            "Run a PowerShell script on the desktop client, with the script text "
-            "fed to PowerShell via stdin (no cmd.exe quote-mangling). Use this "
+            "Run a PowerShell script on the targeted desktop client through a "
+            "private temporary UTF-8 file (no cmd.exe quote-mangling). Use this "
             "instead of desktop_terminal('powershell -Command \"...\"') — the "
             "latter loses quotes, here-strings, and dollar-vars to nested parsers. "
             "Picks `pwsh` when present, falls back to Windows PowerShell on "
-            "Windows. Returns {stdout, stderr, exit_code, duration_ms, shell}."
+            "Windows. Returns stdout, stderr, exit_code, shell, and explicit "
+            "per-stream byte/truncation metadata. The required payload field is script."
         ),
         "parameters": {
             "type": "object",
@@ -649,6 +777,85 @@ _SCHEMAS: dict[str, dict[str, Any]] = {
             },
             "required": ["script"],
         },
+    },
+    "desktop_usb_devices": {
+        "name": "desktop_usb_devices",
+        "description": (
+            "List USB devices visible to the targeted desktop. Governed by the "
+            "host's Raw USB Off/Ask/Allow policy."
+        ),
+        "parameters": {"type": "object", "properties": {"reason": {"type": "string"}}},
+    },
+    "desktop_usb_run": {
+        "name": "desktop_usb_run",
+        "description": (
+            "Run a native or vendor USB utility by direct executable + argument "
+            "array, without shell parsing. This is host-wide Raw USB access and "
+            "is governed by the selected desktop's USB Off/Ask/Allow policy."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "executable": {"type": "string", "description": "Executable name or path."},
+                "arguments": {"type": "array", "items": {"type": "string"}, "maxItems": 128, "default": []},
+                "cwd": {"type": "string", "description": "Working directory for the utility."},
+                "timeout": {"type": "integer", "default": 30, "maximum": 120},
+                "reason": {"type": "string"},
+            },
+            "required": ["executable"],
+        },
+    },
+    "desktop_adb_devices": {
+        "name": "desktop_adb_devices",
+        "description": "List Android devices visible to the targeted desktop's brokered ADB backend.",
+        "parameters": {"type": "object", "properties": {"reason": {"type": "string"}}},
+    },
+    "desktop_adb_shell": {
+        "name": "desktop_adb_shell",
+        "description": "Run a bounded ADB shell command against one explicit device serial.",
+        "parameters": {"type": "object", "properties": {
+            "serial": {"type": "string"}, "command": {"type": "string"},
+            "timeout": {"type": "integer", "default": 30, "maximum": 120},
+            "reason": {"type": "string"},
+        }, "required": ["serial", "command"]},
+    },
+    "desktop_adb_push": {
+        "name": "desktop_adb_push",
+        "description": "Push one local file to one explicit Android device serial.",
+        "parameters": {"type": "object", "properties": {
+            "serial": {"type": "string"}, "source": {"type": "string"},
+            "destination": {"type": "string"}, "timeout": {"type": "integer", "default": 60, "maximum": 120},
+            "reason": {"type": "string"},
+        }, "required": ["serial", "source", "destination"]},
+    },
+    "desktop_adb_pull": {
+        "name": "desktop_adb_pull",
+        "description": "Pull one file from one explicit Android device serial.",
+        "parameters": {"type": "object", "properties": {
+            "serial": {"type": "string"}, "source": {"type": "string"},
+            "destination": {"type": "string"}, "timeout": {"type": "integer", "default": 60, "maximum": 120},
+            "reason": {"type": "string"},
+        }, "required": ["serial", "source", "destination"]},
+    },
+    "desktop_adb_install": {
+        "name": "desktop_adb_install",
+        "description": "Install one APK on one explicit Android device serial through the broker.",
+        "parameters": {"type": "object", "properties": {
+            "serial": {"type": "string"}, "apk": {"type": "string"},
+            "replace": {"type": "boolean", "default": True},
+            "timeout": {"type": "integer", "default": 120, "maximum": 120},
+            "reason": {"type": "string"},
+        }, "required": ["serial", "apk"]},
+    },
+    "desktop_adb_logcat": {
+        "name": "desktop_adb_logcat",
+        "description": "Return a bounded recent logcat snapshot from one explicit Android device serial.",
+        "parameters": {"type": "object", "properties": {
+            "serial": {"type": "string"},
+            "lines": {"type": "integer", "default": 500, "minimum": 1, "maximum": 5000},
+            "timeout": {"type": "integer", "default": 30, "maximum": 120},
+            "reason": {"type": "string"},
+        }, "required": ["serial"]},
     },
     # ── Process management ────────────────────────────────────────────────
     "desktop_spawn_detached": {
@@ -882,12 +1089,15 @@ _SCHEMAS: dict[str, dict[str, Any]] = {
     "desktop_health": {
         "name": "desktop_health",
         "description": (
-            "Report the connected desktop client's identity (host, platform, "
-            "version, pid), uptime, advertised tools, last error, and the most "
+            "List every connected desktop target's stable device_id, name, and "
+            "advertised tools, plus compatibility diagnostics for the most recent "
+            "client and the most "
             "recent commands the relay has dispatched. Answered by the relay "
             "directly — does NOT round-trip through the client — so it works "
-            "even when other tools are wedged. Use this to debug 'why isn't "
-            "desktop_terminal responding?' before giving up."
+            "even when other tools are wedged. When several desktops are listed, "
+            "choose one and pass its device_id in the device field of every "
+            "client-routed call. USB/ADB calls use device for the host PC and "
+            "serial for attached hardware where required."
         ),
         "parameters": {"type": "object", "properties": {}},
     },
@@ -1082,6 +1292,14 @@ _HANDLERS: dict[str, Any] = {
     "desktop_patch":         lambda args, **kw: desktop_patch(**args),
     # Shell
     "desktop_powershell":    lambda args, **kw: desktop_powershell(**args),
+    "desktop_usb_devices": lambda args, **kw: desktop_usb_devices(**args),
+    "desktop_usb_run": lambda args, **kw: desktop_usb_run(**args),
+    "desktop_adb_devices": lambda args, **kw: desktop_adb_devices(**args),
+    "desktop_adb_shell": lambda args, **kw: desktop_adb_shell(**args),
+    "desktop_adb_push": lambda args, **kw: desktop_adb_push(**args),
+    "desktop_adb_pull": lambda args, **kw: desktop_adb_pull(**args),
+    "desktop_adb_install": lambda args, **kw: desktop_adb_install(**args),
+    "desktop_adb_logcat": lambda args, **kw: desktop_adb_logcat(**args),
     # Process management
     "desktop_spawn_detached":  lambda args, **kw: desktop_spawn_detached(**args),
     "desktop_list_processes":  lambda args, **kw: desktop_list_processes(**args),
@@ -1107,6 +1325,84 @@ _HANDLERS: dict[str, Any] = {
     "desktop_computer_grant_request": lambda args, **kw: desktop_computer_grant_request(**args),
     "desktop_computer_cancel":        lambda args, **kw: desktop_computer_cancel(**args),
 }
+
+
+def _targeted_handler(handler: Any) -> Any:
+    """Consume the relay-only device selector before calling a tool function."""
+
+    def invoke(args: dict[str, Any], **kwargs: Any) -> Any:
+        call_args = dict(args)
+        target = call_args.pop("device", None) or call_args.pop("device_id", None)
+        token = _DESKTOP_TARGET.set(str(target).strip() if target else None)
+        try:
+            return handler(call_args, **kwargs)
+        finally:
+            _DESKTOP_TARGET.reset(token)
+
+    return invoke
+
+
+for _tool_name, _handler in list(_HANDLERS.items()):
+    if _tool_name != "desktop_health":
+        _HANDLERS[_tool_name] = _targeted_handler(_handler)
+
+_DEVICE_SELECTOR_SCHEMA = {
+    "type": "string",
+    "description": (
+        "Target desktop device_id or unambiguous device/host name. Required when "
+        "more than one desktop daemon is connected; use desktop_health to list clients."
+    ),
+}
+_TOOL_CAPABILITIES = {
+    "desktop_read_file": "files.read",
+    "desktop_search_files": "files.read",
+    "desktop_checksum": "files.read",
+    "desktop_write_file": "files.write",
+    "desktop_patch": "files.write",
+    "desktop_copy_directory": "files.write",
+    "desktop_zip": "files.write",
+    "desktop_unzip": "files.write",
+    "desktop_terminal": "system.execute",
+    "desktop_powershell": "system.execute",
+    "desktop_usb_devices": "devices.usb",
+    "desktop_usb_run": "devices.usb",
+    "desktop_adb_devices": "devices.usb",
+    "desktop_adb_shell": "devices.usb",
+    "desktop_adb_push": "devices.usb",
+    "desktop_adb_pull": "devices.usb",
+    "desktop_adb_install": "devices.usb",
+    "desktop_adb_logcat": "devices.usb",
+    "desktop_spawn_detached": "system.execute",
+    "desktop_job_start": "system.execute",
+    "desktop_job_status": "process.manage",
+    "desktop_job_logs": "process.manage",
+    "desktop_job_cancel": "process.manage",
+    "desktop_job_list": "process.manage",
+    "desktop_list_processes": "process.manage",
+    "desktop_kill_process": "process.manage",
+    "desktop_find_pid_by_port": "process.manage",
+    "desktop_clipboard_read": "clipboard.read",
+    "desktop_clipboard_write": "clipboard.write",
+    "desktop_screenshot": "screen.observe",
+    "desktop_open_in_editor": "user_context.open",
+    "desktop_computer_status": "screen.observe",
+    "desktop_computer_screenshot": "screen.observe",
+    "desktop_computer_action": "input.control",
+    "desktop_computer_grant_request": "permissions.request",
+    "desktop_computer_cancel": "permissions.revoke",
+}
+for _tool_name, _schema in _SCHEMAS.items():
+    if _tool_name == "desktop_health":
+        continue
+    _parameters = _schema.get("parameters")
+    if isinstance(_parameters, dict):
+        _properties = _parameters.setdefault("properties", {})
+        if isinstance(_properties, dict):
+            _properties["device"] = dict(_DEVICE_SELECTOR_SCHEMA)
+    _capability = _TOOL_CAPABILITIES.get(_tool_name)
+    if _capability:
+        _schema["x-hermes-capability"] = _capability
+        _schema["x-hermes-raw-system-access"] = _capability == "system.execute"
 
 
 # Tools whose check_fn should ping the relay rather than a specific client tool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.6.3"
+version = "1.6.4"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [

--- a/user-docs/desktop/tools.md
+++ b/user-docs/desktop/tools.md
@@ -1,10 +1,10 @@
 # Local tool routing <ExperimentalBadge />
 
-The big feature. The remote Hermes agent can read, write, search, execute, capture, paste, and edit on **your machine** — not the server — through the same WSS relay it uses for chat. The agent's brain and conversation state stay on the host; your laptop is the hands.
+The big feature. The remote Hermes agent can read, write, search, execute, capture, paste, edit, and use explicitly brokered connected devices on **your machine** — not the server — through the same WSS relay it uses for chat. The agent's brain and conversation state stay on the host; your laptop is the hands.
 
 ## What the agent can do
 
-Tools are registered in the `desktop` toolset. The agent sees them as normal tools alongside its usual ones — no special syntax needed, just "read my notes" or "run `tsc --noEmit`". The shipped toolset is grouped into six families:
+Tools are registered in the `desktop` toolset. The agent sees them as normal tools alongside its usual ones — no special syntax needed, just "read my notes" or "run `tsc --noEmit`". The shipped toolset is grouped into seven families:
 
 **Filesystem**
 
@@ -20,7 +20,7 @@ Tools are registered in the `desktop` toolset. The agent sees them as normal too
 | Tool | Signature | Example use |
 |------|-----------|-------------|
 | `desktop_terminal` | `(command: string, cwd?: string, timeout?: number)` | "Run `tsc --noEmit` and tell me what's broken." `bash -lc` on POSIX, `cmd /c` on Windows. |
-| `desktop_powershell` | `(script: string, cwd?: string, timeout?: number)` | Runs a PowerShell script piped over stdin (`pwsh` preferred, falls back to `powershell`) — no `cmd.exe` quote-mangling. |
+| `desktop_powershell` | `(script: string, cwd?: string, timeout?: number, device?: string)` | Runs a private temporary PowerShell script (`pwsh` preferred, falls back to `powershell`) with complete UTF-8 stdout/stderr, native exit status, and explicit truncation metadata. |
 
 **Process management**
 
@@ -59,9 +59,53 @@ Tools are registered in the `desktop` toolset. The agent sees them as normal too
 | `desktop_screenshot` | `(display?: number \| string, save_to?: string)` | Capture all monitors (default), primary (`'primary'`), or a specific display (`1` / `2` / ...). Returns base64 + dimensions, or saves to `save_to` and returns the path. |
 | `desktop_open_in_editor` | `(path: string, line?: number, col?: number, wait?: boolean)` | Open a file in the user's editor. Detects `$VISUAL` → `$EDITOR` → `code` / `cursor` / `subl` / `nvim` / `vim` on PATH → platform fallback. Injects `-g path:line:col` for GUI editors. |
 
-That's the 23 tools the client advertises by default. A further **computer-use** family (`desktop_computer_status` / `_screenshot` / `_action` / `_grant_request` / `_cancel`) is registered for full local UI control but ships **experimental and off by default**. Enable it persistently with `hermes-relay computer-use enable` or from the Windows tray; one-process flag/env overrides remain available. Host input still fails closed without a task-scoped grant approved locally.
+**USB devices**
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
+| `desktop_usb_devices` | `(reason?: string)` | List USB devices visible to the selected desktop host. |
+| `desktop_usb_run` | `(executable: string, arguments?: string[], cwd?: string, timeout?: number, reason?: string)` | Direct-spawn a native or vendor USB utility without shell parsing. |
+
+**Android Debug Bridge service**
+
+| Tool | Signature | Example use |
+|------|-----------|-------------|
+| `desktop_adb_devices` | `(reason?: string)` | List devices visible to the local ADB backend. |
+| `desktop_adb_shell` | `(serial: string, command: string, timeout?: number, reason?: string)` | Run one bounded Android shell operation on an explicit serial. |
+| `desktop_adb_push` | `(serial: string, source: string, destination: string, timeout?: number, reason?: string)` | Push one local file to an explicit serial. |
+| `desktop_adb_pull` | `(serial: string, source: string, destination: string, timeout?: number, reason?: string)` | Pull one device file to the local PC. |
+| `desktop_adb_install` | `(serial: string, apk: string, replace?: boolean, timeout?: number, reason?: string)` | Install one local APK on an explicit serial. |
+| `desktop_adb_logcat` | `(serial: string, lines?: number, timeout?: number, reason?: string)` | Return a bounded recent logcat snapshot. |
+
+The two raw USB tools appear when the selected host's USB policy is Ask or
+Allow. The six ADB tools additionally require a working ADB backend. Structured
+mode omits the four general shell/process escape hatches but retains these
+separately gated USB paths. A further **computer-use** family
+(`desktop_computer_status` / `_screenshot` / `_action` / `_grant_request` /
+`_cancel`) is registered for full local UI control but ships **experimental and
+off by default**. Enable it persistently with `hermes-relay computer-use enable`
+or from the Windows tray; one-process flag/env overrides remain available. Host
+input still fails closed without a task-scoped grant approved locally.
 
 All tools run under a **30-second AbortController** ceiling enforced by the router. `desktop_terminal` / `desktop_powershell` accept a per-call `timeout` (seconds, per the wire spec — converted to ms internally) that's clamped to a 10-minute maximum. `desktop_screenshot` has its own 10 s timeout and 50 MB cap. `desktop_clipboard_*` 5 s timeout and 10 MB cap.
+
+Every client-routed tool also accepts `device`, using the stable device ID or an
+unambiguous computer name shown by `desktop_health`. It is optional with one
+connected PC and required when several desktop daemons are online. An
+untargeted call fails closed rather than choosing the latest heartbeat.
+
+Prefer the typed file, process, job, transfer, screen, clipboard, and connected-
+device tools for ordinary work. `desktop_terminal`, `desktop_powershell`,
+detached commands, and command jobs are intentionally labeled `system.execute`:
+because they run as your Windows user, they can indirectly access files and
+attached hardware. **Structured** mode withholds those four escape hatches. Its
+separate per-host Raw USB policy defaults Off, can Ask through the local
+approval card for every operation, or can Allow after explicit confirmation.
+It governs host-wide direct execution of native/vendor USB utilities and all
+enabled USB services; it is not scoped to one physical device. ADB remains a
+secondary service and its device operations require an exact serial. Full
+Access does not bypass USB policy. Camera and microphone remain unavailable
+until controlled paths exist.
 
 The router heartbeats `desktop.status` every 30 s, advertising the full handler-name list, so the server's `desktop` channel knows which tools your client can service. Servers ping `/desktop/_ping?tool=<name>` to fail fast when a tool isn't advertised.
 
@@ -168,7 +212,7 @@ How you approve depends on how the client is running:
 
 - **Interactive (`shell` / `chat` on a TTY):** a visible prompt appears in your terminal — type `yes` to approve.
 - **Headless (`daemon`, no TTY):** approvals route through the local file bridge at `~/.hermes/grant-bridge` (override with `HERMES_RELAY_GRANT_BRIDGE_DIR`). The daemon writes `request-<id>.json`; `hermes-relay grants` reviews it and writes the matching response. Without a local approver, the request times out and input stays failed-closed.
-- **Windows tray:** a new pending request raises a native security alert. Choose **Review pending grants…** to open the same `hermes-relay grants` review in a terminal. The tray never auto-approves a request and has no hidden approval window.
+- **Windows tray:** a pending request raises a dedicated borderless approval card without opening the main management UI. The card identifies the host, operation scope, and reason; it never auto-approves.
 
 Use `hermes-relay computer-use status` to see the persisted preference, daemon privilege, active grant/expiry, pending count, and whether a restart is required. Disabling desktop use requests exact-once cancellation from the running daemon. The Windows tray displays the same state and warns explicitly when an Administrator control grant is active.
 


### PR DESCRIPTION
## Server hotfix 1.6.4

- retains multiple connected desktop clients instead of replacing the previous WebSocket
- requires explicit device selection when several desktops are online
- binds each pending request and response to the selected desktop
- exposes all connected targets through desktop_health
- keeps PC device selection separate from attached USB/ADB serial selection

## Verification
- based on immutable server-v1.6.3
- plugin metadata synchronized at 1.6.4
- focused routing/auth/session suite: 45 passed, 1 skipped
- full plugin suite on the integrated feature: 1302 passed, 9 skipped

The wider dev release PR was closed because unrelated Android lint was failing; this server-only hotfix does not bypass it.