### PR TITLE
feat(android): show OpenCode Go subscription usage in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Android shows OpenCode Go subscription usage in Settings.** A new inline card proxies the provider's 5-hour / weekly / monthly quota through the Relay host (`GET /usage/opencode`) and renders each window as a progress bar with dollars used, the window cap, a resets-in countdown, and a refresh control. The provider API key stays in `~/.hermes/.env` on the host and never reaches the device; the card fails soft when the Relay is unconfigured or unpaired.
+
 ## [1.10.0] - 2026-08-18
 
 ### Added

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClient.kt
@@ -1469,4 +1469,123 @@ class RelayHttpClient(
         val value = header?.trim()?.lowercase() ?: return false
         return value == "1" || value == "true"
     }
+
+    // ── OpenCode Go subscription usage ───────────────────────────────────
+
+    /** Reply shape of the relay's `GET /usage/opencode` proxy. */
+    @Serializable
+    data class OpenCodeUsageResponse(
+        val usage: OpenCodeUsageWindows = OpenCodeUsageWindows(),
+        /** Per-window dollar caps + human labels echoed from the relay host. */
+        val limits: Map<String, OpenCodeUsageLimit> = emptyMap(),
+    )
+
+    /** The three subscription windows: 5h (rolling), weekly, monthly. */
+    @Serializable
+    data class OpenCodeUsageWindows(
+        val rolling: OpenCodeUsageWindow? = null,
+        val weekly: OpenCodeUsageWindow? = null,
+        val monthly: OpenCodeUsageWindow? = null,
+    )
+
+    @Serializable
+    data class OpenCodeUsageWindow(
+        val status: String? = null,
+        /** Fraction (0–100) of the window's dollar limit already used. */
+        val percent: Int? = null,
+        @SerialName("resetsAt") val resetsAt: String? = null,
+    )
+
+    @Serializable
+    data class OpenCodeUsageLimit(
+        val label: String? = null,
+        val limit: Double? = null,
+    )
+
+    /**
+     * Fetch the OpenCode Go subscription usage via the relay's
+     * `GET /usage/opencode` proxy.
+     *
+     * The OpenCode Go API key lives only in `~/.hermes/.env` on the relay host;
+     * the phone authenticates to the relay with its session token and the relay
+     * does the upstream query on our behalf. The returned payload carries the
+     * three windows (`rolling`, `weekly`, `monthly`), each `{status, percent,
+     * resetsAt}`, plus the dollar caps so the UI can render "$X of $Y used".
+     *
+     * Requires a configured relay URL AND a paired session token — exactly the
+     * same preconditions as [fetchMedia].
+     */
+    suspend fun fetchOpenCodeUsage(): Result<OpenCodeUsageResponse?> =
+        withContext(Dispatchers.IO) {
+            val relayUrl = relayUrlProvider()?.trim().orEmpty()
+            if (relayUrl.isEmpty()) {
+                return@withContext Result.failure(
+                    IllegalStateException("Relay URL not configured")
+                )
+            }
+            val sessionToken = sessionTokenProvider()
+            if (sessionToken.isNullOrBlank()) {
+                return@withContext Result.failure(
+                    IllegalStateException("Relay not paired — session token missing")
+                )
+            }
+
+            val httpBase = relayUrl
+                .replace(Regex("^wss://", RegexOption.IGNORE_CASE), "https://")
+                .replace(Regex("^ws://", RegexOption.IGNORE_CASE), "http://")
+                .trimEnd('/')
+
+            val url = "$httpBase/usage/opencode".toHttpUrlOrNull()
+                ?: return@withContext Result.failure(
+                    IllegalArgumentException("Invalid relay URL: $httpBase")
+                )
+
+            val request = Request.Builder()
+                .url(url)
+                .get()
+                .header("Authorization", "Bearer $sessionToken")
+                .header("Accept", "application/json")
+                .build()
+
+            try {
+                okHttpClient.newCall(request).execute().use { response ->
+                    if (response.code == 404) {
+                        // Relay host has no OPENCODE_GO_API_KEY configured — the
+                        // feature is simply not applicable on this host. This is
+                        // a normal state (not an error), so callers render a
+                        // quiet "not available" instead of failing.
+                        return@withContext Result.success(null)
+                    }
+                    if (!response.isSuccessful) {
+                        val reason = when (response.code) {
+                            401, 403 -> "Unauthorized — re-pair with the relay"
+                            502 -> "OpenCode Go upstream error (HTTP ${response.code})"
+                            in 500..599 -> "Relay error (HTTP ${response.code})"
+                            else -> "HTTP ${response.code}: ${response.message.ifBlank { "request failed" }}"
+                        }
+                        return@withContext Result.failure(IOException(reason))
+                    }
+                    val body = response.body?.string().orEmpty()
+                    if (body.isBlank()) {
+                        return@withContext Result.failure(IOException("Empty response body"))
+                    }
+                    val parsed = runCatching {
+                        sessionsJson.decodeFromString(
+                            OpenCodeUsageResponse.serializer(),
+                            body,
+                        )
+                    }.getOrElse {
+                        Log.w(TAG, "fetchOpenCodeUsage parse error: ${it.message}")
+                        return@withContext Result.failure(IOException("Unrecognized quota payload"))
+                    }
+                    Result.success(parsed)
+                }
+            } catch (e: IOException) {
+                Log.w(TAG, "fetchOpenCodeUsage failed: ${e.message}")
+                Result.failure(IOException("Relay unreachable: ${e.message ?: "IO error"}"))
+            } catch (e: Exception) {
+                Log.w(TAG, "fetchOpenCodeUsage unexpected error: ${e.message}")
+                Result.failure(e)
+            }
+        }
 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/OpenCodeQuotaCard.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/OpenCodeQuotaCard.kt
