### PR TITLE
chore(ci): commission review candidate reporting

### DIFF
--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -1,0 +1,169 @@
+'use strict';
+
+const COMMENT_MARKER = '<!-- hermes-relay-review-candidate -->';
+const ARTIFACT_NAME_RE = /^hermes-relay-review-pr-(\d+)-([0-9a-f]{12})$/;
+
+function formatExpiry(value) {
+  if (!value) return 'the artifact retention window';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+function buildReviewComment({ conclusion, prNumber, headSha, runUrl, artifact }) {
+  const shortSha = headSha.slice(0, 12);
+
+  if (conclusion === 'success' && artifact) {
+    const artifactUrl = `${runUrl}/artifacts/${artifact.id}`;
+    return `${COMMENT_MARKER}
+## Review candidate ready
+
+Built from PR #${prNumber} head \`${shortSha}\`.
+
+[Download \`${artifact.name}\`](${artifactUrl}) — expires **${formatExpiry(artifact.expires_at)}**.
+
+1. Unzip the bundle and verify its files against \`SHA256SUMS.txt\`.
+2. Install the APK under \`android/\`. It appears as **Hermes Candidate**, leaves stable installs untouched, and must be paired separately.
+3. Test the Relay package only in a disposable/staging Hermes instance or with an explicit snapshot and rollback plan. Confirm the source SHA in \`REVIEW_MANIFEST.json\`.
+
+[View workflow run](${runUrl})`;
+  }
+
+  if (conclusion === 'action_required') {
+    return `${COMMENT_MARKER}
+## Review candidate awaiting approval
+
+GitHub held the build for PR #${prNumber} head \`${shortSha}\` at the first-time fork approval gate. A maintainer must approve the run before any candidate can be published.
+
+[Review and approve the workflow run](${runUrl})`;
+  }
+
+  const result = conclusion || 'unknown';
+  return `${COMMENT_MARKER}
+## Review candidate unavailable
+
+The build for PR #${prNumber} head \`${shortSha}\` completed with **${result}** and did not publish a candidate bundle.
+
+[View workflow run](${runUrl})`;
+}
+
+function artifactPrNumber(artifacts, headSha) {
+  const shortSha = headSha.slice(0, 12);
+  for (const artifact of artifacts) {
+    const match = ARTIFACT_NAME_RE.exec(artifact.name);
+    if (match && match[2] === shortSha) return Number(match[1]);
+  }
+  return null;
+}
+
+async function resolvePrNumber({ github, owner, repo, run, artifacts }) {
+  const payloadPr = run.pull_requests?.[0]?.number;
+  if (payloadPr) return payloadPr;
+
+  const artifactPr = artifactPrNumber(artifacts, run.head_sha);
+  if (artifactPr) return artifactPr;
+
+  const headOwner = run.head_repository?.owner?.login;
+  if (!headOwner || !run.head_branch) return null;
+
+  const { data: pulls } = await github.rest.pulls.list({
+    owner,
+    repo,
+    head: `${headOwner}:${run.head_branch}`,
+    state: 'all',
+    per_page: 100,
+  });
+  const exact = pulls.find((pull) =>
+    pull.head.sha === run.head_sha && pull.base.ref === 'dev'
+  );
+  return exact?.number ?? null;
+}
+
+async function resolveWorkflowRun({ github, context, core }) {
+  const completedRun = context.payload.workflow_run;
+  if (completedRun) return completedRun;
+
+  const requested = context.payload.inputs?.run_id;
+  const runId = Number(requested);
+  if (!Number.isSafeInteger(runId) || runId <= 0) {
+    core.setFailed(`Invalid Build Review Bundle run ID: ${requested ?? ''}`);
+    return null;
+  }
+  const { owner, repo } = context.repo;
+  const { data: run } = await github.rest.actions.getWorkflowRun({
+    owner,
+    repo,
+    run_id: runId,
+  });
+  return run;
+}
+
+async function reportReviewBundle({ github, context, core }) {
+  const run = await resolveWorkflowRun({ github, context, core });
+  const { owner, repo } = context.repo;
+  if (!run) return;
+  if (run.name !== 'Build Review Bundle' || run.event !== 'pull_request') {
+    core.info('Ignoring a review-bundle run that was not triggered by a pull request.');
+    return;
+  }
+
+  const artifacts = await github.paginate(
+    github.rest.actions.listWorkflowRunArtifacts,
+    { owner, repo, run_id: run.id, per_page: 100 },
+  );
+  const prNumber = await resolvePrNumber({ github, owner, repo, run, artifacts });
+  if (!prNumber) {
+    core.warning(`Could not resolve a pull request for review-bundle run ${run.id}.`);
+    return;
+  }
+
+  const expectedName = `hermes-relay-review-pr-${prNumber}-${run.head_sha.slice(0, 12)}`;
+  const artifact = artifacts.find((item) => item.name === expectedName && !item.expired);
+  const body = buildReviewComment({
+    conclusion: run.conclusion,
+    prNumber,
+    headSha: run.head_sha,
+    runUrl: run.html_url,
+    artifact,
+  });
+
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: prNumber, per_page: 100 },
+  );
+  const existing = comments.find((comment) =>
+    comment.user?.login === 'github-actions[bot]' &&
+    comment.body?.includes(COMMENT_MARKER)
+  );
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    core.info(`Updated review-candidate comment on PR #${prNumber}.`);
+  } else {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+    core.info(`Created review-candidate comment on PR #${prNumber}.`);
+  }
+}
+
+module.exports = {
+  ARTIFACT_NAME_RE,
+  COMMENT_MARKER,
+  artifactPrNumber,
+  buildReviewComment,
+  reportReviewBundle,
+  resolvePrNumber,
+  resolveWorkflowRun,
+};

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -1,0 +1,145 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+  artifactPrNumber,
+  buildReviewComment,
+  reportReviewBundle,
+} = require('./review-bundle-report.cjs');
+
+const run = {
+  id: 32729383426,
+  name: 'Build Review Bundle',
+  event: 'pull_request',
+  conclusion: 'success',
+  head_sha: '90ab705a883ca963035f4f8ccda815619dbd4f3b',
+  head_branch: 'fix/gateway-history-attachments',
+  head_repository: { owner: { login: 'JackHunzicker' } },
+  html_url: 'https://github.com/Codename-11/hermes-relay/actions/runs/32729383426',
+  pull_requests: [],
+};
+const artifact = {
+  id: 9521126010,
+  name: 'hermes-relay-review-pr-398-90ab705a883c',
+  expired: false,
+  expires_at: '2026-08-31T12:52:24Z',
+};
+
+assert.equal(artifactPrNumber([artifact], run.head_sha), 398);
+
+const successBody = buildReviewComment({
+  conclusion: 'success',
+  prNumber: 398,
+  headSha: run.head_sha,
+  runUrl: run.html_url,
+  artifact,
+});
+assert.match(successBody, /## Review candidate ready/);
+assert.match(successBody, /hermes-relay-review-pr-398-90ab705a883c/);
+assert.match(successBody, /expires \*\*August 31, 2026\*\*/);
+assert.match(successBody, /Hermes Candidate/);
+assert.match(successBody, /REVIEW_MANIFEST\.json/);
+
+const blockedBody = buildReviewComment({
+  conclusion: 'action_required',
+  prNumber: 398,
+  headSha: run.head_sha,
+  runUrl: run.html_url,
+});
+assert.match(blockedBody, /## Review candidate awaiting approval/);
+assert.doesNotMatch(blockedBody, /Download/);
+
+async function testExistingCommentIsUpdated() {
+  const calls = { create: [], update: [] };
+  const github = {
+    rest: {
+      actions: { listWorkflowRunArtifacts() {} },
+      issues: {
+        listComments() {},
+        createComment: async (args) => calls.create.push(args),
+        updateComment: async (args) => calls.update.push(args),
+      },
+      pulls: { list: async () => ({ data: [] }) },
+    },
+    paginate: async (method) => {
+      if (method === github.rest.actions.listWorkflowRunArtifacts) return [artifact];
+      if (method === github.rest.issues.listComments) {
+        return [{
+          id: 77,
+          user: { login: 'github-actions[bot]' },
+          body: '<!-- hermes-relay-review-candidate -->\nold',
+        }];
+      }
+      throw new Error('Unexpected pagination method');
+    },
+  };
+  const messages = [];
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: { workflow_run: run },
+    },
+    core: {
+      info: (message) => messages.push(message),
+      warning: (message) => messages.push(message),
+    },
+  });
+  assert.equal(calls.create.length, 0);
+  assert.equal(calls.update.length, 1);
+  assert.equal(calls.update[0].comment_id, 77);
+  assert.match(calls.update[0].body, /## Review candidate ready/);
+  assert.deepEqual(messages, ['Updated review-candidate comment on PR #398.']);
+}
+
+async function testManualRunSelectionCreatesComment() {
+  const calls = { create: [], update: [] };
+  const github = {
+    rest: {
+      actions: {
+        getWorkflowRun: async ({ run_id: runId }) => {
+          assert.equal(runId, run.id);
+          return { data: run };
+        },
+        listWorkflowRunArtifacts() {},
+      },
+      issues: {
+        listComments() {},
+        createComment: async (args) => calls.create.push(args),
+        updateComment: async (args) => calls.update.push(args),
+      },
+      pulls: { list: async () => ({ data: [] }) },
+    },
+    paginate: async (method) => {
+      if (method === github.rest.actions.listWorkflowRunArtifacts) return [artifact];
+      if (method === github.rest.issues.listComments) return [];
+      throw new Error('Unexpected pagination method');
+    },
+  };
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: { inputs: { run_id: String(run.id) } },
+    },
+    core: {
+      info() {},
+      warning() {},
+      setFailed: (message) => assert.fail(message),
+    },
+  });
+  assert.equal(calls.update.length, 0);
+  assert.equal(calls.create.length, 1);
+  assert.equal(calls.create[0].issue_number, 398);
+  assert.match(calls.create[0].body, /## Review candidate ready/);
+}
+
+Promise.all([
+  testExistingCommentIsUpdated(),
+  testManualRunSelectionCreatesComment(),
+])
+  .then(() => console.log('Review-bundle report tests passed.'))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/.github/workflows/review-bundle-report.yml
+++ b/.github/workflows/review-bundle-report.yml
@@ -1,0 +1,55 @@
+name: Report Review Bundle
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Completed Build Review Bundle run ID to report
+        required: true
+        type: string
+  workflow_run:
+    workflows:
+      - Build Review Bundle
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: review-bundle-report-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'pull_request'
+      }}
+    name: Update pull request comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Check out only the trusted default branch. Never check out the PR head or
+      # execute/download its candidate artifact in this write-capable workflow.
+      - name: Checkout trusted reporter
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Test trusted reporter
+        run: node .github/scripts/review-bundle-report.test.cjs
+
+      - name: Report candidate status
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const reporter = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/review-bundle-report.cjs`
+            );
+            await reporter.reportReviewBundle({ github, context, core });

--- a/.github/workflows/review-bundle.yml
+++ b/.github/workflows/review-bundle.yml
@@ -6,6 +6,8 @@ on:
       - dev
     types:
       - labeled
+      - reopened
+      - synchronize
 
 permissions:
   contents: read
@@ -17,7 +19,11 @@ concurrency:
 
 jobs:
   resolve:
-    if: ${{ github.event.label.name == 'review-candidate' }}
+    if: >-
+      ${{
+        (github.event.action == 'labeled' && github.event.label.name == 'review-candidate') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'review-candidate'))
+      }}
     name: Resolve exact source
     runs-on: ubuntu-latest
     outputs:
@@ -29,7 +35,7 @@ jobs:
       source_kind: ${{ steps.source.outputs.source_kind }}
       source_value: ${{ steps.source.outputs.source_value }}
     steps:
-      - name: Resolve pull request or exact SHA
+      - name: Resolve exact pull request head
         id: source
         uses: actions/github-script@v8
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Review candidates are an explicit PR opt-in with one trusted handoff comment.** Maintainers can apply `review-candidate` for exact-head Android and Relay bundles; a separate reporter updates the PR with the artifact, expiry, source SHA, and bounded review instructions without executing fork code with write permission.
+
 ## [Android 1.12.1] - 2026-08-22
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,16 @@ scripts/dev.bat relay      # Start relay server (dev, no TLS)
 ### Review bundles
 
 Maintainers can produce a matched Android + Relay handoff for one pull request
-without cutting a release. Run **Actions → Build Review Bundle** with the PR
-number or an exact 40-character SHA. The short-lived artifact contains a
-side-by-side Candidate APK, Relay packages/source from the same commit,
-provenance, checksums, and install/rollback guidance.
+without cutting a release. Apply the `review-candidate` label to an open PR
+targeting `dev`. The short-lived artifact contains a side-by-side Candidate APK,
+Relay packages/source from the same exact PR commit, provenance, checksums, and
+install/rollback guidance. While the label remains applied, a new PR head commit
+automatically replaces any in-progress build with a bundle for the new head.
+For a first-time fork contributor, GitHub may hold the first run for explicit
+maintainer approval before any untrusted code executes.
+When the run completes, a separate trusted reporter creates or updates one PR
+comment with the exact source SHA, artifact link, expiry, and concise install and
+rollback guidance.
 
 Review bundles never bump versions, create tags, upload to Play, or replace the
 stable Android app. Relay review still requires a staging Hermes instance or an

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,19 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-24 — Review-candidate commissioning
+
+The repository label catalog now provisions `review-candidate` as the sole
+automation label for matched Android and Relay PR bundles. The unprivileged
+workflow rebuilds an opted-in PR when its exact head changes, while documentation
+now reflects the label-driven path instead of an unavailable manual dispatch.
+The first live bundle completed for PR #398 after GitHub's normal first-time fork
+approval gate; the downloaded manifest matched the PR head and all four packaged
+artifact checksums verified.
+A separate trusted completion reporter reads only run/artifact metadata, checks
+out only the default branch, and creates or updates one marked PR comment with
+the exact candidate link and bounded review instructions. It never checks out or
+executes fork code with write permission.
+
 ## 2026-08-23 — GitHub Discussions community surface
 
 GitHub Discussions is enabled as the repository's lightweight community surface.

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -84,7 +84,7 @@ branches can run concurrently. `ISSUE-BRIEF.md` is git-ignored. Tear down with
 
 ## Setup (one-time)
 
-The workflows can only apply labels that already exist. Create them once:
+Repository automation only recognizes labels that already exist. Create them once:
 
 ```bash
 gh label create "area:android"            -c "1d76db" -d "Kotlin app"
