### PR TITLE
release(desktop): desktop-v0.4.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.4.0-beta.4] - 2026-08-15
+
+### Fixed
+
+- **The Windows management UI remains available while the daemon is stopped.** Missing, stale, malformed, or temporarily unavailable daemon status now resolves to an explicit stopped state instead of trapping the tray on its loading screen, so configuration, diagnostics, host management, and daemon controls remain accessible.
+
 ## [1.9.0] - 2026-08-14
 
 ### Added

--- a/CLI_RELEASE_NOTES.md
+++ b/CLI_RELEASE_NOTES.md
@@ -1,23 +1,17 @@
 # Hermes-Relay CLI v__VERSION__
 
-**Release Date:** 2026-08-14
+**Release Date:** 2026-08-15
 
-This patch prevents the Windows management tray from accumulating Hermes-Relay, registry, and ADB helper processes when a refresh is slow or fails, and adds bounded diagnostics for future recovery.
+This patch keeps the Windows management UI usable when the Relay daemon is stopped or its status cannot be read.
 
 **Beta phase.** Assets remain unsigned, so Windows SmartScreen and macOS Gatekeeper may warn on first launch. Standalone CLI binaries ship for Windows x64, Linux x64, and macOS x64/arm64; the management UI is Windows-only.
 
 ## What's changed
 
-### Changed
-
-- **Grant discovery stays lightweight.** The approval window reads local bridge state instead of rebuilding the complete management snapshot, schedules each refresh only after the previous one finishes, and pauses idle polling while hidden.
-- **Management refreshes are visibility-aware and resilient.** Concurrent snapshot requests share one bounded result, optional static checks are cached, and repeated failures back off instead of creating more work.
-
 ### Fixed
 
-- **Windows helper processes are contained.** Tray-launched commands have hard deadlines, bounded output capture, descendant cleanup, and suppressed loader-error dialogs, preventing stalled probes from growing into a process storm.
-- **Daemon startup is serialized across launchers.** Cross-process lifecycle and runtime ownership locks prevent concurrent start or restart requests from leaving duplicate daemons behind.
-- **Tray failures are diagnosable without exposing command data.** A rotated, sanitized `tray.log` records bounded probe and lifecycle outcomes separately from `daemon.log`.
+- **Stopped daemons no longer block the management UI.** Missing, stale, malformed, or temporarily unavailable daemon status falls back to an explicit stopped state while hosts, settings, activity, CLI details, diagnostics, and daemon controls continue loading normally.
+- **Starting the daemon restores live status without reopening the UI.** A valid running status continues through the same bounded, single-flight snapshot path introduced in beta.3.
 
 ## Install
 

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,21 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-14 — Android 1.9.0 session identity and conversation controls
+
+Hermes-Relay Android 1.9.0 is published from the immutable
+`android-v1.9.0` tag. Multi-profile session browsing now keeps the aggregate
+drawer scope selected while transcript hydration, resume, sending, and header
+identity follow the session's owning profile. New Chat from All Profiles uses
+the default profile, and the session list starts ungrouped while retaining
+project grouping and the other desktop-style views as explicit options.
+
+Message reactions now resolve durable rows for both user and assistant
+messages. Vanilla Hermes voice remains on the authenticated Gateway instead of
+requiring the optional API fallback. Session rows can expose profile, project,
+branch, and pull-request context without crowding the chat header, secondary
+drawer actions remain available in All Profiles, and outside taps dismiss the
+drawer.
+
 ## 2026-08-09 — Gateway activity recovery and chat speech
 
 Successful Android Gateway turns now reconcile against their profile-owned,

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-beta.3",
+      "version": "0.4.0-beta.4",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-beta.3" as const
+export const VERSION = "0.4.0-beta.4" as const

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-beta.3"
+version = "0.4.0-beta.4"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-beta.3"
+version = "0.4.0-beta.4"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-beta.3",
+      "version": "0.4.0-beta.4",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/src/main.rs
+++ b/desktop/tray/src/main.rs
@@ -273,7 +273,7 @@ mod app {
             && fs::write(path, std::process::id().to_string()).is_ok()
     }
 
-    #[derive(Debug, Clone, Default, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Deserialize, Serialize)]
     struct DaemonStatus {
         #[serde(default = "stopped")]
         state: String,
@@ -293,6 +293,25 @@ mod app {
 
     fn stopped() -> String {
         "stopped".to_string()
+    }
+
+    impl Default for DaemonStatus {
+        fn default() -> Self {
+            Self {
+                state: stopped(),
+                running: false,
+                url: None,
+                configured_url: None,
+                active_route: None,
+                privilege: None,
+                username: None,
+                updated_at: None,
+                last_event: None,
+                reconnect_attempt: None,
+                retry_at: None,
+                last_error: None,
+            }
+        }
     }
 
     #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1048,6 +1067,13 @@ mod app {
         availability
     }
 
+    fn daemon_status_from_probe(result: Result<Value, String>) -> DaemonStatus {
+        result
+            .ok()
+            .and_then(|value| serde_json::from_value(value).ok())
+            .unwrap_or_default()
+    }
+
     fn build_snapshot() -> Result<Snapshot, String> {
         let selected = active_url();
         let mut hosts = match run_json(&["hosts", "list", "--json"]) {
@@ -1067,9 +1093,7 @@ mod app {
                 host.access_mode = "ask-every-time".to_string();
             }
         }
-        let daemon =
-            serde_json::from_value::<DaemonStatus>(run_json(&["daemon", "status", "--json"])?)
-                .map_err(|_| "the installed CLI returned an invalid daemon status".to_string())?;
+        let daemon = daemon_status_from_probe(run_json(&["daemon", "status", "--json"]));
         let pending_grants = pending_grants_from_bridge();
         let (cli_version, cli_path) = cli_details();
         let computer_control_engine = cached_computer_control_engine();
@@ -2520,6 +2544,32 @@ mod app {
                 clean_cli_version("hermes-relay 0.4.0-alpha.7\r\n"),
                 "0.4.0-alpha.7"
             );
+        }
+
+        #[test]
+        fn failed_daemon_status_probe_keeps_management_snapshot_stopped() {
+            for result in [
+                Err("daemon is not running".to_string()),
+                Ok(serde_json::json!({"running": "invalid"})),
+            ] {
+                let status = daemon_status_from_probe(result);
+                assert_eq!(status.state, "stopped");
+                assert!(!status.running);
+                assert!(status.url.is_none());
+            }
+        }
+
+        #[test]
+        fn live_daemon_status_probe_preserves_running_state() {
+            let status = daemon_status_from_probe(Ok(serde_json::json!({
+                "state": "connected",
+                "running": true,
+                "url": "wss://relay.example.test"
+            })));
+
+            assert_eq!(status.state, "connected");
+            assert!(status.running);
+            assert_eq!(status.url.as_deref(), Some("wss://relay.example.test"));
         }
 
         #[test]

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- keep the Windows management UI available when daemon status is missing or invalid
- report a typed stopped state while retaining hosts, settings, activity, diagnostics, and daemon controls
- bump synchronized Desktop metadata and publish patch release notes

## Verification
- npm --prefix desktop run verify
- isolated packaged Windows smoke with daemon status exiting 1
- git diff --check