### PR TITLE
fix(ci): grant reporter pull request comment access

### DIFF
--- a/.github/workflows/review-bundle-report.yml
+++ b/.github/workflows/review-bundle-report.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: review-bundle-report-${{ github.event.workflow_run.id || inputs.run_id }}


### PR DESCRIPTION
## Summary

Grant the trusted review-bundle reporter the second permission GitHub requires to create or update a pull-request comment.

## Changes

- change only `pull-requests: read` to `pull-requests: write`
- retain `issues: write`; all other reporter permissions and fork-code isolation remain unchanged

## Evidence

Commissioning run [32735391960](https://github.com/Codename-11/hermes-relay/actions/runs/32735391960) received `Issues: write` but `PullRequests: read`. GitHub rejected `POST /issues/398/comments` with `x-accepted-github-permissions: issues=write; pull_requests=write`.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-bundle-report.yml` — passed
- `git diff --check` — passed

## Lineage / contributor credit

- Source PR(s): #406, #408
- Attribution preserved by: original maintainer follow-up

## Checklist

- [x] Target branch is `dev`
- [x] Android, translation, server, desktop, docs, and UI changes: N/A
- [x] Commit follows Conventional Commits
- [x] Public writing hygiene checked