### PR TITLE
chore(release): standardize public and candidate names

### DIFF
--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -26,7 +26,7 @@ Built from PR #${prNumber} head \`${shortSha}\`.
 [Download \`${artifact.name}\`](${artifactUrl}) — expires **${formatExpiry(artifact.expires_at)}**.
 
 1. Unzip the bundle and verify its files against \`SHA256SUMS.txt\`.
-2. Install the APK under \`android/\`. It appears as **Hermes Candidate**, leaves stable installs untouched, and must be paired separately.
+2. Install the APK under \`android/\`. It appears as **HR Candidate**, leaves stable installs untouched, and must be paired separately.
 3. Test the Relay package only in a disposable/staging Hermes instance or with an explicit snapshot and rollback plan. Confirm the source SHA in \`REVIEW_MANIFEST.json\`.
 
 [View workflow run](${runUrl})`;

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -37,7 +37,8 @@ const successBody = buildReviewComment({
 assert.match(successBody, /## Review candidate ready/);
 assert.match(successBody, /hermes-relay-review-pr-398-90ab705a883c/);
 assert.match(successBody, /expires \*\*August 31, 2026\*\*/);
-assert.match(successBody, /Hermes Candidate/);
+assert.match(successBody, /HR Candidate/);
+assert.ok(!successBody.includes(['Hermes', 'Candidate'].join(' ')));
 assert.match(successBody, /REVIEW_MANIFEST\.json/);
 
 const blockedBody = buildReviewComment({

--- a/.github/workflows/approve-release-android.yml
+++ b/.github/workflows/approve-release-android.yml
@@ -1,10 +1,10 @@
-# Hermes-Relay-Android — explicit public release approval
+# Hermes-Relay Android — explicit public release approval
 #
 # Run from main only after the automated Play preflight passes and the release
 # PR has merged. Starting this workflow is the release approval. Creating the
 # stable tag triggers Play submission first, then GitHub publication.
 
-name: Approve Android Release
+name: Hermes-Relay Android Release Approval
 
 on:
   workflow_dispatch:
@@ -37,7 +37,7 @@ jobs:
           REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           if [ "$GITHUB_REF" != "refs/heads/main" ]; then
-            echo "::error::Approve Android Release must run from main, not $GITHUB_REF"
+            echo "::error::Hermes-Relay Android Release Approval must run from main, not $GITHUB_REF"
             exit 1
           fi
           TOML_VERSION=$(grep -oP 'appVersionName\s*=\s*"\K[^"]+' gradle/libs.versions.toml)

--- a/.github/workflows/play-preflight-android.yml
+++ b/.github/workflows/play-preflight-android.yml
@@ -1,4 +1,4 @@
-# Hermes-Relay-Android — private Google Play preflight
+# Hermes-Relay Android — private Google Play preflight
 #
 # Run manually from the final dev or untagged main tree before creating
 # android-v*. The job
@@ -7,7 +7,7 @@
 # Play gate while no public GitHub Release or sideload APK exists. Console-only
 # pre-review and pre-launch reports are informational and do not block release.
 
-name: Play Preflight — Android
+name: Hermes-Relay Android Play Preflight
 
 on:
   workflow_dispatch:
@@ -119,7 +119,7 @@ jobs:
             --track=production \
             --release-status=draft \
             --resolution-strategy=ignore \
-            --release-name="Hermes-Relay ${{ steps.metadata.outputs.version }}"
+            --release-name="Hermes-Relay Android v${{ steps.metadata.outputs.version }}"
 
       - name: Record successful preflight for the exact commit
         run: |
@@ -152,4 +152,4 @@ jobs:
           echo "- Release tree: \`${{ steps.metadata.outputs.tree }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Play track/status: **Production draft**" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "The signed build, DEX scan, and Play draft upload passed. Ensure this exact release tree is on main, then run **Approve Android Release** from main. Console-only reports are informational and non-blocking." >> "$GITHUB_STEP_SUMMARY"
+          echo "The signed build, DEX scan, and Play draft upload passed. Ensure this exact release tree is on main, then run **Hermes-Relay Android Release Approval** from main. Console-only reports are informational and non-blocking." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,17 +1,18 @@
-# Hermes-Relay-Android — Release Pipeline
+# Hermes-Relay Android — Release Pipeline
 #
 # Triggered when an Android release tag (android-v*) is pushed.
 # Validates the tag matches the app version in libs.versions.toml,
 # runs focused Android checks, builds release APK/AAB artifacts, and creates a
-# GitHub Release. Server/Python package releases use server-v* tags.
+# GitHub Release. Plugin/Python package releases use server-v* tags.
 
-name: Release Android
+name: Hermes-Relay Android Release
 
 on:
   push:
     tags:
       - "android-v*"
-  # Approve Android Release creates its tag with GITHUB_TOKEN, whose tag event
+  # Hermes-Relay Android Release Approval creates its tag with GITHUB_TOKEN,
+  # whose tag event
   # does not recursively start workflows. It dispatches the current workflow
   # definition from main, while every job checks out the immutable tag. Manual
   # tag pushes continue to use the push trigger.
@@ -120,7 +121,7 @@ jobs:
             --jq '[.artifacts[] | select(.expired == false)] | length')
           if [ "$COUNT" -lt 1 ]; then
             echo "::error::No successful Play preflight found for version $VERSION with tree $RELEASE_TREE"
-            echo "Run Play Preflight from the final dev tree, merge that unchanged tree to main, then approve the release."
+            echo "Run Hermes-Relay Android Play Preflight from the final dev tree, merge that unchanged tree to main, then approve the release."
             exit 1
           fi
           echo "Play preflight proof found: $ARTIFACT_NAME"
@@ -220,7 +221,7 @@ jobs:
           SOURCE_SHA="$(git rev-parse HEAD)"
           ./gradlew :app:assembleSideloadCandidate \
             -Pcandidate.kind=rc \
-            -Pcandidate.label="Android ${VERSION}" \
+            -Pcandidate.label="Hermes-Relay Android v${VERSION}" \
             -Pcandidate.sourceRef="android-v${VERSION}" \
             -Pcandidate.sourceSha="$SOURCE_SHA" \
             --console=plain
@@ -309,7 +310,7 @@ jobs:
             --update=production \
             --version-code=${{ needs.validate.outputs.version_code }} \
             --release-status=completed \
-            --release-name="Hermes-Relay ${{ needs.validate.outputs.version }}"
+            --release-name="Hermes-Relay Android v${{ needs.validate.outputs.version }}"
 
       # Public distribution happens only after Play accepts the production
       # submission above. This keeps a Play-detected release blocker from
@@ -318,7 +319,7 @@ jobs:
         if: ${{ needs.validate.outputs.prerelease != 'true' }}
         uses: softprops/action-gh-release@v3
         with:
-          name: Hermes-Relay-Android v${{ needs.validate.outputs.version }}
+          name: Hermes-Relay Android v${{ needs.validate.outputs.version }}
           tag_name: android-v${{ needs.validate.outputs.version }}
           body_path: RELEASE_NOTES.md
           prerelease: false
@@ -333,7 +334,7 @@ jobs:
         if: ${{ needs.validate.outputs.prerelease == 'true' }}
         uses: softprops/action-gh-release@v3
         with:
-          name: Hermes-Relay-Android v${{ needs.validate.outputs.version }}
+          name: Hermes-Relay Android v${{ needs.validate.outputs.version }}
           tag_name: android-v${{ needs.validate.outputs.version }}
           body_path: RELEASE_NOTES.md
           prerelease: true
@@ -347,7 +348,7 @@ jobs:
           HERMES_KEYSTORE_BASE64: ${{ secrets.HERMES_KEYSTORE_BASE64 }}
           PRERELEASE: ${{ needs.validate.outputs.prerelease }}
         run: |
-          echo "## Hermes-Relay-Android v${{ needs.validate.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Hermes-Relay Android v${{ needs.validate.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "$PRERELEASE" = "true" ] && [ -n "$HERMES_KEYSTORE_BASE64" ]; then
             echo "✅ **Release-signed Candidate app** — separate package ID; never uploaded to Play" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -351,9 +351,9 @@ jobs:
           echo "## Hermes-Relay Android v${{ needs.validate.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "$PRERELEASE" = "true" ] && [ -n "$HERMES_KEYSTORE_BASE64" ]; then
-            echo "✅ **Release-signed Candidate app** — separate package ID; never uploaded to Play" >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ **Release-signed HR Candidate app** — separate package ID; never uploaded to Play" >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PRERELEASE" = "true" ]; then
-            echo "⚠️ **Debug-signed Candidate app** — separate package ID; never uploaded to Play" >> "$GITHUB_STEP_SUMMARY"
+            echo "⚠️ **Debug-signed HR Candidate app** — separate package ID; never uploaded to Play" >> "$GITHUB_STEP_SUMMARY"
           elif [ -n "$HERMES_KEYSTORE_BASE64" ]; then
             echo "✅ **Signed with release keystore** — suitable for Play Store upload" >> "$GITHUB_STEP_SUMMARY"
           else

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Release Desktop
+name: Hermes-Relay CLI+UI Release
 
 on:
   push:
@@ -58,13 +58,13 @@ jobs:
           if [[ "$version" == *-* ]]; then
             git fetch origin dev --no-tags
             if ! git merge-base --is-ancestor "$tag_commit" origin/dev; then
-              echo "Desktop prereleases must be tagged from dev; $tag_commit is not in origin/dev" >&2
+              echo "CLI+UI prereleases must be tagged from dev; $tag_commit is not in origin/dev" >&2
               exit 1
             fi
           else
             git fetch origin main --no-tags
             if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
-              echo "Stable Desktop releases must be tagged from main; $tag_commit is not in origin/main" >&2
+              echo "Stable CLI+UI releases must be tagged from main; $tag_commit is not in origin/main" >&2
               exit 1
             fi
           fi
@@ -425,7 +425,7 @@ jobs:
       # (the other publish-release steps only consume downloaded build artifacts).
       - uses: actions/checkout@v7
 
-      - name: Extract Desktop version
+      - name: Extract CLI+UI version
         id: version
         run: echo "version=${GITHUB_REF_NAME#desktop-v}" >> "$GITHUB_OUTPUT"
 
@@ -457,7 +457,7 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: Hermes-Relay-Desktop v${{ steps.version.outputs.version }}
+          name: Hermes-Relay CLI+UI v${{ steps.version.outputs.version }}
           tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, 'alpha') || contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'rc') }}

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,4 +1,4 @@
-name: Release Server
+name: Hermes-Relay Plugin Release
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   validate:
-    name: Validate Server release
+    name: Validate Plugin release
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -24,11 +24,11 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/server-v}" >> "$GITHUB_OUTPUT"
 