@@ -92,11 +92,15 @@ gh label create "area:cli"                -c "0e8a16" -d "desktop/ Node CLI"
 gh label create "area:plugin"             -c "fbca04" -d "plugin/ Python relay + tools"
 gh label create "area:dashboard"          -c "c5def5" -d "plugin/dashboard React UI"
 gh label create "area:docs"               -c "bfd4f2" -d "docs/ or user-docs/"
+gh label create "review-candidate"         -c "ffb300" -d "Build a side-by-side Android and Relay review bundle for this PR"
 ```
 
 ## Operational notes
 
 - **Manual issue labels.** Type and area labels are applied during maintainer
   triage; no issue-open workflow guesses ownership from keywords.
+- **Review-candidate PRs.** Applying `review-candidate` opts an open PR targeting
+  `dev` into exact-head Android and Relay review bundles until the label is
+  removed.
 - **No write-access escalation from issues.** Auto-attempting a fix from
   untrusted issue text remains intentionally out of scope.

--- a/docs/review-candidates.md
+++ b/docs/review-candidates.md
@@ -4,7 +4,7 @@ Hermes-Relay supports two candidate lanes with different intent:
 
 | Lane | Source | Publication | Version/tag |
 |---|---|---|---|
-| PR review bundle | Exact PR head or 40-character SHA | Private GitHub Actions artifact | No version bump or tag |
+| PR review bundle | Exact PR head commit | Private GitHub Actions artifact | No version bump or tag |
 | Release candidate | Release-prepared exact `dev` SHA | Public GitHub prerelease | Surface tag ending in `-rc.N` |
 
 Neither lane changes a stable Android installation. Candidate APKs use the
@@ -19,7 +19,22 @@ stable app's encrypted connection state.
 
 For an open PR targeting `dev`, apply the `review-candidate` label. The label
 event runs in the PR's unprivileged workflow context and builds that exact head
-commit, including fork PRs.
+commit, including fork PRs. The label is an ongoing opt-in: reopening the PR or
+pushing a new head commit rebuilds the bundle from the new exact head. Removing
+the label stops those automatic rebuilds. GitHub may hold a first-time fork
+contributor's initial run for explicit maintainer approval before any untrusted
+code executes.
+
+After each completion, a separate trusted `workflow_run` reporter creates or
+updates one marked comment on the PR. It reads only workflow and artifact
+metadata from the completed run and checks out only the repository's default
+branch; it never checks out the PR head, downloads the candidate, or executes
+fork code with write permission. The comment links the exact artifact and run,
+records the source SHA and expiry, and keeps the install and Relay rollback
+instructions brief. Rebuilt heads update the same bot comment instead of adding
+new comments. Maintainers may also dispatch the reporter with an existing
+completed **Build Review Bundle** run ID; the reporter validates that workflow
+identity before using its metadata.
 
 For an integrated `dev` commit, use the release-candidate lane below. Review
 bundles intentionally have no privileged manual-dispatch path that can execute


### PR DESCRIPTION
## Summary

Commission the label-driven Android + Relay review-candidate lane and add a trusted PR comment reporter without giving fork code write permission.

## Changes

- keep `review-candidate` as an ongoing exact-head opt-in that rebuilds on synchronize or reopen
- add a separate trusted `workflow_run` reporter that creates or updates one marked PR comment with artifact, SHA, expiry, and concise review guidance
- self-test the trusted reporter before every write and support a validated manual Build Review Bundle run ID for commissioning an existing artifact
- document first-time fork approval, stable-install isolation, Relay rollback boundaries, and the PR comment handoff

## Verification

- `node .github/scripts/review-bundle-report.test.cjs` — passed create/update, blocked-run, artifact resolution, and manual run selection coverage
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-bundle.yml .github/workflows/review-bundle-report.yml` — passed
- [PR #398 review bundle](https://github.com/Codename-11/hermes-relay/actions/runs/32729383426) — passed for exact head `90ab705a883c`; downloaded manifest and four checksums verified
- `git diff --check` — passed

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Android changes: workflow-only; hosted isolated Candidate bundle passed
- [x] Translation changes: N/A
- [x] Server changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: operational Markdown only; links and referenced live run verified
- [x] UI changes: N/A
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md updated
- [x] Public writing hygiene checked
- [x] Contributor lineage: N/A