### PR TITLE
fix(ci): promote reporter comment permission to main

### DIFF
--- a/.github/workflows/review-bundle-report.yml
+++ b/.github/workflows/review-bundle-report.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: review-bundle-report-${{ github.event.workflow_run.id || inputs.run_id }}


### PR DESCRIPTION
## Summary

Promote the reviewed PR-comment permission correction from `dev` to the trusted default-branch reporter.

## Evidence

Commissioning run [32735391960](https://github.com/Codename-11/hermes-relay/actions/runs/32735391960) resolved and rendered the exact #398 artifact, then GitHub rejected the comment because the token had `Issues: write` but only `PullRequests: read`. The response required `issues=write; pull_requests=write`.

## Changes

- change only `pull-requests: read` to `pull-requests: write`
- retain all existing read-only artifact permissions and the default-branch-only checkout boundary

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-bundle-report.yml` — passed
- `git diff --check` — passed

## Lineage / contributor credit

- Source PR(s): #409, #408, #406
- Attribution preserved by: original maintainer follow-up

## Checklist

- [x] Focused default-branch automation promotion
- [x] Product, release, Android, server, desktop, docs, and UI changes: N/A
- [x] Commit follows Conventional Commits
- [x] Public writing hygiene checked