-      - name: Verify Server version sync and changelog
+      - name: Verify Plugin version sync and changelog
         run: |
           python scripts/check-plugin-version-sync.py --expect "$TAG_VERSION"
-          if ! grep -Eq "^## \[Server ${TAG_VERSION}\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no Server release heading for $TAG_VERSION"
+          if ! grep -Eq "^## \[Plugin ${TAG_VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no Plugin release heading for $TAG_VERSION"
             exit 1
           fi
         env:
@@ -43,13 +43,13 @@ jobs:
           if [[ "$TAG_VERSION" == *-* ]]; then
             git fetch origin dev --no-tags
             if ! git merge-base --is-ancestor "$tag_commit" origin/dev; then
-              echo "Server prereleases must be tagged from dev; $tag_commit is not in origin/dev" >&2
+              echo "Plugin prereleases must be tagged from dev; $tag_commit is not in origin/dev" >&2
               exit 1
             fi
           else
             git fetch origin main --no-tags
             if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
-              echo "Stable Server releases must be tagged from main; $tag_commit is not in origin/main" >&2
+              echo "Stable Plugin releases must be tagged from main; $tag_commit is not in origin/main" >&2
               exit 1
             fi
           fi
@@ -129,7 +129,7 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: Hermes-Relay-Server v${{ needs.validate.outputs.version }}
+          name: Hermes-Relay Plugin v${{ needs.validate.outputs.version }}
           tag_name: server-v${{ needs.validate.outputs.version }}
           prerelease: ${{ contains(needs.validate.outputs.version, '-') }}
           fail_on_unmatched_files: true

