### PR TITLE
fix(ci): promote skipped-run filter to main

### DIFF
--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -109,6 +109,10 @@ async function reportReviewBundle({ github, context, core }) {
     core.info('Ignoring a review-bundle run that was not triggered by a pull request.');
     return;
   }
+  if (run.conclusion === 'skipped') {
+    core.info(`Ignoring skipped review-bundle run ${run.id}.`);
+    return;
+  }
 
   const artifacts = await github.paginate(
     github.rest.actions.listWorkflowRunArtifacts,

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -134,9 +134,47 @@ async function testManualRunSelectionCreatesComment() {
   assert.match(calls.create[0].body, /## Review candidate ready/);
 }
 
+async function testSkippedRunIsIgnored() {
+  let apiCalled = false;
+  const messages = [];
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRunArtifacts() {},
+      },
+    },
+    paginate: async () => {
+      apiCalled = true;
+      return [];
+    },
+  };
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: {
+        workflow_run: {
+          ...run,
+          id: 32736508535,
+          conclusion: 'skipped',
+          head_sha: 'a38849ff1680a1993230773a5d602b781367c789',
+        },
+      },
+    },
+    core: {
+      info: (message) => messages.push(message),
+      warning: (message) => messages.push(message),
+      setFailed: (message) => assert.fail(message),
+    },
+  });
+  assert.equal(apiCalled, false);
+  assert.deepEqual(messages, ['Ignoring skipped review-bundle run 32736508535.']);
+}
+
 Promise.all([
   testExistingCommentIsUpdated(),
   testManualRunSelectionCreatesComment(),
+  testSkippedRunIsIgnored(),
 ])
   .then(() => console.log('Review-bundle report tests passed.'))
   .catch((error) => {


### PR DESCRIPTION
## Summary

Promote the reviewed skipped-run filter to the trusted default-branch reporter.

## Evidence

Unlabeled PR #407 produced skipped Build Review Bundle run [32736508535](https://github.com/Codename-11/hermes-relay/actions/runs/32736508535). The reporter should ignore that workflow shell instead of posting candidate-failure status.

## Changes

- return before artifact and PR-comment APIs when conclusion is `skipped`
- include the exact skipped-run regression from #411

## Verification

- `node .github/scripts/review-bundle-report.test.cjs` — passed
- `git diff --check` — passed

## Lineage / contributor credit

- Source PR(s): #411, #410, #408
- Attribution preserved by: original maintainer follow-up

## Checklist

- [x] Focused default-branch automation promotion
- [x] Product, release, Android, server, desktop, docs, and UI changes: N/A
- [x] Commit follows Conventional Commits
- [x] Public writing hygiene checked