### PR TITLE
release(desktop): desktop-v0.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **CUA Driver is the preferred Windows structured-control engine.** New local settings prefer a verified CUA runtime for window-targeted background actions, fresh snapshot tokens, and optional per-session animated agent cursors without moving the physical pointer; Windows input is now the explicit compatibility backend and backend choice is fixed for each control session. Full-display observation remains on the read-only system capture path. CLI and UI can explicitly install, check, or update the canonical CUA package after verifying the upstream release manifest and installer checksum; nothing is bundled or updated automatically, driver telemetry stays off, and the local activity timeline records only bounded, redacted control metadata.
 - **Android can edit current Hermes profiles through the standard Gateway.** The Profile Inspector capability-gates `profiles.describe` and `profiles.configure`, keeps Relay-only memory editing and older-Hermes fallback intact, and reports partial section saves without discarding failed drafts.
 - **Android sessions show their coding context when Hermes supplies it.** Session rows can display repository, Git branch, and the current state of the pull request created by that session while older hosts remain unchanged.
 - Android Manage can now finish host-owned backup workflows, edit or remove learning nodes with explicit recovery guidance, configure and activate memory providers, and complete profile-scoped WhatsApp QR onboarding through the authenticated upstream Dashboard contracts.
 
 ### Fixed
 
-- **Windows bundle updates fail closed when installed processes retain a binary lock.** Setup now waits for the invoking CLI, quiesces the tray and its short-lived CLI children, checks every payload extraction before writing release metadata, preserves custom install directories, and returns a failure instead of reporting a mixed-version installation.
 - **Android preserves authoritative Gateway outcomes.** Protected-file cards cannot offer forbidden persistent scopes, compression no-ops show the server result, bounded resume failures do not create context-free replacement sessions, and edit/regenerate retains durable row identities across consecutive rewinds.
 - **Android routes and uploads against live upstream truth.** Multiplex API fallback trusts `served_profiles` instead of installed profiles, and generic documents carry the Gateway-issued `@file:` reference into ordinary and queued prompts.
 - **Android clarify cards preserve upstream decision semantics.** Multi-select prompts keep independent selections and submit one exact list, while server expiry events—not an invented local deadline—retire unanswered cards.
 - **Android keeps profile management and retained automation truthful.** Custom Endpoint list and mutation routes now follow the selected Hermes profile, while completed one-shot cron jobs show their retained outcome and expose only valid Runs/Delete actions.
 - **Android and Relay recover more generated media reliably.** Android accepts upstream-valid wrapped, punctuated, adjacent, spaced, and Windows `MEDIA:` markers without consuming fenced examples, and Relay translates Docker-visible workspace, home, cache, and configured-mount paths before applying its existing credential, sandbox, and size checks.
+
+## [0.4.0-beta.1] - 2026-08-14
+
+### Added
+
+- **CUA Driver is the preferred Windows structured-control engine.** New local settings prefer a verified CUA runtime for window-targeted background actions, fresh snapshot tokens, and optional per-session animated agent cursors without moving the physical pointer; Windows Input is the explicit compatibility backend and backend choice is fixed for each control session. Full-display observation remains on the read-only system capture path. CLI and UI can explicitly install, check, or update the canonical CUA package after verifying the upstream release manifest and installer checksum; nothing is bundled or updated automatically, driver telemetry stays off for Hermes sessions, and activity records contain only bounded, redacted control metadata.
+
+### Fixed
+
+- **Windows bundle updates fail closed when installed processes retain a binary lock.** Setup waits for the invoking CLI, quiesces the tray and its short-lived CLI children, checks every payload extraction before writing release metadata, preserves custom install directories, and returns a failure instead of reporting a mixed-version installation.
+- **CUA readiness follows the published driver contract.** Hermes accepts the documented `ok` health state, distinguishes an installed-but-degraded runtime from a missing installation, and constructs trusted Windows installer paths consistently across verification environments.
 
 ## [1.7.0] - 2026-08-13
 

--- a/CLI_RELEASE_NOTES.md
+++ b/CLI_RELEASE_NOTES.md
@@ -1,30 +1,28 @@
 # Hermes-Relay CLI v__VERSION__
 
-**Release Date:** 2026-08-13
+**Release Date:** 2026-08-14
 