--- a/.github/workflows/review-bundle.yml
+++ b/.github/workflows/review-bundle.yml
@@ -123,7 +123,7 @@ jobs:
           aapt="$(find "$ANDROID_HOME/build-tools" -type f -name aapt -print | sort -V | tail -1)"
           test -x "$aapt"
           "$aapt" dump badging "$apk" | grep -F "package: name='com.axiomlabs.hermesrelay.sideload.candidate'"
-          "$aapt" dump badging "$apk" | grep -F "application-label:'Hermes Candidate'"
+          "$aapt" dump badging "$apk" | grep -F "application-label:'HR Candidate'"
 
       - name: Assemble review bundle
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
-- **Release names use one public product hierarchy.** Future releases use `Hermes-Relay Android`, `Hermes-Relay Plugin`, or `Hermes-Relay CLI+UI` display names without changing immutable tags, package identities, updater contracts, or artifact filenames.
+- **Release and candidate names use one public product hierarchy.** Future releases use `Hermes-Relay Android`, `Hermes-Relay Plugin`, or `Hermes-Relay CLI+UI` display names, while isolated Android review and release-candidate installs use `HR Candidate`, without changing immutable tags, package identities, updater contracts, or artifact filenames.
 - **Review candidates are an explicit PR opt-in with one trusted handoff comment.** Maintainers can apply `review-candidate` for exact-head Android and Relay bundles; a separate reporter updates the PR with the artifact, expiry, source SHA, and bounded review instructions without executing fork code with write permission.
 - **Unlabeled PR updates no longer receive false candidate-failure comments.** The trusted reporter ignores skipped review-bundle workflow shells before reading artifacts or writing to a PR.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Release names use one public product hierarchy.** Future releases use `Hermes-Relay Android`, `Hermes-Relay Plugin`, or `Hermes-Relay CLI+UI` display names without changing immutable tags, package identities, updater contracts, or artifact filenames.
+
 ## [Android 1.12.1] - 2026-08-22
 
 ### Fixed

--- a/CLI_RELEASE_NOTES.md
+++ b/CLI_RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Hermes-Relay CLI v__VERSION__
+# Hermes-Relay CLI+UI v__VERSION__
 
 **Release Date:** 2026-08-15
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,11 @@ scripts/dev.bat relay      # Start relay server (dev, no TLS)
 
 Maintainers can produce a matched Android + Relay handoff for one pull request
 without cutting a release. Apply the `review-candidate` label to an open PR
-targeting `dev`. The short-lived artifact contains a side-by-side Candidate APK,
-Relay packages/source from the same exact PR commit, provenance, checksums, and
-install/rollback guidance. While the label remains applied, a new PR head commit
-automatically replaces any in-progress build with a bundle for the new head.
+targeting `dev`. The short-lived artifact contains a side-by-side
+**HR Candidate** APK, Relay packages/source from the same exact PR commit,
+provenance, checksums, and install/rollback guidance. While the label remains
+applied, a new PR head commit automatically replaces any in-progress build with
+a bundle for the new head.
 For a first-time fork contributor, GitHub may hold the first run for explicit
 maintainer approval before any untrusted code executes.
 When an opted-in candidate run completes, a separate trusted reporter creates or

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,14 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-24 — Release surface naming
+
+Future Android, Plugin, and CLI+UI GitHub Releases, Android Play submissions,
+candidate provenance, release-note templates, workflow summaries, operator
+guidance, and user documentation use the
+`Hermes-Relay <Surface> v<version>` display-name contract. Immutable tags,
+package identities, machine-readable version-track IDs, updater channels, and
+artifact filenames remain unchanged.
+
 ## 2026-08-23 — GitHub Discussions community surface
 
 GitHub Discussions is enabled as the repository's lightweight community surface.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -8,6 +8,10 @@ guidance, and user documentation use the
 `Hermes-Relay <Surface> v<version>` display-name contract. Immutable tags,
 package identities, machine-readable version-track IDs, updater channels, and
 artifact filenames remain unchanged.
