### PR TITLE
fix(ci): ignore skipped review bundle runs

### DIFF
--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -109,6 +109,10 @@ async function reportReviewBundle({ github, context, core }) {
     core.info('Ignoring a review-bundle run that was not triggered by a pull request.');
     return;
   }
+  if (run.conclusion === 'skipped') {
+    core.info(`Ignoring skipped review-bundle run ${run.id}.`);
+    return;
+  }
 
   const artifacts = await github.paginate(
     github.rest.actions.listWorkflowRunArtifacts,

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -134,9 +134,47 @@ async function testManualRunSelectionCreatesComment() {
   assert.match(calls.create[0].body, /## Review candidate ready/);
 }
 
+async function testSkippedRunIsIgnored() {
+  let apiCalled = false;
+  const messages = [];
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRunArtifacts() {},
+      },
+    },
+    paginate: async () => {
+      apiCalled = true;
+      return [];
+    },
+  };
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: {
+        workflow_run: {
+          ...run,
+          id: 32736508535,
+          conclusion: 'skipped',
+          head_sha: 'a38849ff1680a1993230773a5d602b781367c789',
+        },
+      },
+    },
+    core: {
+      info: (message) => messages.push(message),
+      warning: (message) => messages.push(message),
+      setFailed: (message) => assert.fail(message),
+    },
+  });
+  assert.equal(apiCalled, false);
+  assert.deepEqual(messages, ['Ignoring skipped review-bundle run 32736508535.']);
+}
+
 Promise.all([
   testExistingCommentIsUpdated(),
   testManualRunSelectionCreatesComment(),
+  testSkippedRunIsIgnored(),
 ])
   .then(() => console.log('Review-bundle report tests passed.'))
   .catch((error) => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - **Review candidates are an explicit PR opt-in with one trusted handoff comment.** Maintainers can apply `review-candidate` for exact-head Android and Relay bundles; a separate reporter updates the PR with the artifact, expiry, source SHA, and bounded review instructions without executing fork code with write permission.
+- **Unlabeled PR updates no longer receive false candidate-failure comments.** The trusted reporter ignores skipped review-bundle workflow shells before reading artifacts or writing to a PR.
 
 ## [Android 1.12.1] - 2026-08-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,10 @@ install/rollback guidance. While the label remains applied, a new PR head commit
 automatically replaces any in-progress build with a bundle for the new head.
 For a first-time fork contributor, GitHub may hold the first run for explicit
 maintainer approval before any untrusted code executes.
-When the run completes, a separate trusted reporter creates or updates one PR
-comment with the exact source SHA, artifact link, expiry, and concise install and
-rollback guidance.
+When an opted-in candidate run completes, a separate trusted reporter creates or
+updates one PR comment with the exact source SHA, artifact link, expiry, and
+concise install and rollback guidance. Skipped workflow shells for unlabeled PRs
+do not create comments.
 
 Review bundles never bump versions, create tags, upload to Play, or replace the
 stable Android app. Relay review still requires a staging Hermes instance or an

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -13,6 +13,9 @@ A separate trusted completion reporter reads only run/artifact metadata, checks
 out only the default branch, and creates or updates one marked PR comment with
 the exact candidate link and bounded review instructions. It never checks out or
 executes fork code with write permission.
+Skipped Build Review Bundle shells from unlabeled PR synchronize, reopen, or
+unrelated-label events return before artifact lookup and PR comment access, so
+only an explicit `review-candidate` run can produce candidate status copy.
 
 ## 2026-08-23 — GitHub Discussions community surface
 

--- a/docs/review-candidates.md
+++ b/docs/review-candidates.md
@@ -25,8 +25,10 @@ the label stops those automatic rebuilds. GitHub may hold a first-time fork
 contributor's initial run for explicit maintainer approval before any untrusted
 code executes.
 
-After each completion, a separate trusted `workflow_run` reporter creates or
-updates one marked comment on the PR. It reads only workflow and artifact
+After each non-skipped candidate completion, a separate trusted `workflow_run`
+reporter creates or updates one marked comment on the PR. Skipped workflow shells
+for unlabeled PR events are ignored before artifact or comment APIs are called.
+The reporter reads only workflow and artifact
 metadata from the completed run and checks out only the repository's default
 branch; it never checks out the PR head, downloads the candidate, or executes
 fork code with write permission. The comment links the exact artifact and run,


### PR DESCRIPTION
## Summary

Prevent the trusted reporter from posting false candidate-failure comments for unlabeled pull requests.

## Root cause

Build Review Bundle records a skipped workflow shell when an unlabeled PR synchronizes, reopens, or receives another label. Reporter run [32736515650](https://github.com/Codename-11/hermes-relay/actions/runs/32736515650) treated skipped build run [32736508535](https://github.com/Codename-11/hermes-relay/actions/runs/32736508535) as a failed candidate request and commented on #407.

## Changes

- return before artifact and PR-comment APIs when the selected Build Review Bundle run concluded `skipped`
- add a regression proving a skipped run performs no paginated API call
- document that only non-skipped, opted-in candidate runs produce status comments

## Verification

- `node .github/scripts/review-bundle-report.test.cjs` — passed, including exact skipped-run regression
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-bundle-report.yml` — passed
- `git diff --check` — passed

## Lineage / contributor credit

- Source PR(s): #406, #409
- Attribution preserved by: original maintainer follow-up

## Checklist

- [x] Target branch is `dev`
- [x] Product, Android, translation, server, desktop, and UI changes: N/A
- [x] Operational docs and CHANGELOG updated
- [x] Commit follows Conventional Commits
- [x] Public writing hygiene checked