### PR TITLE
fix(android): only physical Enter sends; let IME return key insert newline

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ChatInputBar.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ChatInputBar.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
@@ -196,6 +197,13 @@ fun ChatInputBar(
         ChatInputTrailing.STEER,
         ChatInputTrailing.QUEUE,
     )
+
+    // Enter only means "send" when a physical keyboard is attached (see
+    // the key handler below). Read the configuration here, in the composable
+    // scope, and capture it for the non-composable onPreviewKeyEvent lambda.
+    val keyboardAttached =
+        LocalConfiguration.current.keyboard !=
+            android.content.res.Configuration.KEYBOARD_NOKEYS
 
     // Keep the last caption around so the AnimatedVisibility exit doesn't
     // flash an empty line while collapsing.
@@ -375,10 +383,18 @@ fun ChatInputBar(
                                 val native = event.nativeKeyEvent
                                 val isEnter = native.keyCode == android.view.KeyEvent.KEYCODE_ENTER ||
                                     native.keyCode == android.view.KeyEvent.KEYCODE_NUMPAD_ENTER
+                                // Enter only means "send" when a physical keyboard is
+                                // attached. IME-dispatched Enter (commitText or a
+                                // synthesized KEYCODE_ENTER) must always fall through
+                                // so the soft keyboard's return key inserts a newline
+                                // instead of sending (issue #367). Key events alone
+                                // cannot distinguish physical vs IME origin — deviceId
+                                // is 0 or -1 depending on the IME — so gate on the
+                                // hardware keyboard configuration (read above).
                                 val isSubmitShortcut = native.isCtrlPressed || native.isMetaPressed
                                 if (native.action != android.view.KeyEvent.ACTION_DOWN || !isEnter) {
                                     false
-                                } else if (isSubmitShortcut || (physicalEnterSends && !native.isShiftPressed)) {
+                                } else if (isSubmitShortcut || (keyboardAttached && physicalEnterSends && !native.isShiftPressed)) {
                                     if (canSubmit) onSend()
                                     true
                                 } else {

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ChatInputBarTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ChatInputBarTest.kt
@@ -10,7 +10,8 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasImeAction
-import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -33,9 +34,10 @@ import org.robolectric.annotation.GraphicsMode
 class ChatInputBarTest {
 
     @get:Rule
-    val compose = createComposeRule()
+    val compose = createAndroidComposeRule<ComponentActivity>()
 
     @Test
+    @Config(qualifiers = "w360dp-h720dp-xhdpi-qwerty")
     fun `hardware enter submits through the composer action`() {
         var sent = 0
         setComposer(value = "Hello") { sent++ }
@@ -64,6 +66,7 @@ class ChatInputBarTest {
     }
 
     @Test
+    @Config(qualifiers = "w360dp-h720dp-xhdpi-qwerty")
     fun `plain enter inserts newline when configured while ctrl enter submits`() {
         var value = "Hello"
         var sent = 0
@@ -88,6 +91,7 @@ class ChatInputBarTest {
     }
 
     @Test
+    @Config(qualifiers = "w360dp-h720dp-xhdpi-qwerty")
     fun `hardware submit preserves steer action`() {
         var submitted = 0
         setComposer(value = "Correct this", trailing = ChatInputTrailing.STEER) { submitted++ }
@@ -109,6 +113,7 @@ class ChatInputBarTest {
     }
 
     @Test
+    @Config(qualifiers = "w360dp-h720dp-xhdpi-qwerty")
     fun `hardware submit preserves queue action`() {
         var submitted = 0
         setComposer(value = "Follow up", trailing = ChatInputTrailing.QUEUE) { submitted++ }
@@ -153,6 +158,44 @@ class ChatInputBarTest {
 
         compose.runOnIdle {
             assertEquals("Hello\nWorld", value)
+            assertEquals(0, sent)
+        }
+    }
+
+    @Test
+    fun `ime synthesized enter key inserts newline instead of submitting`() {
+        var value = "Hello"
+        var sent = 0
+        setComposer(value = value, onValueChange = { value = it }) { sent++ }
+
+        // Some IMEs dispatch the return key as a synthesized KEYCODE_ENTER
+        // key event instead of committing "\n" directly. With no physical
+        // keyboard attached the send path must not fire, otherwise the soft
+        // keyboard's return key sends the message (issue #367). Inject the
+        // event at the view root exactly like the IME's InputConnection
+        // key-event path does.
+        val imeDown = android.view.KeyEvent(
+            -1, 0,
+            android.view.KeyEvent.ACTION_DOWN,
+            android.view.KeyEvent.KEYCODE_ENTER,
+            0, 0,
+        )
+        val imeUp = android.view.KeyEvent(
+            -1, 0,
+            android.view.KeyEvent.ACTION_UP,
+            android.view.KeyEvent.KEYCODE_ENTER,
+            0, 0,
+        )
+
+        input().performClick()
+        compose.runOnIdle {
+            val root = compose.activity.findViewById<android.view.View>(android.R.id.content)
+            root.dispatchKeyEvent(imeDown)
+            root.dispatchKeyEvent(imeUp)
+        }
+
+        compose.runOnIdle {
+            assertEquals("Hello\n", value)
             assertEquals(0, sent)
         }
     }


### PR DESCRIPTION
## Summary

Fixes the remaining half of #367. v1.10.0 (ad98ca9) changed the composer's `imeAction` to `Default`, which fixed the issue for **Gboard-style IMEs** — they commit `\n` directly through the input connection (the commitText path), so the keyboard now shows a return key that inserts a newline.

But IMEs that dispatch the return key as a **synthesized `KEYCODE_ENTER` key event** (e.g. **SwiftKey**) were still broken: the `onPreviewKeyEvent` handler added for #318 treats any Enter key-down as a submit when `physicalEnterSends` is enabled, so it caught the soft keyboard's return key and sent the message instead of inserting a newline.

### Root cause

Key events alone can't distinguish a physical Enter from an IME-dispatched Enter — `deviceId` is `0` or `-1` depending on the IME (and even the Android test framework synthesizes both with `-1`). So gating on `deviceId` is unreliable.

### The fix

`ChatInputBar.kt` — gate the submit path on **hardware keyboard presence** (`LocalConfiguration.current.keyboard != KEYBOARD_NOKEYS`):

| Input | Before | After |
|---|---|---|
| Soft keyboard return, no physical keyboard (Gboard/commitText) | newline (v1.10.0) | newline ✓ |
| Soft keyboard return, no physical keyboard (**SwiftKey**/key event) | **sent the message** | **newline** ✓ |
| Physical Enter (send mode) | sends | sends ✓ |
| Physical Shift+Enter | newline | newline ✓ |
| Physical Ctrl/Cmd+Enter | sends | sends ✓ |

When no physical keyboard is attached, Enter is never intercepted — the text field inserts a newline on its own. With a physical keyboard attached, all of the #318 behavior is preserved.

### Tests

- New regression test **`ime synthesized enter key inserts newline instead of submitting`**: injects a synthesized Enter key event at the view root (exactly the IME key-event path) and asserts it inserts a newline without sending.
- Updated the 4 existing hardware-keyboard tests to simulate an attached keyboard (Robolectric `qwerty` qualifier) so they exercise the physical-Enter submit path.
- All 13 `ChatInputBarTest` cases pass locally.

### Verification

Confirmed on-device by the reporter: with this build, a newline is inserted on **SwiftKey** (the previously-broken case); Gboard already worked on v1.10.0.

Closes #367