+The isolated Android review and release-candidate application is branded
+`HR Candidate` in its launcher label, workflow verification, handoff comment,
+and active contributor and release documentation. Its package identity, build
+type, tags, and artifact contracts remain unchanged.
 
 ## 2026-08-24 — Review-candidate commissioning
 

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Hermes-Relay-Server v__VERSION__
+# Hermes-Relay Plugin v__VERSION__
 
 **Release Date:** August 21, 2026
 
@@ -34,4 +34,4 @@ Standard chat, session history, and Vanilla Hermes voice remain upstream-owned a
 
 ---
 
-Tag prefixes: Android releases use android-v*, Server releases use server-v*, and Desktop releases use desktop-v*.
+Tag prefixes: Android releases use android-v*, Plugin releases use server-v*, and CLI+UI releases use desktop-v*.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -422,14 +422,15 @@ the threshold is intent-driven, not event-driven.
 If you want to dogfood a frozen `dev` release candidate without declaring GA,
 tag the exact release-prepared `dev` commit with a **prerelease** tag such as
 `android-vX.Y.Z-rc.N` or `server-vX.Y.Z-rc.N`. Android prereleases publish the
-side-by-side Candidate app and never upload to Play. Plugin prereleases publish
-opt-in packages for staging and do not automatically replace production.
+side-by-side **HR Candidate** app and never upload to Play. Plugin prereleases
+publish opt-in packages for staging and do not automatically replace production.
 See [Review builds and release candidates](docs/review-candidates.md).
 
-For one-PR review, do not bump versions or create a tag. Run **Build Review
-Bundle** for the PR number or exact SHA. It produces one short-lived matched
-Android + Relay artifact; the Candidate app uses a separate application ID and
-the Relay package requires an explicit staging or snapshot/rollback install.
+For one-PR review, do not bump versions or create a tag. Apply the
+`review-candidate` label to an open PR targeting `dev`. It produces one
+short-lived matched Android + Relay artifact; the **HR Candidate** app uses a
+separate application ID and the Relay package requires an explicit staging or
+snapshot/rollback install.
 
 ## Release train ownership
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,15 +14,15 @@ with optional prerelease identifiers.
 - Prerelease suffixes: `-alpha`, `-beta`, `-rc.N` (e.g. `0.2.0-beta.1`)
 
 Hermes-Relay ships three independently versioned production surfaces. Public
-GitHub Release titles use product names (`Hermes-Relay-Android`,
-`Hermes-Relay-Server`, `Hermes-Relay-Desktop`); immutable tag prefixes select
-the corresponding build and deployment lane.
+GitHub Release titles use `Hermes-Relay <Surface> v<version>` (for example,
+`Hermes-Relay Android v1.13.0-rc.1`); immutable tag prefixes select the
+corresponding build and deployment lane.
 
 | Surface | Tag prefix | Version source | Bump script | Release workflow |
 |---|---|---|---|---|
-| Hermes-Relay-Android | `android-v*` | `gradle/libs.versions.toml` | `scripts/bump-android-version.sh` | `.github/workflows/release-android.yml` |
-| Hermes-Relay-Server | `server-v*` | `pyproject.toml` plus checked plugin/dashboard metadata | `scripts/bump-plugin-version.sh` | `.github/workflows/release-plugin.yml` |
-| Hermes-Relay-Desktop | `desktop-v*` | `desktop/package.json` | `cd desktop && npm version --no-git-tag-version <version>` | `.github/workflows/release-cli.yml` |
+| Hermes-Relay Android | `android-v*` | `gradle/libs.versions.toml` | `scripts/bump-android-version.sh` | `.github/workflows/release-android.yml` |
+| Hermes-Relay Plugin | `server-v*` | `pyproject.toml` plus checked plugin/dashboard metadata | `scripts/bump-plugin-version.sh` | `.github/workflows/release-plugin.yml` |
+| Hermes-Relay CLI+UI | `desktop-v*` | `desktop/package.json` | `cd desktop && npm version --no-git-tag-version <version>` | `.github/workflows/release-cli.yml` |
 
 This split is intentional. The plugin carries relay features for both Android
 and CLI clients, so plugin fixes can ship without forcing an Android app
@@ -88,7 +88,7 @@ lockstep:
 | `plugin/dashboard/package.json` | `"version": "..."` | dashboard build/package metadata |
 | `plugin/dashboard/package-lock.json` | `"version": "..."` | locked dashboard package metadata |
 
-Always bump Server releases via:
+Always bump Plugin releases via:
 
 ```bash
 bash scripts/bump-plugin-version.sh 0.6.2
@@ -106,23 +106,23 @@ Check all release tracks at once with:
 python scripts/check-version-tracks.py
 ```
 
-This aggregate check reports Android, Server, and Desktop versions
+This aggregate check reports Android, Plugin, and CLI+UI versions
 side by side and validates that each track's own source files are internally
 consistent. It deliberately does not require all three tracks to share the same
 SemVer.
 
 The `server-v*` release workflow validates the tag against the same metadata,
 runs plugin tests, builds a wheel and sdist, generates checksums, and