-This alpha makes the compact **Hermes-Relay CLI UI** responsive during connection changes, expands host and capability management, and presents live route security and diagnostics without turning the tray into a full desktop client.
+This first beta makes structured Windows computer control safer and more capable through an optional CUA Driver integration, while hardening in-place CLI and management UI updates.
 
-**Experimental phase.** Assets remain unsigned, so Windows SmartScreen and macOS Gatekeeper may warn on first launch. Standalone CLI binaries ship for Windows x64, Linux x64, and macOS x64/arm64; the management tray is Windows-only.
+**Beta phase.** Assets remain unsigned, so Windows SmartScreen and macOS Gatekeeper may warn on first launch. Standalone CLI binaries ship for Windows x64, Linux x64, and macOS x64/arm64; the management UI is Windows-only.
 
 ## What's changed
 
 ### Added
 
-- **Host management hub.** Each paired Hermes host has local identity, pairing facts, access and capability controls, authorized-client revocation, re-pairing, and guarded removal.
-- **Evidence-first activity.** Overview shows the latest three events and detailed views retain bounded command, output, exit, duration, and truncation evidence.
-- **Live route details.** The Agent-to-PC path shows route type, encryption state, endpoint, packet motion, and a connection test with reachability and latency.
+- **CUA Driver computer control.** Windows sessions prefer the verified CUA runtime for window-targeted background actions, fresh pre/post snapshots, one-use element tokens, and optional per-session animated cursors that do not move the physical pointer.
+- **Explicit engine management.** The CLI and management UI show CUA installation, compatibility, health, active backend, and session state, with guarded Install, Check, and Update actions.
+- **Bounded control activity.** Computer-control events show backend, dispatch, target, action, and verification phases without retaining screenshots, UI trees, entered values, or raw session identifiers.
 
 ### Changed
 
-- **Connection lifecycle stays responsive.** Connect, disconnect, and snapshot work run outside the UI thread with immediate transition feedback and single-flight live polling.
-- **Access presets are explicit.** Restricted, Ask Every Time, Standard, Full Access, and Custom map visibly onto individual command, file, screen/input, and hardware capabilities.
-- **Tailscale is the recommended remote route.** Direct TLS and Hermes Secure Link remain supported; Hermes Reach is marked experimental and stays below supported routes.
+- **Windows Input is the compatibility backend.** Engine selection is fixed for each authenticated control session; CUA never silently falls back to foreground input after a session starts.
+- **CUA remains optional.** Hermes verifies the canonical upstream package and supported version range. The driver is not bundled or silently updated, and Hermes sessions force driver telemetry off.
 
 ### Fixed
 
-- **Legacy LAN and Tailscale routes no longer appear as Custom VPN.** Route testing infers generic saved roles from the endpoint and reports the correct network path.
-- **PowerShell output remains complete.** Scalar, pipeline, JSON, native output, errors, exit status, and truncation metadata return reliably through desktop RPC.
-- **Tray placement follows the real notification area.** Responsive geometry uses the tray monitor and DPI and remains anchored above the icon.
+- **Bundle updates handle locked processes safely.** The installer waits for the invoking process, quiesces tray children, retries checked payload extraction, preserves custom install directories, and fails before release metadata changes if replacement cannot complete.
+- **CUA readiness uses the documented health schema.** A healthy `ok` result is accepted, installed-but-degraded UI Automation is explained accurately, and trusted Windows installer paths validate consistently.
 
 ## Install
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.8",
+  "version": "0.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-alpha.8",
+      "version": "0.4.0-beta.1",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-alpha.8",
+  "version": "0.4.0-beta.1",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-alpha.8" as const
+export const VERSION = "0.4.0-beta.1" as const

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.8"
+version = "0.4.0-beta.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-alpha.8"
+version = "0.4.0-beta.1"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-alpha.8",
+  "version": "0.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-alpha.8",
+      "version": "0.4.0-beta.1",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-alpha.8",
+  "version": "0.4.0-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-alpha.8",
+  "version": "0.4.0-beta.1",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- promote the verified CUA Driver integration and updater hardening to the first Desktop beta
- bump CLI and Windows management UI metadata to 0.4.0-beta.1
- publish scoped changelog and release notes while leaving Android work unreleased

## Verification
- desktop type-check
- 160 desktop tests
- Windows compiled-binary smoke
- tray UI production build
- cargo fmt, clippy, check, and 15 Rust tests
- version-track consistency