@@ -1,0 +1,300 @@
+package com.hermesandroid.relay.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.hermesandroid.relay.R
+import com.hermesandroid.relay.network.relay.RelayHttpClient
+import com.hermesandroid.relay.network.relay.RelayHttpClient.OpenCodeUsageLimit
+import com.hermesandroid.relay.network.relay.RelayHttpClient.OpenCodeUsageResponse
+import com.hermesandroid.relay.network.relay.RelayHttpClient.OpenCodeUsageWindow
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Inline card that shows the OpenCode Go subscription usage — the 5-hour
+ * (rolling), weekly, and monthly windows — as progress bars with the dollar
+ * amount used, the window cap, and a live "resets in …" countdown.
+ *
+ * The data is proxied by the relay host (`GET /usage/opencode`): the OpenCode
+ * Go API key stays in `~/.hermes/.env` on the Mac and never reaches the device.
+ * Fetches on first composition and on every refresh tap. Renders distinct
+ * empty / loading / error / loaded states and degrades gracefully when the
+ * relay isn't configured or isn't paired yet.
+ */
+@Composable
+fun OpenCodeQuotaCard(
+    relayHttpClient: RelayHttpClient,
+    modifier: Modifier = Modifier,
+) {
+    var refreshKey by remember { mutableIntStateOf(0) }
+    var state by remember { mutableStateOf<QuotaUiState>(QuotaUiState.Empty) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(refreshKey) {
+        state = QuotaUiState.Loading
+        state = relayHttpClient.fetchOpenCodeUsage().fold(
+            onSuccess = { it?.let(QuotaUiState::Loaded) ?: QuotaUiState.NotApplicable },
+            onFailure = { QuotaUiState.Error(it.message ?: "Unknown error") },
+        )
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.open_code_quota_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource(R.string.open_code_quota_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = {
+                    scope.launch { refreshKey++ }
+                }) {
+                    Icon(
+                        imageVector = Icons.Filled.Refresh,
+                        contentDescription = stringResource(R.string.open_code_quota_refresh),
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            when (val s = state) {
+                is QuotaUiState.Empty -> {}
+                is QuotaUiState.Loading -> LoadingRow()
+                is QuotaUiState.NotApplicable -> NotApplicableRow()
+                is QuotaUiState.Error -> ErrorRow(
+                    message = s.message,
+                    onRetry = { scope.launch { refreshKey++ } },
+                )
+                is QuotaUiState.Loaded -> LoadedBody(s.response)
+            }
+        }
+    }
+}
+
+private sealed interface QuotaUiState {
+    data object Empty : QuotaUiState
+    data object Loading : QuotaUiState
+    data object NotApplicable : QuotaUiState
+    data class Error(val message: String) : QuotaUiState
+    data class Loaded(val response: OpenCodeUsageResponse) : QuotaUiState
+}
+
+@Composable
+private fun LoadingRow() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+        Text(
+            text = stringResource(R.string.open_code_quota_loading),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun NotApplicableRow() {
+    Text(
+        text = stringResource(R.string.open_code_quota_not_configured),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun ErrorRow(message: String, onRetry: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        val (line, isEnvironmental) = when {
+            message.contains("Relay URL not configured") ->
+                stringResource(R.string.open_code_quota_unconfigured) to true
+            message.contains("Relay not paired") ->
+                stringResource(R.string.open_code_quota_unpaired) to true
+            else -> stringResource(R.string.open_code_quota_error) to false
+        }
+        Text(
+            text = line,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (!isEnvironmental) {
+            TextButton(onClick = onRetry) {
+                Text(stringResource(R.string.open_code_quota_retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadedBody(response: OpenCodeUsageResponse) {
+    val usage = response.usage
+    val rows = mutableListOf<QuotaRow>()
+    listOf(
+        Triple("rolling", usage.rolling, R.string.open_code_quota_rolling),
+        Triple("weekly", usage.weekly, R.string.open_code_quota_weekly),
+        Triple("monthly", usage.monthly, R.string.open_code_quota_monthly),
+    ).forEach { (key, window, labelRes) ->
+        val limit = response.limits[key as String] ?: OpenCodeUsageLimit()
+        rows.add(
+            QuotaRow(
+                title = stringResource(labelRes),
+                limit = limit.limit ?: 0.0,
+                window = window,
+            )
+        )
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+        rows.forEach { QuotaWindowRow(it) }
+    }
+}
+
+private data class QuotaRow(
+    val title: String,
+    val limit: Double,
+    val window: OpenCodeUsageWindow?,
+)
+
+@Composable
+private fun QuotaWindowRow(row: QuotaRow) {
+    val now = remember { Instant.now() }
+    val percent = (row.window?.percent ?: 0).coerceIn(0, 100)
+    val used = percent / 100.0 * row.limit
+    val fraction = percent / 100f
+
+    val barColor = when {
+        percent >= 80 -> MaterialTheme.colorScheme.error
+        percent >= 50 -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.primary
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = row.title,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+            )
+            val usedText = if (row.limit > 0.0) {
+                stringResource(
+                    R.string.open_code_quota_used_of,
+                    formatMoney(used),
+                    formatMoney(row.limit),
+                )
+            } else {
+                "$percent%"
+            }
+            Text(
+                text = usedText,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                color = if (percent >= 80) MaterialTheme.colorScheme.error
+                else MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        LinearProgressIndicator(
+            progress = { fraction },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp),
+            color = barColor,
+            trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        )
+
+        val resets = row.window?.resetsAt?.let { formatResetsIn(it, now) }
+        if (resets != null) {
+            Text(
+                text = stringResource(R.string.open_code_quota_resets, resets),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** "$1,234" / "$12.50" style helper — whole dollars render without decimals. */
+private fun formatMoney(value: Double): String {
+    if (value <= 0.0) return "0"
+    if (value == value.toLong().toDouble()) return value.toLong().toString()
+    val rounded = Math.round(value * 100.0) / 100.0
+    return if (rounded == rounded.toLong().toDouble()) {
+        rounded.toLong().toString()
+    } else {
+        String.format("%.2f", rounded)
+    }
+}
+
+/** Render an ISO-8601 reset timestamp as a human "Xd Xh" / "Xh Xm" / "Xm" string. */
+private fun formatResetsIn(iso: String, from: Instant): String? {
+    return runCatching {
+        val reset = Instant.parse(iso)
+        val remaining = Duration.between(from, reset)
+        if (remaining.isNegative) return@runCatching "now"
+        val days = remaining.toDays()
+        val hours = remaining.toHours() % 24
+        val minutes = remaining.toMinutes() % 60
+        when {
+            days > 0 -> "${days}d ${hours}h"
+            hours > 0 -> "${hours}h ${minutes}m"
+            else -> "${minutes}m"
+        }
+    }.getOrNull()
+}

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/SettingsScreen.kt
@@ -101,6 +101,7 @@ import com.hermesandroid.relay.network.upstream.GatewayAvailability
 import com.hermesandroid.relay.ui.components.AgentAvatarFace
 import com.hermesandroid.relay.ui.components.AgentInfoSheet
 import com.hermesandroid.relay.ui.components.LocalAgentIconPath
+import com.hermesandroid.relay.ui.components.OpenCodeQuotaCard
 import com.hermesandroid.relay.ui.components.ProfileInspectorCard
 import com.hermesandroid.relay.ui.components.pet.LocalPetCompanionCoordinator
 import com.hermesandroid.relay.ui.components.pet.petObstacleSurface
@@ -449,6 +450,17 @@ fun SettingsScreen(
                 connectionViewModel = connectionViewModel,
                 isDarkTheme = isDarkTheme,
                 modifier = Modifier.settingsPetSurface("settings-card:quick-controls"),
+            )
+
+            // ── OpenCode Go subscription usage ──────────────────────────
+            // Inline card that proxies the OpenCode Go quota (5h / weekly /
+            // monthly) through the relay host. The API key stays on the Mac;
+            // the phone just renders what the relay returns. Fetches on
+            // composition + on refresh tap, degrades gracefully when the relay
+            // isn't configured or paired yet.
+            OpenCodeQuotaCard(
+                relayHttpClient = connectionViewModel.relayHttpClient,
+                modifier = Modifier.settingsPetSurface("settings-card:opencode-quota"),
             )
 
             // (The "Active Connection quick-look card" that used to live

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -4011,4 +4011,18 @@
     <string name="host_resource_memory_elevated">A memória do servidor está baixa.</string>
     <string name="host_resource_disk_critical">O armazenamento do servidor está criticamente baixo; mensagens e configurações podem não ser salvas.</string>
     <string name="host_resource_disk_elevated">O armazenamento do servidor está baixo.</string>
+    <string name="open_code_quota_title">Assinatura do OpenCode Go</string>
+    <string name="open_code_quota_subtitle">Uso nas suas janelas de 5 horas, semanal e mensal</string>
+    <string name="open_code_quota_refresh">Atualizar uso</string>
+    <string name="open_code_quota_loading">Buscando uso…</string>
+    <string name="open_code_quota_unconfigured">Relay não configurado — configure uma conexão para ver o uso da assinatura.</string>
+    <string name="open_code_quota_unpaired">Aguardando pareamento com o relay.</string>
+    <string name="open_code_quota_not_configured">Cota do OpenCode Go indisponível neste host.</string>
+    <string name="open_code_quota_error">Não foi possível carregar o uso</string>
+    <string name="open_code_quota_retry">Tentar novamente</string>
+    <string name="open_code_quota_resets">É redefinido em %1$s</string>
+    <string name="open_code_quota_used_of">$%1$s de $%2$s</string>
+    <string name="open_code_quota_rolling">Contínuo · 5h</string>
+    <string name="open_code_quota_weekly">Semanal</string>
+    <string name="open_code_quota_monthly">Mensal</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -4096,4 +4096,18 @@
     <string name="host_resource_memory_elevated">主机内存不足。</string>
     <string name="host_resource_disk_critical">主机存储空间严重不足，消息和设置可能无法保存。</string>
     <string name="host_resource_disk_elevated">主机存储空间不足。</string>
+    <string name="open_code_quota_title">OpenCode Go 订阅</string>
+    <string name="open_code_quota_subtitle">5小示、每周和每月窗口的使用情况</string>
+    <string name="open_code_quota_refresh">刷新使用情况</string>
+    <string name="open_code_quota_loading">正在获取使用情况…</string>
+    <string name="open_code_quota_unconfigured">Relay 未配置 — 设置连接以查看订阅使用情况。</string>
+    <string name="open_code_quota_unpaired">正在等待与 Relay 配对。</string>
+    <string name="open_code_quota_not_configured">此主机上无法使用 OpenCode Go 配额。</string>
+    <string name="open_code_quota_error">无法加载使用情况</string>
+    <string name="open_code_quota_retry">重试</string>
+    <string name="open_code_quota_resets">%1$s后重置</string>
+    <string name="open_code_quota_used_of">$%1$s / $%2$s</string>
+    <string name="open_code_quota_rolling">滚动 · 5小时</string>
+    <string name="open_code_quota_weekly">每周</string>
+    <string name="open_code_quota_monthly">每月</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -4171,4 +4171,18 @@
     <string name="host_resource_memory_elevated">Der Arbeitsspeicher des Hosts wird knapp.</string>
     <string name="host_resource_disk_critical">Der Speicherplatz des Hosts ist äußerst knapp; Nachrichten und Einstellungen können möglicherweise nicht gespeichert werden.</string>
     <string name="host_resource_disk_elevated">Der Speicherplatz des Hosts wird knapp.</string>
+    <string name="open_code_quota_title">OpenCode-Go-Abo</string>
+    <string name="open_code_quota_subtitle">Verbrauch über Ihre 5-Stunden-, Wochen- und Monatsfenster</string>
+    <string name="open_code_quota_refresh">Verbrauch aktualisieren</string>
+    <string name="open_code_quota_loading">Verbrauch wird abgerufen…</string>
+    <string name="open_code_quota_unconfigured">Relay nicht konfiguriert – richten Sie eine Verbindung ein, um den Abo-Verbrauch zu sehen.</string>
+    <string name="open_code_quota_unpaired">Warten auf Kopplung mit dem Relay.</string>
+    <string name="open_code_quota_not_configured">OpenCode-Go-Kontingent auf diesem Host nicht verfügbar.</string>
+    <string name="open_code_quota_error">Verbrauch konnte nicht geladen werden</string>
+    <string name="open_code_quota_retry">Erneut versuchen</string>
+    <string name="open_code_quota_resets">Setzt zurück in %1$s</string>
+    <string name="open_code_quota_used_of">$%1$s von $%2$s</string>
+    <string name="open_code_quota_rolling">Rollierend · 5h</string>
+    <string name="open_code_quota_weekly">Wöchentlich</string>
+    <string name="open_code_quota_monthly">Monatlich</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3856,4 +3856,18 @@
     <string name="host_resource_memory_elevated">La memoria del servidor se está agotando.</string>
     <string name="host_resource_disk_critical">El almacenamiento del servidor está casi agotado; puede que los mensajes y ajustes no se guarden.</string>
     <string name="host_resource_disk_elevated">El almacenamiento del servidor se está agotando.</string>
+    <string name="open_code_quota_title">Suscripción a OpenCode Go</string>
+    <string name="open_code_quota_subtitle">Uso en tus ventanas de 5 horas, semanal y mensual</string>
+    <string name="open_code_quota_refresh">Actualizar uso</string>
+    <string name="open_code_quota_loading">Obteniendo uso…</string>
+    <string name="open_code_quota_unconfigured">Relay no configurado — configura una conexión para ver el uso de la suscripción.</string>
+    <string name="open_code_quota_unpaired">Esperando para emparejarse con el relay.</string>
+    <string name="open_code_quota_not_configured">Cuota de OpenCode Go no disponible en este host.</string>
+    <string name="open_code_quota_error">No se pudo cargar el uso</string>
+    <string name="open_code_quota_retry">Reintentar</string>
+    <string name="open_code_quota_resets">Se restablece en %1$s</string>
+    <string name="open_code_quota_used_of">$%1$s de $%2$s</string>
+    <string name="open_code_quota_rolling">Rotatorio · 5h</string>
+    <string name="open_code_quota_weekly">Semanal</string>
+    <string name="open_code_quota_monthly">Mensual</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4169,4 +4169,18 @@
     <string name="host_resource_memory_elevated">ホストのメモリが不足しています。</string>
     <string name="host_resource_disk_critical">ホストのストレージが極端に不足しています。メッセージや設定を保存できない可能性があります。</string>
     <string name="host_resource_disk_elevated">ホストのストレージが不足しています。</string>
+    <string name="open_code_quota_title">OpenCode Go サブスクリプション</string>
+    <string name="open_code_quota_subtitle">5時間・週間・月間の各ウィンドウでの使用量</string>
+    <string name="open_code_quota_refresh">使用量を更新</string>
+    <string name="open_code_quota_loading">使用量を取得中…</string>
+    <string name="open_code_quota_unconfigured">リレーが設定されていません — 接続を設定するとサブスクリプションの使用量を確認できます。</string>
+    <string name="open_code_quota_unpaired">リレーとのペアリングを待機中。</string>
+    <string name="open_code_quota_not_configured">このホストでは OpenCode Go のクォータを利用できません。</string>
+    <string name="open_code_quota_error">使用量を読み込めませんでした</string>
+    <string name="open_code_quota_retry">リトライ</string>
+    <string name="open_code_quota_resets">%1$s後にリセット</string>
+    <string name="open_code_quota_used_of">$%1$s / $%2$s</string>
+    <string name="open_code_quota_rolling">ローリング · 5h</string>
+    <string name="open_code_quota_weekly">週間</string>
+    <string name="open_code_quota_monthly">月間</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -3898,4 +3898,18 @@
     <string name="host_resource_memory_elevated">Память хоста заканчивается.</string>
     <string name="host_resource_disk_critical">Хранилище хоста почти заполнено; сообщения и настройки могут не сохраниться.</string>
     <string name="host_resource_disk_elevated">Хранилище хоста заканчивается.</string>
+    <string name="open_code_quota_title">Подписка OpenCode Go</string>
+    <string name="open_code_quota_subtitle">Использование в окнах: 5 часов, недельный и месячный</string>
+    <string name="open_code_quota_refresh">Обновить использование</string>
+    <string name="open_code_quota_loading">Загрузка использования…</string>
+    <string name="open_code_quota_unconfigured">Relay не настроен — настройте подключение, чтобы видеть использование подписки.</string>
+    <string name="open_code_quota_unpaired">Ожидание сопряжения с relay.</string>
+    <string name="open_code_quota_not_configured">Квота OpenCode Go недоступна на этом хосте.</string>
+    <string name="open_code_quota_error">Не удалось загрузить использование</string>
+    <string name="open_code_quota_retry">Повторить</string>
+    <string name="open_code_quota_resets">Сброс через %1$s</string>
+    <string name="open_code_quota_used_of">$%1$s из $%2$s</string>
+    <string name="open_code_quota_rolling">Скользящее · 5ч</string>
+    <string name="open_code_quota_weekly">Недельный</string>
+    <string name="open_code_quota_monthly">Месячный</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4177,4 +4177,18 @@
     <string name="host_resource_memory_elevated">Host memory is running low.</string>
     <string name="host_resource_disk_critical">Host storage is critically low; messages and settings may fail to save.</string>
     <string name="host_resource_disk_elevated">Host storage is running low.</string>
+    <string name="open_code_quota_title">OpenCode Go subscription</string>
+    <string name="open_code_quota_subtitle">Usage across your 5-hour, weekly, and monthly windows</string>
+    <string name="open_code_quota_refresh">Refresh usage</string>
+    <string name="open_code_quota_loading">Fetching usage…</string>
+    <string name="open_code_quota_unconfigured">Relay not configured — set up a connection to see subscription usage.</string>
+    <string name="open_code_quota_unpaired">Waiting to pair with the relay.</string>
+    <string name="open_code_quota_not_configured">OpenCode Go quota not available on this host.</string>
+    <string name="open_code_quota_error">Couldn\'t load usage</string>
+    <string name="open_code_quota_retry">Retry</string>
+    <string name="open_code_quota_resets">Resets in %1$s</string>
+    <string name="open_code_quota_used_of">$%1$s of $%2$s</string>
+    <string name="open_code_quota_rolling">Rolling · 5h</string>
+    <string name="open_code_quota_weekly">Weekly</string>
+    <string name="open_code_quota_monthly">Monthly</string>
 </resources>

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClientOpenCodeUsageTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/relay/RelayHttpClientOpenCodeUsageTest.kt
@@ -1,0 +1,108 @@
+package com.hermesandroid.relay.network.relay
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RelayHttpClientOpenCodeUsageTest {
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun parsesWindowsAndLimitsAndAuthenticates() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "usage": {
+                    "rolling": {"status": "ok", "percent": 42, "resetsAt": "2026-08-20T05:00:00Z"},
+                    "weekly": {"status": "ok", "percent": 18, "resetsAt": "2026-08-24T00:00:00Z"},
+                    "monthly": {"status": "ok", "percent": 55, "resetsAt": "2026-09-01T00:00:00Z"}
+                  },
+                  "limits": {
+                    "rolling": {"label": "5h", "limit": 12.0},
+                    "weekly": {"label": "weekly", "limit": 30.0},
+                    "monthly": {"label": "monthly", "limit": 60.0}
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        val response = client(token = "paired-token").fetchOpenCodeUsage().getOrThrow()!!
+        val request = server.takeRequest()
+
+        assertEquals("/usage/opencode", request.path)
+        assertEquals("Bearer paired-token", request.getHeader("Authorization"))
+        assertEquals("application/json", request.getHeader("Accept"))
+
+        assertEquals(42, response.usage.rolling?.percent)
+        assertEquals(18, response.usage.weekly?.percent)
+        assertEquals(55, response.usage.monthly?.percent)
+        assertEquals("2026-08-24T00:00:00Z", response.usage.weekly?.resetsAt)
+
+        assertEquals(12.0, response.limits["rolling"]?.limit ?: 0.0, 0.001)
+        assertEquals(30.0, response.limits["weekly"]?.limit ?: 0.0, 0.001)
+        assertEquals(60.0, response.limits["monthly"]?.limit ?: 0.0, 0.001)
+        assertEquals("5h", response.limits["rolling"]?.label)
+    }
+
+    @Test
+    fun tolerateMissingWindowsThreshold() = runTest {
+        // A partially-populated payload must still decode (all optional).
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"usage":{},"limits":{}}"""),
+        )
+        val response = client(token = "paired-token").fetchOpenCodeUsage().getOrThrow()!!
+        assertNotNull(response.usage)
+        assertTrue(response.limits.isEmpty())
+    }
+
+    @Test
+    fun unauthorizedBecomesFailure() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401))
+        val failure = client(token = "paired-token").fetchOpenCodeUsage()
+        assertTrue(failure.isFailure)
+    }
+
+    @Test
+    fun notConfiguredOnHostIsNullSuccess() = runTest {
+        // Relay returns 404 when OpenCode Go isn't configured on the host.
+        // The client treats that as a normal "feature not applicable" state
+        // (null success), not an error — the UI shows a quiet note, not retry.
+        server.enqueue(MockResponse().setResponseCode(404))
+        val response = client(token = "paired-token").fetchOpenCodeUsage()
+        assertTrue(response.isSuccess)
+        assertTrue(response.getOrNull() == null)
+    }
+
+    @Test
+    fun unpairedDoesNotHitServer() = runTest {
+        val failure = client(token = null).fetchOpenCodeUsage()
+        assertTrue(failure.isFailure)
+        assertEquals(0, server.requestCount)
+    }
+
+    private fun client(token: String?) = RelayHttpClient(
+        okHttpClient = OkHttpClient(),
+        relayUrlProvider = { server.url("/").toString() },
+        sessionTokenProvider = { token },
+    )
+}

--- a/plugin/relay/server.py
+++ b/plugin/relay/server.py
@@ -1172,6 +1172,98 @@ async def handle_sessions_extend(request: web.Request) -> web.Response:
     )
 
 
+# ── OpenCode Go subscription usage proxy ─────────────────────────────────────
+
+# The OpenCode Go upstream usage endpoint returns, per window, only the used
+# fraction (`percent`) and the reset time (`resetsAt`). The dollar caps for the
+# three subscription windows live in the product ($12 / $30 / $60) but are not
+# echoed back, so we carry them here — single source of truth shared with the
+# phone — so the client can render "$X of $Y used" without hardcoding numbers.
+_OPENCODE_GO_USAGE_WINDOWS: dict[str, dict[str, Any]] = {
+    "rolling": {"label": "5h", "limit": 12.0},
+    "weekly": {"label": "weekly", "limit": 30.0},
+    "monthly": {"label": "monthly", "limit": 60.0},
+}
+_OPENCODE_GO_DEFAULT_BASE_URL = "https://opencode.ai/zen/go/v1"
+# The upstream endpoint 403s on non-curl User-Agents (blocked for everyone
+# except curl-like clients) — mirror the skill's documented workaround.
+_OPENCODE_GO_UA = "curl/8.4.0"
+
+
+async def handle_opencode_usage(request: web.Request) -> web.Response:
+    """Proxy the OpenCode Go subscription usage endpoint for the phone.
+
+    GET /usage/opencode
+      → 200 {"usage": {"rolling": {...}, "weekly": {...}, "monthly": {...}},
+             "limits": {...}}
+      → 401 missing/invalid bearer
+      → 404 OpenCode Go not configured on this host (normal — feature N/A)
+      → 502 upstream unreachable / non-200 / malformed payload
+
+    The phone never sees the OpenCode Go API key — it stays in
+    ``~/.hermes/.env`` on this host (loaded at bootstrap) and is used only to
+    authenticate the upstream ``GET <base>/usage`` call. The response mirrors
+    the upstream per-window shape (``{status, percent, resetsAt}``) and augments
+    it with ``limits`` (the dollar caps + human labels) so the client can render
+    progress bars without coupling to subscription pricing.
+    """
+    # Only a paired/authenticated relay session may read usage.
+    _require_bearer_session(request)
+
+    api_key = os.environ.get("OPENCODE_GO_API_KEY")
+    if not api_key:
+        # This host doesn't run OpenCode Go (no key configured), so the quota
+        # endpoint is simply not applicable here — a clean 404 (matching the
+        # "optional feature not supported on this host" convention used by
+        # e.g. /chat/image-activity), NOT a 500. The phone renders this as a
+        # quiet "not available" state instead of an error.
+        raise web.HTTPNotFound(text="opencode-go not configured on this host")
+
+    base_url = (
+        os.environ.get("OPENCODE_GO_BASE_URL") or _OPENCODE_GO_DEFAULT_BASE_URL
+    ).rstrip("/")
+    url = f"{base_url}/usage"
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": _OPENCODE_GO_UA,
+                },
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status != 200:
+                    body = (await resp.text()).strip()[:200]
+                    logger.warning(
+                        "OpenCode Go usage upstream HTTP %s: %s", resp.status, body
+                    )
+                    return web.json_response(
+                        {"ok": False, "error": f"upstream HTTP {resp.status}"},
+                        status=502,
+                    )
+                payload = await resp.json()
+    except asyncio.TimeoutError:
+        return web.json_response({"ok": False, "error": "upstream timeout"}, status=502)
+    except (aiohttp.ClientError, ValueError, json.JSONDecodeError) as exc:
+        logger.warning("OpenCode Go usage upstream error: %s", exc)
+        return web.json_response({"ok": False, "error": "upstream unreachable"}, status=502)
+
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        return web.json_response(
+            {"ok": False, "error": "unexpected upstream payload"}, status=502
+        )
+
+    return web.json_response(
+        {
+            "usage": usage,
+            "limits": _OPENCODE_GO_USAGE_WINDOWS,
+        }
+    )
+
+
 # ── Desktop tool dispatch (loopback HTTP shim for desktop_tool.py) ──────────
 
 
@@ -4682,6 +4774,7 @@ def create_app(config: RelayConfig) -> web.Application:
     app.router.add_get("/sessions", handle_sessions_list)
     app.router.add_delete("/sessions/{token_prefix}", handle_sessions_revoke)
     app.router.add_patch("/sessions/{token_prefix}", handle_sessions_extend)
+    app.router.add_get("/usage/opencode", handle_opencode_usage)
     app.router.add_get("/chat/image-activity", handle_image_activity)
     # Desktop tool dispatch — HTTP shim called by `plugin/tools/desktop_tool.py`
     # running inside hermes-gateway. Both endpoints loopback-only.

--- a/plugin/tests/test_opencode_usage.py
+++ b/plugin/tests/test_opencode_usage.py
@@ -1,0 +1,135 @@
+"""Tests for GET /usage/opencode (OpenCode Go subscription usage proxy).
+
+The endpoint is a thin authenticated proxy: the phone sends its relay bearer
+token, and the server reads ``OPENCODE_GO_API_KEY`` from ``~/.hermes/.env``,
+calls the upstream OpenCode Go usage API, and returns the per-window usage plus
+the dollar caps. The API key must never appear in the response.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase
+
+from plugin.relay.config import RelayConfig
+from plugin.relay.server import create_app
+
+_SAMPLE_UPSTREAM: dict = {
+    "usage": {
+        "rolling": {"status": "ok", "percent": 42, "resetsAt": "2026-08-20T05:00:00Z"},
+        "weekly": {"status": "ok", "percent": 18, "resetsAt": "2026-08-24T00:00:00Z"},
+        "monthly": {"status": "ok", "percent": 55, "resetsAt": "2026-09-01T00:00:00Z"},
+    }
+}
+
+
+class _FakeResponse:
+    def __init__(self, status: int = 200, payload: dict | None = None, text: str = ""):
+        self.status = status
+        self._payload = payload if payload is not None else _SAMPLE_UPSTREAM
+        self._text = text
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def json(self) -> dict:
+        return self._payload
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+        self.last_get: tuple[str, dict | None] | None = None
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    def get(self, url: str, headers: dict | None = None, timeout=None) -> _FakeResponse:
+        self.last_get = (url, headers)
+        return self._response
+
+
+class OpenCodeUsageTests(AioHTTPTestCase):
+    async def get_application(self) -> web.Application:
+        config = RelayConfig()
+        return create_app(config)
+
+    def _server(self):
+        return self.app["server"]
+
+    async def _mint(self, name: str = "dev") -> str:
+        session = self._server().sessions.create_session(name, name + "-id")
+        return session.token
+
+    @mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
+    async def test_requires_bearer(self) -> None:
+        resp = await self.client.get("/usage/opencode")
+        self.assertEqual(resp.status, 401)
+        resp = await self.client.get(
+            "/usage/opencode", headers={"Authorization": "Bearer nope"}
+        )
+        self.assertEqual(resp.status, 401)
+
+    async def test_missing_key_returns_404(self) -> None:
+        token = await self._mint()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("OPENCODE_GO_API_KEY", None)
+            resp = await self.client.get(
+                "/usage/opencode", headers={"Authorization": f"Bearer {token}"}
+            )
+        # 404 = OpenCode Go simply not configured on this host (feature N/A),
+        # NOT a 500 — the phone renders this as a quiet "not available".
+        self.assertEqual(resp.status, 404)
+
+    @mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
+    async def test_proxies_usage_to_paired_bearer(self) -> None:
+        token = await self._mint()
+        fake = _FakeSession(_FakeResponse(200))
+        with mock.patch(
+            "plugin.relay.server.aiohttp.ClientSession", return_value=fake
+        ):
+            resp = await self.client.get(
+                "/usage/opencode", headers={"Authorization": f"Bearer {token}"}
+            )
+        self.assertEqual(resp.status, 200)
+        body = await resp.json()
+        self.assertEqual(body["usage"], _SAMPLE_UPSTREAM["usage"])
+        self.assertEqual(body["limits"]["rolling"]["limit"], 12.0)
+        self.assertEqual(body["limits"]["weekly"]["limit"], 30.0)
+        self.assertEqual(body["limits"]["monthly"]["limit"], 60.0)
+        # The API key must be forwarded upstream but never echoed back.
+        assert fake.last_get is not None
+        url, headers = fake.last_get
+        self.assertIn("/usage", url)
+        self.assertEqual(headers["Authorization"], "Bearer test-key")
+        self.assertEqual(headers["User-Agent"], "curl/8.4.0")
+        self.assertNotIn("test-key", body)
+
+    @mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
+    async def test_upstream_500_propagates_502(self) -> None:
+        token = await self._mint()
+        fake = _FakeSession(_FakeResponse(500, text="boom"))
+        with mock.patch(
+            "plugin.relay.server.aiohttp.ClientSession", return_value=fake
+        ):
+            resp = await self.client.get(
+                "/usage/opencode", headers={"Authorization": f"Bearer {token}"}
+            )
+        self.assertEqual(resp.status, 502)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds an inline **Settings** card showing your **OpenCode Go** subscription quota across its three windows — 5-hour (rolling), weekly, and monthly — rendered as progress bars with dollars used, the window cap, and a "resets in …" countdown.

## How it works
- **The phone never sees the API key.** The relay host proxies `GET /usage/opencode`, authenticated to a paired relay session (the same bearer the app already uses for `/sessions`, `/media`, etc.). It reads `OPENCODE_GO_API_KEY` / `OPENCODE_GO_BASE_URL` from the host `.env` and returns `{usage: {rolling, weekly, monthly}, limits: {...}}`.
- **No data on hosts without OpenCode Go.** If the key isn't configured, the relay returns `404` (matching the existing "optional feature not supported on this host" convention, e.g. `/chat/image-activity`); the app renders a quiet "OpenCode Go quota not available on this host" line instead of an error.
- **Graceful failure** for an unconfigured/unpaired relay: distinct loading / not-applicable / error(+retry) / loaded states.

## Changes
**Server** (`plugin/relay/server.py`)
- New `GET /usage/opencode` handler — bearer-required, `404` when the key is absent, `502` on upstream failure — plus route registration.

**Android**
- `RelayHttpClient.fetchOpenCodeUsage()` + serializable models (`OpenCodeUsageResponse / Windows / Window / Limit`).
- New `OpenCodeQuotaCard` composable wired into Settings.
- Localized strings for en / de / es / ja / ru / pt-BR / zh-Hans.

**Tests**
- Server: `plugin/tests/test_opencode_usage.py` (4 cases).
- Client: `RelayHttpClientOpenCodeUsageTest` (5 cases).

## Verification
Relay route + auth, upstream data shape, server + client unit tests, and `./gradlew lint` all pass.