-publishes a `Hermes-Relay-Server vX.Y.Z` GitHub Release with the package
+publishes a `Hermes-Relay Plugin vX.Y.Z` GitHub Release with the package
 artifacts.
 
 ### CLI / tray versioning
 
-`desktop/package.json` is the Desktop/CLI release track's source of truth. Its version
+`desktop/package.json` is the CLI+UI release track's source of truth. Its version
 must match the generated CLI and Windows tray metadata. The tray is a compact
 management popup over the installed CLI and shared state; it has no chat,
 embedded terminal, plugins, voice, or separate desktop product surface. The public
-release remains one `Hermes-Relay-Desktop` track containing CLI binaries plus the
+release remains one `Hermes-Relay CLI+UI` track containing CLI binaries plus the
 optional Windows installer.
 
 | File | Purpose |
@@ -422,7 +422,7 @@ the threshold is intent-driven, not event-driven.
 If you want to dogfood a frozen `dev` release candidate without declaring GA,
 tag the exact release-prepared `dev` commit with a **prerelease** tag such as
 `android-vX.Y.Z-rc.N` or `server-vX.Y.Z-rc.N`. Android prereleases publish the
-side-by-side Candidate app and never upload to Play. Server prereleases publish
+side-by-side Candidate app and never upload to Play. Plugin prereleases publish
 opt-in packages for staging and do not automatically replace production.
 See [Review builds and release candidates](docs/review-candidates.md).
 
@@ -586,7 +586,7 @@ Optional device smoke test: `scripts\dev.bat release` then
 ### 4. Run the private Play preflight from `dev`
 
 The release-prep commit lands on `dev` first. Before any public tag or GitHub
-Release exists, open **Actions → Play Preflight — Android**, choose **Run
+Release exists, open **Actions → Hermes-Relay Android Play Preflight**, choose **Run
 workflow**, select the final `dev` branch, and enter the prepared version.
 
 The preflight workflow:
@@ -629,11 +629,11 @@ git add gradle/libs.versions.toml RELEASE_NOTES.md CHANGELOG.md \
 git commit -m "release(android): android-v0.6.2"
 git push origin dev
 
-# Run Play Preflight — Android from dev and require a successful workflow.
+# Run Hermes-Relay Android Play Preflight from dev and require a successful workflow.
 # Open the release PR (dev -> main) and merge with --no-ff.
 ```
 
-Then open **Actions → Approve Android Release**, choose **Run workflow**, select
+Then open **Actions → Hermes-Relay Android Release Approval**, choose **Run workflow**, select
 `main`, and enter the version. Starting the workflow is the release approval. It
 verifies that `main` has the exact preflighted tree and creates the
 `android-v<version>` tag. Because tags created with `GITHUB_TOKEN` do not trigger
@@ -653,7 +653,7 @@ publication.
 Plugin/Python version files are intentionally not part of an Android app
 release unless the plugin package itself is also being released.
 
-### Server / Python package release
+### Plugin / Python package release
 
 Use this when plugin or relay behavior changes independently of Android app
 delivery, for example CLI channel support, bridge routes, pairing server fixes,
@@ -664,6 +664,8 @@ First **rewrite `PLUGIN_RELEASE_NOTES.md`** — it is the GitHub Release body fo
 Summary and the Added/Changed/Fixed groups from the plugin-relevant bullets in the
 promoted `CHANGELOG.md` block, keep the `__VERSION__` token in the Install command
 (the workflow substitutes it), and apply the same public-distribution scrub as §2.
+Name the promoted changelog heading `## [Plugin <version>]`; the compatibility
+tag remains `server-v<version>`.
 
 ```bash
 git checkout dev
@@ -688,15 +690,16 @@ validates all plugin-owned version metadata with
 `python scripts/check-version-tracks.py` locally before tagging when a change
 touches more than one release surface. The workflow also runs plugin tests,
 builds a wheel and sdist, generates `SHA256SUMS.txt`, and creates a GitHub
-Release named `Hermes-Relay-Server v<version>` for the server/plugin package.
+Release named `Hermes-Relay Plugin v<version>` for the plugin package.
 
-### CLI / Windows systray release
+### CLI+UI release
 
 Use this when the standalone CLI, daemon, desktop tools, or Windows tray changes.
 Android and plugin versions do not need to move with it.
 
-First rewrite `CLI_RELEASE_NOTES.md` for the new Desktop release and promote only
-CLI/tray-relevant changelog bullets into the release block. Then:
+First rewrite `CLI_RELEASE_NOTES.md` for the new CLI+UI release and promote only
+CLI/tray-relevant changelog bullets into the release block. The compatibility
+tag and source directory remain `desktop-v<version>` and `desktop/`. Then:
 
 ```powershell
 git switch dev
@@ -850,7 +853,7 @@ On every push of a tag matching `android-v*`, `.github/workflows/release-android
 5. Generates `SHA256SUMS.txt` covering the two attached files.
 6. For stable releases only, promotes the exact preflighted Production draft to
    `completed`; prereleases never upload to Play.
-7. Creates a GitHub Release named `Hermes-Relay-Android v<version>` with `RELEASE_NOTES.md` as
+7. Creates a GitHub Release named `Hermes-Relay Android v<version>` with `RELEASE_NOTES.md` as
    the body. Attaches the APK, AAB, and `SHA256SUMS.txt`. Tags any version
    containing a dash (e.g. `android-v0.2.0-beta.1`) as a prerelease automatically.
 8. Prints a `$GITHUB_STEP_SUMMARY` with the release and Play result.
@@ -865,7 +868,7 @@ On every push of a tag matching `server-v*`,
 2. Runs plugin syntax checks and the focused route/auth/session test slice.
 3. Builds the Python wheel and sdist with `python -m build`.
 4. Generates `dist/SHA256SUMS.txt`.
-5. Creates a GitHub Release named `Hermes-Relay-Server v<version>` with the wheel,
+5. Creates a GitHub Release named `Hermes-Relay Plugin v<version>` with the wheel,
    sdist, and checksum file attached.
 
 On every push of a tag matching `desktop-v*`,
@@ -933,13 +936,13 @@ For an Android app hotfix:
    `dev`'s `appVersionCode` lags behind `main` and the next app release
    bump collides.
 
-For a Server hotfix, branch from the affected `server-v*` tag, apply
+For a Plugin hotfix, branch from the affected `server-v*` tag, apply
 the fix, run `bash scripts/bump-plugin-version.sh <next-version>`, merge to
 `main`, tag `server-v<next-version>`, verify the package/deployment, and merge
 `main` back to `dev`. Do not touch
 `gradle/libs.versions.toml` unless an Android app release is also shipping.
 
-For a Desktop hotfix, branch from the affected `desktop-v*` tag, update only
+For a CLI+UI hotfix, branch from the affected `desktop-v*` tag, update only
 `desktop/package.json` and its generated lock/runtime/tray metadata, merge to
 `main`, tag `desktop-v<next-version>`, verify all binaries and the installer,
 then merge `main` back to `dev`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Hermes-Relay-Android v1.12.1
+# Hermes-Relay Android v1.12.1
 
 **Release Date:** August 22, 2026
 

--- a/app/src/candidate/AndroidManifest.xml
+++ b/app/src/candidate/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <application
         android:icon="@mipmap/ic_launcher_candidate"
-        android:label="Hermes Candidate"
+        android:label="HR Candidate"
         android:roundIcon="@mipmap/ic_launcher_candidate_round"
         tools:replace="android:icon,android:label" />
 </manifest>

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -48,7 +48,7 @@ startup entry; the separate **Start daemon with UI** preference decides whether
 opening the tray also connects remote access. Automatic daemon startup is off
 for existing installs until explicitly enabled. Settings also exposes **Open
 terminal**, **Open Hermes CLI**, **View daemon log**, and **Run diagnostics**,
-and manages Desktop release updates. **Help &
+and manages CLI+UI release updates. **Help &
 About** reports the UI, CLI, and connected Relay versions and links to the docs,
 troubleshooting, release notes, logs, and diagnostics. Tray lifecycle and child-
 process failures are written to `~/.hermes/tray.log`; daemon connection and tool-

--- a/desktop/tray/ui/App.tsx
+++ b/desktop/tray/ui/App.tsx
@@ -1060,7 +1060,7 @@ function SettingsPage({ daemon, computerControl, startup, daemonAutostart, activ
         ? `Version ${update.current} · up to date`
         : update?.latest_version
           ? `${update.current} → ${update.latest_version} available`
-          : 'Check the desktop release channel.'
+          : 'Check the CLI+UI release channel.'
 
   const cuaReady = computerControl?.available === true && computerControl.state === 'ready'
   const engineState = computerControl?.state ?? 'not_installed'

--- a/docs/review-candidates.md
+++ b/docs/review-candidates.md
@@ -7,9 +7,9 @@ Hermes-Relay supports two candidate lanes with different intent:
 | PR review bundle | Exact PR head commit | Private GitHub Actions artifact | No version bump or tag |
 | Release candidate | Release-prepared exact `dev` SHA | Public GitHub prerelease | Surface tag ending in `-rc.N` |
 
-Neither lane changes a stable Android installation. Candidate APKs use the
+Neither lane changes a stable Android installation. **HR Candidate** APKs use the
 dedicated package ID `com.axiomlabs.hermesrelay.sideload.candidate`, the launcher
-label **Hermes Candidate**, an amber launcher background, separate Android app
+label **HR Candidate**, an amber launcher background, separate Android app
 data, and a persistent in-app banner containing the candidate kind, source, and
 short commit SHA. Installing a newer candidate replaces only the previous
 candidate slot. It must be paired separately because it does not share the
@@ -59,7 +59,7 @@ updater notification.
 
 1. Verify the downloaded files with `SHA256SUMS.txt`.
 2. Install the APK normally or with `adb install -r <candidate.apk>`.
-3. Confirm the launcher says **Hermes Candidate** and the in-app banner shows
+3. Confirm the launcher says **HR Candidate** and the in-app banner shows
    the expected PR/SHA before pairing it.
 4. Remove only the candidate with:
    `adb uninstall com.axiomlabs.hermesrelay.sideload.candidate`.
@@ -94,7 +94,7 @@ metadata and notes have been prepared on `dev`.
 2. Create the affected surface tag, such as `android-v1.12.0-rc.1`,
    `server-v1.9.0-rc.1`, or `desktop-v0.5.0-rc.1`, at that commit.
 3. The release workflow verifies the prerelease tag is contained in `dev`.
-4. Android RCs publish the side-by-side Candidate APK and never upload to Play.
+4. Android RCs publish the side-by-side **HR Candidate** APK and never upload to Play.
 5. Plugin RCs publish prerelease packages for explicit staging/opt-in install;
    they do not replace a running production plugin automatically.
 6. CLI+UI RCs publish opt-in prerelease binaries/installers; stable updater

--- a/docs/review-candidates.md
+++ b/docs/review-candidates.md
@@ -78,9 +78,9 @@ metadata and notes have been prepared on `dev`.
    `server-v1.9.0-rc.1`, or `desktop-v0.5.0-rc.1`, at that commit.
 3. The release workflow verifies the prerelease tag is contained in `dev`.
 4. Android RCs publish the side-by-side Candidate APK and never upload to Play.
-5. Server RCs publish prerelease packages for explicit staging/opt-in install;
+5. Plugin RCs publish prerelease packages for explicit staging/opt-in install;
    they do not replace a running production plugin automatically.
-6. Desktop RCs publish opt-in prerelease binaries/installers; stable updater
+6. CLI+UI RCs publish opt-in prerelease binaries/installers; stable updater
    channels continue to ignore them.
 7. Record the exact tag/SHA and test results in the release issue.
 

--- a/docs/worktree-workflow.md
+++ b/docs/worktree-workflow.md
@@ -97,5 +97,5 @@ git worktree remove <path> # delete a worktree (must be clean, or pass --force)
 
 Worktrees change *nothing* about the release contract. Feature worktrees merge to
 `dev`; releases are still cut by merging `dev` → `main` with `--no-ff` and tagging
-from `main` (Android `android-v*`, server `server-v*`, desktop `desktop-v*`). Version bumps
+from `main` (Android `android-v*`, Plugin `server-v*`, CLI+UI `desktop-v*`). Version bumps
 happen on `dev` at release-prep, never on a feature branch — see RELEASE.md.

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -16,7 +16,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # Canonical plugin version source is pyproject.toml's [project].version.
 # Keep this runtime constant in sync with pyproject.toml for server-v*
 # releases. Android releases use gradle/libs.versions.toml and android-v* tags;
-# Desktop releases use desktop/package.json and desktop-v* tags. The /health endpoint
+# CLI+UI releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
 __version__ = "1.9.0"

--- a/plugin/update_check.py
+++ b/plugin/update_check.py
@@ -77,7 +77,7 @@ def compare_versions(current: str, latest: str) -> int:
 
 
 def pick_latest_plugin_tag(releases: Any) -> Optional[str]:
-    """Pick the highest Server version from a GitHub releases payload.
+    """Pick the highest Plugin version from a GitHub releases payload.
 
     ``releases`` is the decoded JSON list from the GitHub releases API. Drafts
     are ignored; pre-releases are considered (the plugin ships ``-alpha``/``-rc``

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,9 +3,9 @@
 #
 # Hermes-Relay now has split release tracks:
 #   - Android app: android-vX.Y.Z, version in gradle/libs.versions.toml
-#   - Server/Python package: server-vX.Y.Z, version in pyproject.toml
+#   - Plugin/Python package: server-vX.Y.Z, version in pyproject.toml
 #     and plugin/relay/__init__.py
-#   - Desktop: desktop-vX.Y.Z, version in desktop/package.json
+#   - CLI+UI: desktop-vX.Y.Z, version in desktop/package.json
 #
 # Keep this legacy script as an alias for the Android app bump so older release
 # notes and muscle memory still work, but prefer the explicit script names:

--- a/scripts/check-plugin-version-sync.py
+++ b/scripts/check-plugin-version-sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Verify plugin-owned version metadata stays in sync.
 
-Server releases use the `server-v*` track. The canonical version is
+Plugin releases use the `server-v*` track. The canonical version is
 `pyproject.toml`'s `[project].version`; plugin and dashboard metadata should
 match because they ship as one Hermes plugin package.
 

--- a/scripts/check-version-tracks.py
+++ b/scripts/check-version-tracks.py
@@ -4,8 +4,8 @@
 The repo ships three independently versioned artifacts:
 
 - Android app: ``android-v*`` tags, source in ``gradle/libs.versions.toml``.
-- Server: ``server-v*`` tags, source in ``pyproject.toml``.
-- Desktop: ``desktop-v*`` tags, source in ``desktop/package.json``.
+- Plugin: ``server-v*`` tags, source in ``pyproject.toml``.
+- CLI+UI: ``desktop-v*`` tags, source in ``desktop/package.json``.
 
 This script gives release prep one command that checks the sources without
 forcing unrelated artifacts to share the same SemVer.
@@ -124,6 +124,7 @@ def _plugin_track(errors: list[str]) -> Track:
         if found != version:
             errors.append(f"plugin version mismatch: {source} has {found}, expected {version}")
     return Track(
+        # Stable machine-readable identifier; the public surface name is Plugin.
         name="server",
         version=version,
         source="pyproject.toml",
@@ -156,14 +157,15 @@ def _cli_track(errors: list[str]) -> Track:
         ),
     ]
     if not SEMVER_RE.match(version):
-        errors.append(f"desktop CLI version is not SemVer: {version!r}")
+        errors.append(f"CLI+UI version is not SemVer: {version!r}")
     for source, found in versions:
         if found != version:
             errors.append(
-                f"desktop CLI version mismatch: {source} has {found}, expected {version}; "
+                f"CLI+UI version mismatch: {source} has {found}, expected {version}; "
                 "run npm run sync:version in desktop/"
             )
     return Track(
+        # Stable machine-readable identifier; the public surface name is CLI+UI.
         name="desktop",
         version=version,
         source="desktop/package.json",
@@ -184,7 +186,13 @@ def collect_tracks() -> tuple[list[Track], list[str]]:
 
 def _print_table(tracks: list[Track]) -> None:
     headers = ("track", "version", "source", "tag", "details")
-    rows = [(t.name, t.version, t.source, t.tag, t.details) for t in tracks]
+    # Keep JSON track identifiers stable while presenting the current public
+    # surface names to operators.
+    display_names = {"server": "Plugin", "desktop": "CLI+UI"}
+    rows = [
+        (display_names.get(t.name, t.name), t.version, t.source, t.tag, t.details)
+        for t in tracks
+    ]
     widths = [
         max(len(headers[index]), *(len(row[index]) for row in rows))
         for index in range(len(headers))

--- a/user-docs/desktop/installation.md
+++ b/user-docs/desktop/installation.md
@@ -18,7 +18,7 @@ irm https://raw.githubusercontent.com/Codename-11/hermes-relay/main/desktop/scri
 By default the script installs the Windows CLI **and** management UI through the checksum-verified NSIS package. It:
 
 1. Detects architecture (x64; ARM64 lands once Bun's cross-compile target stabilizes).
-2. Resolves the **latest** Desktop release by querying the GitHub Releases API directly and picking the SemVer-max `desktop-v*` tag, with a migration fallback to historical `cli-v*` releases. Prereleases are included, so alpha builds aren't skipped (see CHANGELOG entry on alpha.11 for why this matters).
+2. Resolves the **latest** CLI+UI release by querying the GitHub Releases API directly and picking the SemVer-max `desktop-v*` tag, with a migration fallback to historical `cli-v*` releases. Prereleases are included, so alpha builds aren't skipped (see CHANGELOG entry on alpha.11 for why this matters).
 3. Downloads `hermes-relay-windows-x64-setup.exe` and verifies SHA256 against the published `SHA256SUMS.txt`.
 4. Runs the per-user installer. No administrator access is required.
 5. Installs `hermes-relay.exe`, `hermes-relay-tray.exe`, and the uninstaller to `%USERPROFILE%\.hermes\bin`.
@@ -179,7 +179,7 @@ See [Uninstall](#uninstall) below — the curl one-liner reverses install.sh, wi
 Once installed, you don't have to keep re-running the `curl | sh` one-liner. The binary self-updates:
 
 ```bash
-hermes-relay update             # download + verify + swap to latest desktop-v*
+hermes-relay update             # download + verify + swap to latest CLI+UI release (desktop-v*)
 hermes-relay update --check     # dry-run: print available version, don't install
 hermes-relay update --yes       # skip confirm prompt
 hermes-relay update --json      # machine-readable status

--- a/user-docs/reference/configuration.md
+++ b/user-docs/reference/configuration.md
@@ -235,7 +235,7 @@ Each edited config is backed up to `<config>.yaml.bak`. Restart the affected gat
 
 ### Keeping the relay plugin updated
 
-The app, the relay plugin, and the desktop CLI version **independently** — they do not need to match. To see whether a newer plugin release exists:
+The Android app, Relay plugin, and CLI+UI have **independent versions** — they do not need to match. To see whether a newer plugin release exists:
 
 ```bash
 hermes relay update-check           # compares your version to the latest plugin release


### PR DESCRIPTION
## Summary

Standardize the public release surfaces as Hermes-Relay Android, Hermes-Relay Plugin, and exact Hermes-Relay CLI+UI. Rename the isolated Android review/release-candidate app to **HR Candidate** so it is clearly ours, not a Nous Research Hermes product.

## Changes

- update GitHub Release, Play, workflow, template, operator, and user-facing surface names
- use **HR Candidate** for the launcher label, candidate workflow verification, RC summaries, PR handoff comment, and active candidate docs
- present Plugin and CLI+UI in human version-track output while retaining JSON IDs `server` and `desktop`
- keep package IDs, build types, tags, workflow filenames, updater contracts, directories, commands/events, schema fields, and artifact names unchanged

## Verification

- `:app:assembleSideloadCandidate` - passed (52 tasks)
- `aapt dump badging` - package remains `com.axiomlabs.hermesrelay.sideload.candidate`; label is `HR Candidate`
- `node .github/scripts/review-bundle-report.test.cjs` - passed
- actionlint - passed all changed release and review-bundle workflows
- `python -m py_compile scripts/check-plugin-version-sync.py scripts/check-version-tracks.py plugin/update_check.py plugin/relay/__init__.py` - passed
- `python scripts/check-plugin-version-sync.py` and `python scripts/check-version-tracks.py` - passed; JSON IDs remain `android,server,desktop`
- `npm --prefix desktop run check:version-sync` - passed
- `npm --prefix desktop run tray:ui:build` - passed
- `npm --prefix user-docs run build` - routes, locale validation, and VitePress build passed
- repo-wide exact `Hermes Candidate` source search - no remaining hits
- `git diff --check` - passed

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Android changes: full HR Candidate APK assembled and inspected
- [x] Translation changes: N/A; no localized app strings changed
- [x] Plugin changes: Python compilation and version checks passed
- [x] CLI+UI changes: version sync and tray production build passed
- [x] Docs/site changes: user-docs production build passed
- [x] UI changes are naming-only; packaged launcher identity and tray bundle verified
- [x] Commits follow Conventional Commits
- [x] CHANGELOG.md updated
- [x] Public writing hygiene checked
- [x] Contributor lineage: N/A