### PR TITLE
fix(desktop): integrate pending runtime fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **Desktop daemon connections recover instead of exiting after an interrupted Relay socket.** Healthy daemons retry through Relay restarts and repeated failed reconnect attempts, oversized desktop-tool results fail within a bounded response instead of closing the shared WebSocket, and terminal failures leave an accurate stopped status for the tray.
+- **Desktop computer control follows Hermes' current CUA Driver contract.** CUA Driver 0.20 and newer are accepted when their manifest, daemon/MCP arguments, required tools, and canonical path remain compatible, and Windows sessions use the manifest-declared direct standard-mode runtime instead of a potentially stale machine-wide daemon. Current 0.21 installations no longer fall back solely because of an obsolete upper version pin or daemon contract.
 
 ## [Android 1.12.1] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Desktop daemon connections recover instead of exiting after an interrupted Relay socket.** Healthy daemons retry through Relay restarts and repeated failed reconnect attempts, oversized desktop-tool results fail within a bounded response instead of closing the shared WebSocket, and terminal failures leave an accurate stopped status for the tray.
+
 ## [Android 1.12.1] - 2026-08-22
 
 ### Fixed

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -680,6 +680,13 @@ hermes-relay daemon
 
 `status` reads the heartbeat file a running daemon maintains and cross-checks that the pid is alive — it exits non-zero (and says "not running") when the daemon is gone, so scripts can branch on it.
 
+Once authenticated, the daemon automatically reconnects through Relay service
+restarts and repeated transient socket failures using bounded exponential
+backoff. Desktop-tool results are kept below the shared WebSocket message limit;
+oversized results return a bounded-output error rather than terminating the
+daemon. Terminal authentication or policy failures persist a stopped reason in
+the status file before the process exits.
+
 On Windows, keep the tray and normal daemon unelevated for routine operation.
 Use **Restart as Administrator...** only when a desktop action requires
 administrator access. Windows displays UAC consent, and the elevated daemon

--- a/desktop/src/commands/daemon.ts
+++ b/desktop/src/commands/daemon.ts
@@ -1034,15 +1034,16 @@ export async function daemonCommand(args: ParsedArgs): Promise<number> {
   }
   const updateStatus = (partial: Partial<DaemonStatus> & { state?: DaemonState }) => {
     Object.assign(status, partial, { updated_at: nowSec() })
-    void writeDaemonStatus(status)
+    return writeDaemonStatus(status)
   }
-  updateStatus({})
+  void updateStatus({})
 
   const relay = new RelayTransport({
     url,
     sessionToken: token,
     sessionHeader: useSessionHeader,
     broker: brokerRoute,
+    autoReconnect: true,
     ...desktopRelayIdentity()
   })
 
@@ -1069,14 +1070,25 @@ export async function daemonCommand(args: ParsedArgs): Promise<number> {
     updateStatus({ state: 'connected', last_event: 'reconnected', reconnect_attempt: null, retry_at: null, last_error: null })
     void appendAudit({ ts: Date.now(), kind: 'connection.state', tool: 'daemon.reconnected', category: 'system', ok: true, host_url: configuredUrl, summary: 'Relay tunnel restored' })
   })
-  relay.on('exit', (code: unknown) => {
+  relay.on('exit', (code: unknown, reason: unknown) => {
     // Transport gave up (auth.fail, reconnect gate returned false, or
     // reconnect attempts exhausted). Daemon exits non-zero so the
     // service manager decides whether to restart.
-    log.error({ event: 'transport_exited', code: typeof code === 'number' ? code : null })
-    void appendAudit({ ts: Date.now(), kind: 'connection.state', tool: 'daemon.disconnected', category: 'system', ok: false, host_url: configuredUrl, summary: 'Relay transport stopped', error: 'Automatic reconnect stopped' })
-    // Defer exit so the log line flushes before the process dies.
-    setImmediate(() => process.exit(1))
+    const closeCode = typeof code === 'number' ? code : null
+    const closeReason = typeof reason === 'string' && reason ? reason : 'Automatic reconnect stopped'
+    const lastError = `Relay connection stopped${closeCode === null ? '' : ` (code ${closeCode})`}: ${closeReason}`
+    log.error({ event: 'transport_exited', code: closeCode, reason: closeReason })
+    const statusWrite = updateStatus({
+      state: 'stopped',
+      last_event: 'transport_exited',
+      reconnect_attempt: null,
+      retry_at: null,
+      last_error: lastError
+    })
+    const auditWrite = appendAudit({ ts: Date.now(), kind: 'connection.state', tool: 'daemon.disconnected', category: 'system', ok: false, host_url: configuredUrl, summary: 'Relay transport stopped', error: lastError })
+    // Preserve the terminal state before exiting so the tray never renders a
+    // stale connected heartbeat from a process that is already gone.
+    void Promise.allSettled([statusWrite, auditWrite]).finally(() => process.exit(1))
   })
 
   relay.start()

--- a/desktop/src/tools/cuaDriver.ts
+++ b/desktop/src/tools/cuaDriver.ts
@@ -6,8 +6,11 @@ import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 
 import { readDesktopUseSettingsSync } from '../lib/desktopUseSettings.js'
 
-const SUPPORTED_MIN_VERSION = [0, 19, 3] as const
-const SUPPORTED_MAX_VERSION = [0, 20, 0] as const
+// Match Hermes' current runtime contract: 0.20 introduced the manifest-backed
+// daemon/MCP surface. Newer releases remain eligible when they continue to
+// advertise that contract; capability checks, not a stale upper version pin,
+// decide compatibility.
+const SUPPORTED_MIN_VERSION = [0, 20, 0] as const
 const DEFAULT_TIMEOUT_MS = 8_000
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
 const REQUIRED_TOOLS = Object.freeze([
@@ -22,6 +25,14 @@ const REQUIRED_TOOLS = Object.freeze([
   'scroll'
 ])
 const ALLOWED_TOOLS = Object.freeze([...REQUIRED_TOOLS, 'set_agent_cursor_enabled'])
+const REQUIRED_MANIFEST_ARGS = Object.freeze({
+  mcp: Object.freeze(['--socket', '--grant']),
+  serve: Object.freeze([
+    '--socket', '--permission-mode', '--capability-manifest',
+    '--approve-capability-manifest', '--embedded'
+  ]),
+  stop: Object.freeze(['--socket'])
+})
 
 export interface CuaProcessResult {
   stdout: string
@@ -113,6 +124,8 @@ interface CuaManifest {
   schema_version?: unknown
   binary_version?: unknown
   binary_path?: unknown
+  mcp_invocation?: unknown
+  subcommands?: unknown
 }
 
 interface CuaHealthReport {
@@ -153,8 +166,11 @@ class CuaMcpClient {
   private stdout = ''
   private closed = false
 
-  private constructor(binaryPath: string) {
-    this.child = spawn(binaryPath, ['mcp', '--socket', '\\\\.\\pipe\\cua-driver'], {
+  private constructor(binaryPath: string, mcpArgs: readonly string[]) {
+    // Follow Hermes' standard Windows runtime: the manifest-declared MCP
+    // process owns its runtime directly. Do not force it through the optional
+    // machine-wide daemon, whose independently updated contract may be stale.
+    this.child = spawn(binaryPath, [...mcpArgs], {
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
       env: cuaDriverEnvironment()
@@ -164,8 +180,8 @@ class CuaMcpClient {
     this.child.on('close', code => this.failAll(new CuaRuntimeError(`CUA MCP transport closed (${code ?? 'unknown'})`, 'transport')))
   }
 
-  static async connect(binaryPath: string, expectedVersion: string): Promise<CuaMcpClient> {
-    const client = new CuaMcpClient(binaryPath)
+  static async connect(binaryPath: string, expectedVersion: string, mcpArgs: readonly string[]): Promise<CuaMcpClient> {
+    const client = new CuaMcpClient(binaryPath, mcpArgs)
     const initialized = await client.request('initialize', {
       protocolVersion: '2025-06-18',
       capabilities: {},
@@ -369,6 +385,46 @@ function parseJsonObject(text: string, label: string): Record<string, unknown> {
   return parsed as Record<string, unknown>
 }
 
+function manifestRuntimeContract(manifest: CuaManifest): { mcpArgs: string[] } {
+  const invocation = manifest.mcp_invocation
+  const invocationArgs = invocation && typeof invocation === 'object' && !Array.isArray(invocation)
+    ? (invocation as Record<string, unknown>).args
+    : null
+  if (!Array.isArray(invocationArgs) || invocationArgs.length === 0 || !invocationArgs.every(arg => typeof arg === 'string' && arg.length > 0)) {
+    throw new CuaRuntimeError('CUA Driver manifest does not provide an MCP launch command', 'incompatible')
+  }
+
+  const advertised = new Map<string, Set<string>>()
+  if (Array.isArray(manifest.subcommands)) {
+    for (const entry of manifest.subcommands) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+      const command = entry as Record<string, unknown>
+      if (typeof command.name !== 'string') continue
+      const args = new Set<string>()
+      if (Array.isArray(command.args)) {
+        for (const arg of command.args) {
+          if (arg && typeof arg === 'object' && !Array.isArray(arg) && typeof (arg as Record<string, unknown>).name === 'string') {
+            args.add((arg as Record<string, unknown>).name as string)
+          }
+        }
+      }
+      advertised.set(command.name, args)
+    }
+  }
+
+  const missing: string[] = []
+  for (const [command, requiredArgs] of Object.entries(REQUIRED_MANIFEST_ARGS)) {
+    const actual = advertised.get(command) ?? new Set<string>()
+    for (const arg of requiredArgs) {
+      if (!actual.has(arg)) missing.push(`${command} ${arg}`)
+    }
+  }
+  if (missing.length > 0) {
+    throw new CuaRuntimeError(`CUA Driver manifest is missing: ${missing.join(', ')}`, 'incompatible')
+  }
+  return { mcpArgs: [...invocationArgs] as string[] }
+}
+
 function validatePositiveInteger(value: number, name: string): void {
   if (!Number.isSafeInteger(value) || value <= 0) {
     throw new CuaRuntimeError(`${name} must be a positive integer`, 'transport')
@@ -448,7 +504,8 @@ export class CuaDriverAdapter {
     permissionMode: 'standard' | 'bounded',
     private readonly runner: CuaProcessRunner,
     private readonly usePersistentMcp: boolean,
-    private readonly supportsCursorToggle: boolean
+    private readonly supportsCursorToggle: boolean,
+    private readonly mcpArgs: readonly string[]
   ) {
     this.binaryPath = binaryPath
     this.binaryVersion = binaryVersion
@@ -470,7 +527,7 @@ export class CuaDriverAdapter {
     }
     const versionText = await run(['--version'])
     const versionTuple = parseVersion(versionText)
-    if (!versionTuple || compareVersion(versionTuple, SUPPORTED_MIN_VERSION) < 0 || compareVersion(versionTuple, SUPPORTED_MAX_VERSION) >= 0) {
+    if (!versionTuple || compareVersion(versionTuple, SUPPORTED_MIN_VERSION) < 0) {
       throw new CuaRuntimeError(`Unsupported CUA Driver version: ${versionText || 'unknown'}`, 'incompatible')
     }
     const manifest = parseJsonObject(await run(['manifest', '--pretty']), 'CUA Driver manifest') as CuaManifest
@@ -481,22 +538,22 @@ export class CuaDriverAdapter {
     if (resolve(manifestPath).toLowerCase() !== resolve(binaryPath).toLowerCase()) {
       throw new CuaRuntimeError('CUA Driver manifest identifies a different executable', 'incompatible')
     }
+    const { mcpArgs } = manifestRuntimeContract(manifest)
     const toolNames = new Set((await run(['list-tools'])).split(/\r?\n/).map(line => line.split(':', 1)[0]?.trim()).filter(Boolean))
     const missingTools = REQUIRED_TOOLS.filter(tool => !toolNames.has(tool))
     if (missingTools.length > 0) {
       throw new CuaRuntimeError(`CUA Driver is missing required tools: ${missingTools.join(', ')}`, 'incompatible')
     }
-    const statusText = await run(['status'])
-    const permissionMatch = /permission mode:\s*(standard|bounded|unrestricted)\b/i.exec(statusText)
-    if (!permissionMatch || permissionMatch[1]?.toLowerCase() === 'unrestricted') {
-      throw new CuaRuntimeError('CUA Driver permission mode is unavailable or unrestricted', 'incompatible')
-    }
-    const permissionMode = permissionMatch[1]!.toLowerCase() as 'standard' | 'bounded'
-    // Temporary Windows compatibility policy for trycua/cua#3103. The global
+    // The sanitized direct MCP launch receives no permission-mode override,
+    // capability manifest, or approval-bypass environment, so cua-driver's
+    // fail-closed standard mode owns the child runtime. Host Full Access and
+    // task grants remain separate Relay authorization gates.
+    const permissionMode = 'standard' as const
+    // Temporary Windows compatibility policy for trycua/cua#3103. The
     // health_report performs a whole-desktop UIA walk with a fixed timeout and
     // can poison the driver's busy flag after a false timeout. Runtime
-    // readiness is therefore based on the canonical binary, manifest, tool
-    // contract, daemon status, and safe permission mode. Individual structured
+    // readiness is therefore based on the canonical binary, manifest, and tool
+    // contract. The direct child starts in standard mode, and individual structured
     // actions still fail closed. Keep health_report as an explicit diagnostic
     // via healthStatus(), and remove this split when upstream fixes #3103.
     return new CuaDriverAdapter(
@@ -505,7 +562,8 @@ export class CuaDriverAdapter {
       permissionMode,
       runner,
       options.runner === undefined,
-      toolNames.has('set_agent_cursor_enabled')
+      toolNames.has('set_agent_cursor_enabled'),
+      mcpArgs
     )
   }
 
@@ -531,19 +589,21 @@ export class CuaDriverAdapter {
     const checkedAt = new Date().toISOString()
     try {
       const adapter = await CuaDriverAdapter.connect(options)
-      const runner = options.runner ?? new SpawnCuaProcessRunner()
-      const result = await runner.run(adapter.binaryPath, ['call', 'health_report'], {
-        stdin: '{}',
-        timeoutMs: DEFAULT_TIMEOUT_MS,
-        env: cuaDriverEnvironment()
-      })
-      if (result.exitCode !== 0) {
-        return {
-          state: 'error', checkedAt, temporaryWindowsCompatibility: true,
-          reason: `CUA Driver health probe exited ${result.exitCode}`
+      let health: CuaHealthReport
+      if (options.runner) {
+        const result = await options.runner.run(adapter.binaryPath, ['call', 'health_report'], {
+          stdin: '{}', timeoutMs: DEFAULT_TIMEOUT_MS, env: cuaDriverEnvironment()
+        })
+        if (result.exitCode !== 0) {
+          return {
+            state: 'error', checkedAt, temporaryWindowsCompatibility: true,
+            reason: `CUA Driver health probe exited ${result.exitCode}`
+          }
         }
+        health = parseJsonObject(result.stdout.trim(), 'CUA Driver health report') as CuaHealthReport
+      } else {
+        health = await adapter.healthReport()
       }
-      const health = parseJsonObject(result.stdout.trim(), 'CUA Driver health report') as CuaHealthReport
       if (health.schema_version !== '1' || health.driver_version !== adapter.binaryVersion) {
         return {
           state: 'error', checkedAt, temporaryWindowsCompatibility: true,
@@ -565,13 +625,22 @@ export class CuaDriverAdapter {
     }
   }
 
+  private async healthReport(): Promise<CuaHealthReport> {
+    const mcp = await CuaMcpClient.connect(this.binaryPath, this.binaryVersion, this.mcpArgs)
+    try {
+      return await mcp.call('health_report', {}) as CuaHealthReport
+    } finally {
+      mcp.close()
+    }
+  }
+
   async openSession(identity: CuaControlSessionIdentity, signal?: AbortSignal, cursorEnabled = false): Promise<CuaControlSession> {
     const id = derivedSessionId(identity)
     if (this.sessions.has(id)) {
       throw new CuaRuntimeError('CUA control session is already active', 'transport')
     }
     if (signal?.aborted) throw new CuaRuntimeError('CUA control session was cancelled', 'transport')
-    const mcp = this.usePersistentMcp ? await CuaMcpClient.connect(this.binaryPath, this.binaryVersion) : null
+    const mcp = this.usePersistentMcp ? await CuaMcpClient.connect(this.binaryPath, this.binaryVersion, this.mcpArgs) : null
     const invoke = async (tool: string, args: Record<string, unknown>, invokeSignal?: AbortSignal): Promise<CuaToolResult> => {
       if (invokeSignal?.aborted) throw new CuaRuntimeError('CUA action was cancelled', 'transport')
       if (!ALLOWED_TOOLS.includes(tool)) throw new CuaRuntimeError('Attempted to invoke a non-allowlisted CUA Driver tool', 'transport')

--- a/desktop/src/tools/cuaManagement.ts
+++ b/desktop/src/tools/cuaManagement.ts
@@ -11,8 +11,7 @@ import {
   type CuaProcessRunner
 } from './cuaDriver.js'
 
-export const CUA_SUPPORTED_MIN_VERSION = '0.19.3'
-export const CUA_SUPPORTED_MAX_EXCLUSIVE = '0.20.0'
+export const CUA_SUPPORTED_MIN_VERSION = '0.20.0'
 const TRUSTED_REPOSITORY = 'trycua/cua'
 const TRUSTED_PRODUCT = 'cua-driver-rs'
 const RELEASE_BASE = 'https://github.com/trycua/cua/releases/download'
@@ -51,7 +50,7 @@ export interface CuaManagementStatus {
   bundled: false
   supported_range: {
     minimum: typeof CUA_SUPPORTED_MIN_VERSION
-    maximum_exclusive: typeof CUA_SUPPORTED_MAX_EXCLUSIVE
+    maximum_exclusive: null
   }
   update?: CuaUpdateStatus
   operation?: {
@@ -98,8 +97,7 @@ function compareVersion(left: string, right: string): number | null {
 
 export function isSupportedCuaVersion(value: string): boolean {
   const minimum = compareVersion(value, CUA_SUPPORTED_MIN_VERSION)
-  const maximum = compareVersion(value, CUA_SUPPORTED_MAX_EXCLUSIVE)
-  return minimum !== null && maximum !== null && minimum >= 0 && maximum < 0
+  return minimum !== null && minimum >= 0
 }
 
 function canonicalPaths(homeDir: string): { executable: string; releases: string } {
@@ -208,7 +206,7 @@ export async function getCuaManagementStatus(
     bundled: false,
     supported_range: {
       minimum: CUA_SUPPORTED_MIN_VERSION,
-      maximum_exclusive: CUA_SUPPORTED_MAX_EXCLUSIVE
+      maximum_exclusive: null
     }
   }
 }

--- a/desktop/src/tools/handlers/powershell.ts
+++ b/desktop/src/tools/handlers/powershell.ts
@@ -34,9 +34,10 @@ const DEFAULT_TIMEOUT_MS = 30_000
 // detached job (desktop_job_start) so the agent can poll instead of holding
 // a 10-minute open RPC.
 const MAX_TIMEOUT_MS = 10 * 60_000
-// Cap stdout/stderr per stream. PowerShell can produce a lot when the agent
-// asks for `Get-Process`, but a runaway loop shouldn't OOM the relay.
-const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+// Leave room for stderr, JSON escaping, and the desktop response envelope under
+// the relay's 4 MiB decompressed WebSocket-message limit. The router also owns
+// a final serialized-envelope budget for non-PowerShell handlers.
+const MAX_OUTPUT_BYTES = 1024 * 1024
 
 type ShellPick = 'pwsh' | 'powershell'
 

--- a/desktop/src/tools/router.ts
+++ b/desktop/src/tools/router.ts
@@ -64,6 +64,37 @@ export type ToolResponsePayload =
   | { request_id: string; ok: true; result: unknown }
   | { request_id: string; ok: false; error: string }
 
+// aiohttp's relay WebSocket accepts 4 MiB decompressed messages. Keep a full
+// MiB for the envelope, escaping growth, and protocol evolution. Handlers
+// should still apply useful domain-specific truncation; this is the final
+// fail-safe that prevents one oversized result from closing the shared socket.
+export const DESKTOP_RESPONSE_WIRE_BUDGET_BYTES = 3 * 1024 * 1024
+const ENVELOPE_ID_BUDGET_PLACEHOLDER = '00000000-0000-0000-0000-000000000000'
+
+export function fitDesktopResponseToWire(payload: ToolResponsePayload): ToolResponsePayload {
+  let wireBytes: number
+  try {
+    wireBytes = Buffer.byteLength(JSON.stringify({
+      channel: 'desktop',
+      type: 'desktop.response',
+      id: ENVELOPE_ID_BUDGET_PLACEHOLDER,
+      payload
+    }))
+  } catch {
+    return {
+      request_id: payload.request_id,
+      ok: false,
+      error: 'Desktop result could not be serialized. Retry with bounded text or save the output to a file.'
+    }
+  }
+  if (wireBytes <= DESKTOP_RESPONSE_WIRE_BUDGET_BYTES) return payload
+  return {
+    request_id: payload.request_id,
+    ok: false,
+    error: `Desktop result exceeded the ${DESKTOP_RESPONSE_WIRE_BUDGET_BYTES}-byte relay response budget. Retry with bounded output or save the result to a file.`
+  }
+}
+
 /** Context passed to every handler. `cwd` defaults to `process.cwd()` but
  * per-call overrides (e.g. terminalHandler's own `cwd` arg) still apply
  * inside the handler — this is just the router-level default. `abortSignal`
@@ -546,7 +577,7 @@ export class DesktopToolRouter {
       this.relay.sendChannel(
         'desktop',
         'desktop.response',
-        payload as unknown as Record<string, unknown>
+        fitDesktopResponseToWire(payload) as unknown as Record<string, unknown>
       )
     } catch {
       // If send fails, the server will time out the pending request; no

--- a/desktop/src/transport/RelayTransport.ts
+++ b/desktop/src/transport/RelayTransport.ts
@@ -59,6 +59,8 @@ const asGatewayEvent = (value: unknown): GatewayEvent | null =>
     ? (value as GatewayEvent)
     : null
 
+class CertificatePinMismatchError extends Error {}
+
 interface Pending {
   id: string
   method: string
@@ -156,8 +158,8 @@ export interface RelayTransportConfig {
   ttlSeconds?: number
   /** Test hook. */
   wsFactory?: WSFactory
-  /** Auto-reconnect on WSS close. Default: true. Set false for one-shot
-   * commands (pair, tools list). */
+  /** Auto-reconnect on WSS close. Opt in for long-running commands; one-shot
+   * commands (pair, tools list) remain terminal by default. */
   autoReconnect?: boolean
   /** Max reconnect attempts before giving up and emitting 'exit'. 0 =
    * unlimited. Default: 0. */
@@ -210,7 +212,7 @@ export class RelayTransport extends EventEmitter implements Transport {
   private logs = new CircularBuffer<string>(MAX_LOG_LINES)
   private pending = new Map<string, Pending>()
   private bufferedEvents = new CircularBuffer<GatewayEvent>(MAX_BUFFERED_EVENTS)
-  private pendingExit: number | null | undefined
+  private pendingExit: { code: number | null; reason: string } | undefined
   private subscribed = false
   private authResolved = false
   private authTimer: ReturnType<typeof setTimeout> | null = null
@@ -249,6 +251,10 @@ export class RelayTransport extends EventEmitter implements Transport {
    * pick which auth handler path runs — subsequent auth.ok should fire
    * `'reconnected'`, not settle the initial `whenAuthResolved()` promise. */
   private reconnectInFlight = false
+  /** True after any socket has completed auth. Unlike `authResolved`, this is
+   * not cleared while a replacement socket authenticates, so a failed
+   * reconnect attempt can schedule the next backoff instead of exiting. */
+  private everAuthenticated = false
 
   constructor(cfg: RelayTransportConfig) {
     super()
@@ -370,7 +376,10 @@ export class RelayTransport extends EventEmitter implements Transport {
         const msg = e instanceof Error ? e.message : String(e)
         this.pushLog(`[tofu] ${msg}`)
         this.publish({ type: 'gateway.stderr', payload: { line: `[tofu] ${msg}` } })
-        this.authFailReason = msg
+        // A reviewed pin mismatch is terminal. A refused/timed-out TLS probe
+        // during a Relay restart is transient and must continue the daemon's
+        // reconnect backoff.
+        if (e instanceof CertificatePinMismatchError) this.authFailReason = msg
         this.teardownSocket(-1, msg)
 
         return
@@ -491,7 +500,7 @@ export class RelayTransport extends EventEmitter implements Transport {
         // Surface a user-friendly remediation path. The session file carries
         // the pin so a re-pair clears it; `saveSession(..., {certPin: null})`
         // also wipes it if a `--reset-pin` flag lands.
-        throw new Error(
+        throw new CertificatePinMismatchError(
           `cert pin mismatch for ${key}: expected ${expectedPin}, got ${actualPin}. ` +
             `If this server was legitimately rotated, re-pair with \`hermes-relay pair\` ` +
             `to capture the new pin.`
@@ -651,6 +660,7 @@ export class RelayTransport extends EventEmitter implements Transport {
     if (type === 'auth.ok') {
       const isReconnect = this.reconnectInFlight
       this.authResolved = true
+      this.everAuthenticated = true
       this.state = 'connected'
       this.reconnectAttempt = 0
       this.reconnectInFlight = false
@@ -969,9 +979,9 @@ export class RelayTransport extends EventEmitter implements Transport {
     }
 
     if (this.subscribed) {
-      this.emit('exit', code)
+      this.emit('exit', code, reason)
     } else {
-      this.pendingExit = code
+      this.pendingExit = { code, reason }
     }
   }
 
@@ -1000,7 +1010,7 @@ export class RelayTransport extends EventEmitter implements Transport {
 
     const canReconnect =
       this.cfg.autoReconnect === true &&
-      this.authResolved && // only reconnect sessions that were once healthy
+      this.everAuthenticated && // only reconnect sessions that were once healthy
       !this.authFailReason && // terminal auth failure blocks reconnect
       (this.cfg.reconnectGate?.() ?? true) &&
       this.withinAttemptLimit()
@@ -1093,9 +1103,9 @@ export class RelayTransport extends EventEmitter implements Transport {
     }
 
     if (this.pendingExit !== undefined) {
-      const code = this.pendingExit
+      const { code, reason } = this.pendingExit
       this.pendingExit = undefined
-      this.emit('exit', code)
+      this.emit('exit', code, reason)
     }
   }
 

--- a/desktop/tests/cuaDriver.test.ts
+++ b/desktop/tests/cuaDriver.test.ts
@@ -20,6 +20,15 @@ const REQUIRED_TOOL_LINES = [
   'health_report', 'start_session', 'end_session', 'list_windows', 'get_window_state',
   'click', 'set_value', 'press_key', 'scroll'
 ].map(name => `${name}: test tool`).join('\n')
+const RUNTIME_SUBCOMMANDS = [
+  { name: 'mcp', args: [{ name: '--socket' }, { name: '--grant' }] },
+  { name: 'serve', args: [
+    { name: '--socket' }, { name: '--permission-mode' },
+    { name: '--capability-manifest' }, { name: '--approve-capability-manifest' },
+    { name: '--embedded' }
+  ] },
+  { name: 'stop', args: [{ name: '--socket' }] }
+]
 
 class FakeRunner implements CuaProcessRunner {
   readonly calls: Array<{ executable: string; args: readonly string[]; stdin?: string }> = []
@@ -27,7 +36,7 @@ class FakeRunner implements CuaProcessRunner {
   constructor(
     private readonly binaryPath: string,
     private readonly health = 'ok',
-    private readonly version = '0.19.3',
+    private readonly version = '0.21.0',
     private readonly permissionMode = 'standard'
   ) {}
 
@@ -36,7 +45,11 @@ class FakeRunner implements CuaProcessRunner {
     const command = args.join(' ')
     if (command === '--version') return ok(`cua-driver ${this.version}`)
     if (command === 'manifest --pretty') {
-      return ok(JSON.stringify({ schema_version: '1', binary_version: this.version, binary_path: this.binaryPath }))
+      return ok(JSON.stringify({
+        schema_version: '1', binary_version: this.version, binary_path: this.binaryPath,
+        mcp_invocation: { command: this.binaryPath, args: ['mcp'] },
+        subcommands: RUNTIME_SUBCOMMANDS
+      }))
     }
     if (command === 'list-tools') return ok(REQUIRED_TOOL_LINES)
     if (command === 'status') return ok(`Cua Driver daemon is running\n  permission mode: ${this.permissionMode} (test)`)
@@ -54,7 +67,7 @@ function ok(stdout: string): CuaProcessResult {
 async function fakeInstall(): Promise<{ home: string; binary: string; cleanup(): Promise<void> }> {
   const home = await mkdtemp(join(tmpdir(), 'hermes-cua-'))
   const releases = join(home, '.cua-driver', 'packages', 'releases')
-  const release = join(releases, '0.19.3-x86_64-pc-windows-msvc')
+  const release = join(releases, '0.21.0-x86_64-pc-windows-msvc')
   const current = join(home, '.cua-driver', 'packages', 'current')
   await mkdir(release, { recursive: true })
   const binary = join(release, 'cua-driver.exe')
@@ -69,27 +82,52 @@ test('discovers only the canonical package/current executable and negotiates rea
     const runner = new FakeRunner(install.binary)
     const adapter = await CuaDriverAdapter.connect({ platform: 'win32', homeDir: install.home, runner })
     assert.equal(adapter.binaryPath, install.binary)
-    assert.equal(adapter.binaryVersion, '0.19.3')
+    assert.equal(adapter.binaryVersion, '0.21.0')
     assert.equal(adapter.permissionMode, 'standard')
     assert.equal(runner.calls[0]?.executable, install.binary)
-    assert.deepEqual(runner.calls.map(call => call.args.join(' ')).slice(0, 4), [
-      '--version', 'manifest --pretty', 'list-tools', 'status'
+    assert.deepEqual(runner.calls.map(call => call.args.join(' ')).slice(0, 3), [
+      '--version', 'manifest --pretty', 'list-tools'
     ])
     assert.equal(runner.calls.some(call => call.args.join(' ') === 'call health_report'), false)
   } finally {
     await install.cleanup()
   }
 })
-test('keeps runtime ready when global health is degraded but still rejects unrestricted permission mode', async () => {
+test('keeps runtime ready when global health is degraded and owns a direct standard-mode child', async () => {
   const install = await fakeInstall()
   try {
     const adapter = await CuaDriverAdapter.connect({
-      platform: 'win32', homeDir: install.home, runner: new FakeRunner(install.binary, 'degraded')
+      platform: 'win32', homeDir: install.home, runner: new FakeRunner(install.binary, 'degraded', '0.21.0', 'unrestricted')
     })
-    assert.equal(adapter.binaryVersion, '0.19.3')
+    assert.equal(adapter.binaryVersion, '0.21.0')
+    assert.equal(adapter.permissionMode, 'standard')
+  } finally {
+    await install.cleanup()
+  }
+})
+
+test('rejects pre-contract versions and manifests missing Hermes-required daemon arguments', async () => {
+  const install = await fakeInstall()
+  try {
     await assert.rejects(
-      CuaDriverAdapter.connect({ platform: 'win32', homeDir: install.home, runner: new FakeRunner(install.binary, 'ok', '0.19.3', 'unrestricted') }),
-      (error: unknown) => error instanceof CuaRuntimeError && error.code === 'incompatible'
+      CuaDriverAdapter.connect({ platform: 'win32', homeDir: install.home, runner: new FakeRunner(install.binary, 'ok', '0.19.3') }),
+      /Unsupported CUA Driver version/
+    )
+    const runner = new FakeRunner(install.binary)
+    const originalRun = runner.run.bind(runner)
+    runner.run = async (executable, args, options = {}) => {
+      if (args.join(' ') === 'manifest --pretty') {
+        return ok(JSON.stringify({
+          schema_version: '1', binary_version: '0.21.0', binary_path: install.binary,
+          mcp_invocation: { command: install.binary, args: ['mcp'] },
+          subcommands: [{ name: 'mcp', args: [{ name: '--socket' }] }]
+        }))
+      }
+      return originalRun(executable, args, options)
+    }
+    await assert.rejects(
+      CuaDriverAdapter.connect({ platform: 'win32', homeDir: install.home, runner }),
+      /manifest is missing/
     )
   } finally {
     await install.cleanup()

--- a/desktop/tests/cuaDriverIntegration.test.ts
+++ b/desktop/tests/cuaDriverIntegration.test.ts
@@ -31,14 +31,26 @@ class StatefulFakeCua implements CuaProcessRunner {
     this.calls.push({ args: [...args], payload, signal: options.signal })
     if (options.signal?.aborted) throw new CuaRuntimeError('fake action cancelled', 'transport')
     const command = args.join(' ')
-    if (command === '--version') return ok('cua-driver 0.19.3')
+    if (command === '--version') return ok('cua-driver 0.21.0')
     if (command === 'manifest --pretty') {
-      return ok(JSON.stringify({ schema_version: '1', binary_version: '0.19.3', binary_path: this.binary }))
+      return ok(JSON.stringify({
+        schema_version: '1', binary_version: '0.21.0', binary_path: this.binary,
+        mcp_invocation: { command: this.binary, args: ['mcp'] },
+        subcommands: [
+          { name: 'mcp', args: [{ name: '--socket' }, { name: '--grant' }] },
+          { name: 'serve', args: [
+            { name: '--socket' }, { name: '--permission-mode' },
+            { name: '--capability-manifest' }, { name: '--approve-capability-manifest' },
+            { name: '--embedded' }
+          ] },
+          { name: 'stop', args: [{ name: '--socket' }] }
+        ]
+      }))
     }
     if (command === 'list-tools') return ok(tools.map(tool => `${tool}: fake`).join('\n'))
     if (command === 'status') return ok('permission mode: bounded')
     if (command === 'call health_report') {
-      return ok(JSON.stringify({ schema_version: '1', driver_version: '0.19.3', overall: 'ok' }))
+      return ok(JSON.stringify({ schema_version: '1', driver_version: '0.21.0', overall: 'ok' }))
     }
     if (command === 'call get_window_state') {
       return ok(JSON.stringify({
@@ -63,7 +75,7 @@ async function harness(): Promise<{
   cleanup(): Promise<void>
 }> {
   const home = await mkdtemp(join(tmpdir(), 'hermes-cua-integration-'))
-  const release = join(home, '.cua-driver', 'packages', 'releases', '0.19.3-test')
+  const release = join(home, '.cua-driver', 'packages', 'releases', '0.21.0-test')
   await mkdir(release, { recursive: true })
   const binary = join(release, 'cua-driver.exe')
   await writeFile(binary, '')

--- a/desktop/tests/cuaManagement.test.ts
+++ b/desktop/tests/cuaManagement.test.ts
@@ -18,7 +18,7 @@ import { computerUseCommand } from '../src/commands/computerUse.js'
 
 const ok = (stdout = ''): CuaProcessResult => ({ stdout, stderr: '', exitCode: 0 })
 
-async function packageHome(version = '0.19.3'): Promise<{ root: string; binary: string }> {
+async function packageHome(version = '0.20.0'): Promise<{ root: string; binary: string }> {
   const root = await mkdtemp(join(tmpdir(), 'hermes-cua-management-'))
   const release = join(root, '.cua-driver', 'packages', 'releases', `${version}-x86_64-pc-windows-msvc`)
   const current = join(root, '.cua-driver', 'packages', 'current')
@@ -31,7 +31,7 @@ async function packageHome(version = '0.19.3'): Promise<{ root: string; binary: 
 
 class ProbeRunner implements CuaProcessRunner {
   constructor(
-    readonly version = '0.19.3',
+    readonly version = '0.20.0',
     readonly latest = version,
     readonly onRun?: (executable: string, args: readonly string[], env?: NodeJS.ProcessEnv) => Promise<void> | void,
     readonly health: string = 'ok'
@@ -50,7 +50,17 @@ class ProbeRunner implements CuaProcessRunner {
     if (args[0] === 'manifest') return ok(JSON.stringify({
       schema_version: '1',
       binary_version: this.version,
-      binary_path: executable
+      binary_path: executable,
+      mcp_invocation: { command: executable, args: ['mcp'] },
+      subcommands: [
+        { name: 'mcp', args: [{ name: '--socket' }, { name: '--grant' }] },
+        { name: 'serve', args: [
+          { name: '--socket' }, { name: '--permission-mode' },
+          { name: '--capability-manifest' }, { name: '--approve-capability-manifest' },
+          { name: '--embedded' }
+        ] },
+        { name: 'stop', args: [{ name: '--socket' }] }
+      ]
     }))
     if (args[0] === 'list-tools') return ok([
       'health_report:', 'start_session:', 'end_session:', 'list_windows:',
@@ -64,11 +74,12 @@ class ProbeRunner implements CuaProcessRunner {
   }
 }
 
-test('supported CUA range is bounded to the adapter contract', () => {
-  assert.equal(isSupportedCuaVersion('0.19.2'), false)
-  assert.equal(isSupportedCuaVersion('0.19.3'), true)
-  assert.equal(isSupportedCuaVersion('0.19.99'), true)
-  assert.equal(isSupportedCuaVersion('0.20.0'), false)
+test('supported CUA range follows Hermes minimum-plus-contract semantics', () => {
+  assert.equal(isSupportedCuaVersion('0.19.99'), false)
+  assert.equal(isSupportedCuaVersion('0.20.0'), true)
+  assert.equal(isSupportedCuaVersion('0.21.0'), true)
+  assert.equal(isSupportedCuaVersion('1.0.0'), true)
+  assert.equal(isSupportedCuaVersion('not-semver'), false)
 })
 
 test('status prefers canonical package/current and reports a competing PATH shim', async () => {
@@ -80,7 +91,7 @@ test('status prefers canonical package/current and reports a competing PATH shim
       platform: 'win32', homeDir: home.root, path: stale, runner: new ProbeRunner()
     })
     assert.equal(status.installed, true)
-    assert.equal(status.current_version, '0.19.3')
+    assert.equal(status.current_version, '0.20.0')
     assert.equal(status.compatible, true)
     assert.equal(status.stale_path_shim, true)
     assert.equal(status.canonical_path, home.binary)
@@ -92,21 +103,21 @@ test('status prefers canonical package/current and reports a competing PATH shim
   }
 })
 
-test('check-update exposes a newer incompatible release without applying it', async () => {
+test('check-update accepts a newer release that preserves the Hermes runtime contract', async () => {
   const home = await packageHome()
   try {
     const status = await checkCuaUpdate({
-      platform: 'win32', homeDir: home.root, path: '', runner: new ProbeRunner('0.19.3', '0.20.0')
+      platform: 'win32', homeDir: home.root, path: '', runner: new ProbeRunner('0.20.0', '0.21.0')
     })
     assert.equal(status.update?.update_available, true)
-    assert.equal(status.update?.latest_version, '0.20.0')
-    assert.equal(status.update?.compatible, false)
+    assert.equal(status.update?.latest_version, '0.21.0')
+    assert.equal(status.update?.compatible, true)
   } finally {
     await rm(home.root, { recursive: true, force: true })
   }
 })
 
-test('update refuses an unsupported latest release before any download or apply', async () => {
+test('update refuses an invalid latest version before any download or apply', async () => {
   const home = await packageHome()
   let fetches = 0
   let powershellRuns = 0
@@ -115,7 +126,7 @@ test('update refuses an unsupported latest release before any download or apply'
       platform: 'win32',
       homeDir: home.root,
       path: '',
-      runner: new ProbeRunner('0.19.3', '0.20.0', executable => {
+      runner: new ProbeRunner('0.20.0', 'not-semver', executable => {
         if (executable.toLowerCase() === 'powershell.exe') powershellRuns += 1
       }),
       fetch: async () => {
@@ -144,19 +155,19 @@ test('install verifies trusted release metadata/checksum and sanitizes installer
         schemaVersion: 1,
         repository: 'trycua/cua',
         product: 'cua-driver-rs',
-        version: '0.19.3',
-        tag: 'cua-driver-rs-v0.19.3',
+        version: '0.20.0',
+        tag: 'cua-driver-rs-v0.20.0',
         assets: [{ name: 'install.ps1', sha256: scriptSha }]
       }
     }
   })
   let installerEnvironment: NodeJS.ProcessEnv | undefined
   let installerPath: string | undefined
-  const runner = new ProbeRunner('0.19.3', '0.19.3', async (executable, args, env) => {
+  const runner = new ProbeRunner('0.20.0', '0.20.0', async (executable, args, env) => {
     if (!executable.toLowerCase().endsWith('\\windows\\system32\\windowspowershell\\v1.0\\powershell.exe')) return
     installerEnvironment = env
     installerPath = args[args.indexOf('-File') + 1]
-    const release = join(root, '.cua-driver', 'packages', 'releases', '0.19.3-x86_64-pc-windows-msvc')
+    const release = join(root, '.cua-driver', 'packages', 'releases', '0.20.0-x86_64-pc-windows-msvc')
     await mkdir(release, { recursive: true })
     await writeFile(join(release, 'cua-driver.exe'), 'installed')
     await symlink(release, join(root, '.cua-driver', 'packages', 'current'), 'junction')
@@ -172,7 +183,7 @@ test('install verifies trusted release metadata/checksum and sanitizes installer
     assert.equal(status.operation?.runtime_verified, true)
     assert.equal(installerEnvironment?.OPENAI_API_KEY, undefined)
     assert.equal(installerEnvironment?.CUA_DRIVER_RS_TELEMETRY_ENABLED, '0')
-    assert.equal(installerEnvironment?.CUA_DRIVER_RS_VERSION, '0.19.3')
+    assert.equal(installerEnvironment?.CUA_DRIVER_RS_VERSION, '0.20.0')
     assert.ok(installerPath)
     await assert.rejects(access(installerPath!))
   } finally {
@@ -200,8 +211,8 @@ test('install rejects invalid release identity metadata before downloading the i
               schemaVersion: 1,
               repository: 'attacker/fork',
               product: 'cua-driver-rs',
-              version: '0.19.3',
-              tag: 'cua-driver-rs-v0.19.3',
+              version: '0.20.0',
+              tag: 'cua-driver-rs-v0.20.0',
               assets: [{ name: 'install.ps1', sha256: 'a'.repeat(64) }]
             }
           }
@@ -220,7 +231,7 @@ test('install rejects an installer whose bytes do not match release metadata', a
   try {
     await assert.rejects(installCuaDriver({
       platform: 'win32', homeDir: root, path: '',
-      runner: new ProbeRunner('0.19.3', '0.19.3', executable => {
+      runner: new ProbeRunner('0.20.0', '0.20.0', executable => {
         if (executable.toLowerCase() === 'powershell.exe') powershellRuns += 1
       }),
       fetch: async url => ({
@@ -231,7 +242,7 @@ test('install rejects an installer whose bytes do not match release metadata', a
           assert.match(url, /release-manifest\.json$/)
           return {
             schemaVersion: 1, repository: 'trycua/cua', product: 'cua-driver-rs',
-            version: '0.19.3', tag: 'cua-driver-rs-v0.19.3',
+            version: '0.20.0', tag: 'cua-driver-rs-v0.20.0',
             assets: [{ name: 'install.ps1', sha256: 'a'.repeat(64) }]
           }
         }
@@ -247,9 +258,9 @@ test('post-install runtime verification succeeds while explicit health remains d
   const root = await mkdtemp(join(tmpdir(), 'hermes-cua-degraded-'))
   const script = Buffer.from('installer')
   const checksum = createHash('sha256').update(script).digest('hex')
-  const runner = new ProbeRunner('0.19.3', '0.19.3', async executable => {
+  const runner = new ProbeRunner('0.20.0', '0.20.0', async executable => {
     if (!executable.toLowerCase().endsWith('\\windows\\system32\\windowspowershell\\v1.0\\powershell.exe')) return
-    const release = join(root, '.cua-driver', 'packages', 'releases', '0.19.3-x86_64-pc-windows-msvc')
+    const release = join(root, '.cua-driver', 'packages', 'releases', '0.20.0-x86_64-pc-windows-msvc')
     await mkdir(release, { recursive: true })
     await writeFile(join(release, 'cua-driver.exe'), 'installed')
     await symlink(release, join(root, '.cua-driver', 'packages', 'current'), 'junction')
@@ -265,7 +276,7 @@ test('post-install runtime verification succeeds while explicit health remains d
           assert.match(url, /release-manifest\.json$/)
           return {
             schemaVersion: 1, repository: 'trycua/cua', product: 'cua-driver-rs',
-            version: '0.19.3', tag: 'cua-driver-rs-v0.19.3',
+            version: '0.20.0', tag: 'cua-driver-rs-v0.20.0',
             assets: [{ name: 'install.ps1', sha256: checksum }]
           }
         }
@@ -307,13 +318,13 @@ test('install rejects an unverified installer before process execution', async (
         schemaVersion: 1,
         repository: 'trycua/cua',
         product: 'cua-driver-rs',
-        version: '0.19.3',
-        tag: 'cua-driver-rs-v0.19.3',
+        version: '0.20.0',
+        tag: 'cua-driver-rs-v0.20.0',
         assets: [{ name: 'install.ps1', sha256: '0'.repeat(64) }]
       }
     }
   })
-  const runner = new ProbeRunner('0.19.3', '0.19.3', () => { processStarted = true })
+  const runner = new ProbeRunner('0.20.0', '0.20.0', () => { processStarted = true })
   try {
     await assert.rejects(
       installCuaDriver({ platform: 'win32', homeDir: root, path: '', runner, fetch: fetchImpl }),

--- a/desktop/tests/relayTransportReconnect.test.ts
+++ b/desktop/tests/relayTransportReconnect.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { RelayTransport } from '../src/transport/RelayTransport.js'
+
+type Listener = (event: { code: number; reason: string } | { data: string } | { message?: string } | undefined) => void
+
+class FakeWebSocket {
+  readyState = 0
+  sent: string[] = []
+  private listeners = new Map<string, Listener[]>()
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? []
+    listeners.push(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = 3
+  }
+
+  open(): void {
+    this.readyState = 1
+    this.emit('open', undefined)
+  }
+
+  authOk(): void {
+    this.emit('message', {
+      data: JSON.stringify({
+        channel: 'system',
+        type: 'auth.ok',
+        payload: { session_token: 'session-token', server_version: 'test' }
+      })
+    })
+  }
+
+  drop(code: number, reason: string): void {
+    this.readyState = 3
+    this.emit('close', { code, reason })
+  }
+
+  private emit(type: string, event: Parameters<Listener>[0]): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event)
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for reconnect state')
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+test('authenticated transport keeps retrying when the first reconnect socket also drops', async t => {
+  const sockets: FakeWebSocket[] = []
+  const attempts: number[] = []
+  const relay = new RelayTransport({
+    url: 'ws://relay.example.test:8767',
+    sessionToken: 'session-token',
+    autoReconnect: true,
+    emitWorkspaceEnvelope: false,
+    wsFactory: () => {
+      const socket = new FakeWebSocket()
+      sockets.push(socket)
+      return socket
+    }
+  })
+  t.after(() => relay.kill())
+  relay.on('reconnecting', (info: { attempt: number }) => attempts.push(info.attempt))
+
+  relay.start()
+  await waitFor(() => sockets.length === 1)
+  sockets[0]!.open()
+  sockets[0]!.authOk()
+  assert.equal((await relay.whenAuthResolved()).ok, true)
+
+  sockets[0]!.drop(1006, 'first socket interrupted')
+  await waitFor(() => sockets.length === 2)
+  sockets[1]!.open()
+  sockets[1]!.drop(1006, 'replacement socket interrupted')
+
+  await waitFor(() => attempts.length === 2)
+  assert.deepEqual(attempts, [1, 2])
+  assert.equal(relay.getState(), 'reconnecting')
+})

--- a/desktop/tests/routerResponseBudget.test.ts
+++ b/desktop/tests/routerResponseBudget.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DESKTOP_RESPONSE_WIRE_BUDGET_BYTES,
+  fitDesktopResponseToWire,
+  type ToolResponsePayload
+} from '../src/tools/router.js'
+
+test('desktop response budget preserves ordinary results', () => {
+  const payload: ToolResponsePayload = {
+    request_id: 'request-1',
+    ok: true,
+    result: { stdout: 'complete', exit_code: 0 }
+  }
+
+  assert.equal(fitDesktopResponseToWire(payload), payload)
+})
+
+test('desktop response budget replaces an oversized result with a bounded error', () => {
+  const bounded = fitDesktopResponseToWire({
+    request_id: 'request-2',
+    ok: true,
+    result: { stdout: 'x'.repeat(DESKTOP_RESPONSE_WIRE_BUDGET_BYTES + 1) }
+  })
+
+  assert.deepEqual(bounded, {
+    request_id: 'request-2',
+    ok: false,
+    error: `Desktop result exceeded the ${DESKTOP_RESPONSE_WIRE_BUDGET_BYTES}-byte relay response budget. Retry with bounded output or save the result to a file.`
+  })
+  assert.ok(Buffer.byteLength(JSON.stringify(bounded)) < DESKTOP_RESPONSE_WIRE_BUDGET_BYTES)
+})
+
+test('desktop response budget rejects cyclic results without throwing', () => {
+  const result: Record<string, unknown> = {}
+  result.self = result
+
+  assert.deepEqual(fitDesktopResponseToWire({ request_id: 'request-3', ok: true, result }), {
+    request_id: 'request-3',
+    ok: false,
+    error: 'Desktop result could not be serialized. Retry with bounded text or save the output to a file.'
+  })
+})

--- a/desktop/tray/src/main.rs
+++ b/desktop/tray/src/main.rs
@@ -1068,10 +1068,19 @@ mod app {
     }
 
     fn daemon_status_from_probe(result: Result<Value, String>) -> DaemonStatus {
-        result
-            .ok()
-            .and_then(|value| serde_json::from_value(value).ok())
-            .unwrap_or_default()
+        let parsed = match result {
+            Ok(value) => serde_json::from_value(value).ok(),
+            // `daemon status --json` intentionally exits non-zero when the
+            // recorded process is gone, but stdout is still a useful status
+            // object with `alive:false`. Preserve it instead of surfacing the
+            // raw JSON as a tray command failure.
+            Err(output) => serde_json::from_str(&output).ok(),
+        };
+        let mut status: DaemonStatus = parsed.unwrap_or_default();
+        if !status.running {
+            status.state = stopped();
+        }
+        status
     }
 
     fn build_snapshot() -> Result<Snapshot, String> {
@@ -2557,6 +2566,27 @@ mod app {
                 assert!(!status.running);
                 assert!(status.url.is_none());
             }
+        }
+
+        #[test]
+        fn stale_daemon_json_preserves_diagnostics_without_claiming_connected() {
+            let status = daemon_status_from_probe(Err(serde_json::json!({
+                "state": "connected",
+                "alive": false,
+                "url": "wss://relay.example.test",
+                "last_event": "transport_exited",
+                "last_error": "Relay connection stopped (code 1009): message too big"
+            })
+            .to_string()));
+
+            assert_eq!(status.state, "stopped");
+            assert!(!status.running);
+            assert_eq!(status.url.as_deref(), Some("wss://relay.example.test"));
+            assert_eq!(status.last_event.as_deref(), Some("transport_exited"));
+            assert!(status
+                .last_error
+                .as_deref()
+                .is_some_and(|value| value.contains("1009")));
         }
 
         #[test]

--- a/desktop/tray/ui/App.tsx
+++ b/desktop/tray/ui/App.tsx
@@ -58,7 +58,7 @@ async function call<T>(command: string, args?: Record<string, unknown>): Promise
     if (command === 'check_desktop_update') return { current: '0.4.0-alpha.3', up_to_date: true, ahead_of_latest: true, latest_version: '0.4.0-alpha.2', installed: false, needs_restart: false } as T
     if (command === 'install_desktop_update') return { current: '0.4.0-alpha.3', up_to_date: true, ahead_of_latest: false, installed: true, needs_restart: true } as T
     if (command === 'test_host_route') return { best: { label: 'LAN', url: 'ws://172.16.24.250:8767', reachable: true, elapsed_ms: 36, encrypted: false, security: 'Unencrypted relay connection' }, routes: [] } as T
-    if (command === 'computer_cua_status') return { installed: false, stale_path_shim: false, compatible: false, compatibility_reason: 'CUA Driver is not installed', supported_range: { minimum: '0.19.3', maximum_exclusive: '0.20.0' } } as T
+    if (command === 'computer_cua_status') return { installed: false, stale_path_shim: false, compatible: false, compatibility_reason: 'CUA Driver is not installed', supported_range: { minimum: '0.20.0', maximum_exclusive: null } } as T
     if (command === 'computer_cua_health') return { state: 'degraded', checkedAt: new Date().toISOString(), overall: 'degraded', reason: 'UI Automation desktop enumeration exceeded 2000ms.', temporaryWindowsCompatibility: true } as T
     return undefined as T
   }

--- a/desktop/tray/ui/types.ts
+++ b/desktop/tray/ui/types.ts
@@ -61,7 +61,7 @@ export interface CuaManagementStatus {
   current_version?: string | null
   compatible: boolean
   compatibility_reason?: string | null
-  supported_range: { minimum: string; maximum_exclusive: string }
+  supported_range: { minimum: string; maximum_exclusive: string | null }
   update?: { latest_version?: string; update_available: boolean; compatible: boolean; error?: string; release_notes_url?: string }
   operation?: { kind: 'install' | 'update'; state: 'completed'; version: string }
 }

--- a/user-docs/desktop/installation.md
+++ b/user-docs/desktop/installation.md
@@ -80,12 +80,13 @@ hermes-relay computer-use cua update --yes
 ```
 
 Install is pinned to the minimum compatible release. Update first asks the
-installed driver's native update service which release is current, then refuses
-to apply it if it falls outside Hermes-Relay's supported range (`>=0.19.3,
-<0.20.0`). Hermes downloads the versioned GitHub release manifest and installer,
+installed driver's native update service which release is current. Following
+Hermes, compatibility requires CUA Driver `>=0.20.0` and has no hardcoded upper
+version ceiling; each build must continue to advertise the required manifest,
+daemon/MCP arguments, and tool contract. Hermes-Relay downloads the versioned GitHub release manifest and installer,
 checks the manifest repository/product/version and the installer's SHA-256, and
 then verifies the canonical binary path, version, driver manifest, required
-tools, and permission mode. Accessibility health remains an explicit recheck
+tools, and direct standard-mode MCP launch. Accessibility health remains an explicit recheck
 while the temporary Windows compatibility workaround is active. These are release-metadata and
 checksum integrity checks, not a Windows publisher signature.
 

--- a/user-docs/desktop/subcommands.md
+++ b/user-docs/desktop/subcommands.md
@@ -317,8 +317,10 @@ compatibility choice. Backend selection is fixed when a control session starts,
 so an engine setting change affects only new sessions. CUA lifecycle mutations
 require `--yes` and never run automatically. Hermes verifies the upstream
 release manifest and installer checksum, runs the installer with a sanitized
-environment, and accepts only `>=0.19.3 <0.20.0` under the canonical
-`%USERPROFILE%\.cua-driver\packages\current` package.
+environment, and accepts `>=0.20.0` under the canonical
+`%USERPROFILE%\.cua-driver\packages\current` package when its live manifest,
+daemon/MCP arguments, and required tools remain compatible. On Windows, each
+control session owns the manifest-declared direct standard-mode MCP runtime.
 
 ## `hermes-relay grants`
 

--- a/user-docs/desktop/subcommands.md
+++ b/user-docs/desktop/subcommands.md
@@ -245,6 +245,14 @@ hermes-relay daemon --token <t> --allow-tools    # skip stored-consent gate (onl
 
 `daemon start` (alias `daemon --detach`) re-spawns the foreground daemon detached: no console window, stdio redirected to `~/.hermes/daemon.log`, and it keeps running after you close the terminal. `daemon status` reads the heartbeat file the running daemon maintains and cross-checks that the pid is alive, so a crashed daemon whose file lingers reads as "not running" (and `status` exits non-zero, for scripts). Bare `hermes-relay daemon` still runs in the foreground.
 
+After its first successful authentication, the daemon retries interrupted Relay
+connections indefinitely with bounded exponential backoff. Relay service
+restarts and failed replacement sockets therefore keep the daemon in
+`reconnecting` until the tunnel returns. Authentication rejection and an
+explicit local stop remain terminal. Desktop-tool responses are bounded below
+the Relay WebSocket limit; commands that produce more output return truncation
+or an actionable bounded-output error without taking the connection down.
+
 On Windows, `--administrator` is an explicit UAC boundary for `start`, `stop`,
 or `restart`; it never elevates the tray. `daemon restart --user` is intended
 for an unelevated caller returning an Administrator daemon to normal operation:
@@ -272,7 +280,7 @@ ready                 → DesktopToolRouter attached (advertised_tools list)
 reconnecting          → backoff delay (attempt, delay_ms)
 reconnected           → back online
 shutdown              → SIGTERM/SIGINT/SIGHUP received
-transport_exited      → reconnect budget exhausted; exit 1 so service manager restarts fresh
+transport_exited      → terminal auth/reconnect-policy failure; stopped status persisted, then exit 1
 ```
 
 **Fails closed:** no stored session + no `--token` → exits 1. No `toolsConsented: true` on the stored record → exits 1 unless `--allow-tools` is passed alongside an explicit `--token` (a headless binary must never be the thing that first grants tool access).

--- a/user-docs/desktop/tools.md
+++ b/user-docs/desktop/tools.md
@@ -275,10 +275,14 @@ CUA Driver is a separate optional dependency. Hermes-Relay does not bundle or
 silently install/update it. `computer-use cua status|check-update` are
 read-only; `install|update` require explicit `--yes` confirmation. Hermes uses
 the canonical upstream package, validates versioned GitHub release metadata and
-installer SHA-256, and refuses updates outside `>=0.19.3,<0.20.0`. These checks
+installer SHA-256, and follows Hermes' `>=0.20.0` minimum-plus-runtime-contract
+policy instead of pinning an upper version. The driver must continue to advertise
+the required manifest, daemon/MCP arguments, and tools. Windows sessions launch
+that MCP runtime directly in standard mode instead of depending on the separately
+updated machine-wide daemon. These checks
 do not claim a Windows publisher signature. Hermes executes the verified
 temporary installer under a sanitized environment, then validates the canonical
-`packages/current` binary, driver manifest, and permission mode. The UI and
+`packages/current` binary, driver manifest, and direct runtime contract. The UI and
 `computer-use cua health` can recheck accessibility health without changing
 the selected backend. Hermes forces CUA telemetry off for
 its child invocations; any future telemetry opt-in belongs to the local

--- a/user-docs/desktop/troubleshooting.md
+++ b/user-docs/desktop/troubleshooting.md
@@ -145,8 +145,8 @@ hermes-relay computer-use status --json
 - **Not installed** means the canonical package was not found at
   `%USERPROFILE%\.cua-driver\packages\current\cua-driver.exe`. A PATH-only shim
   is intentionally ignored.
-- **Incompatible** means the executable, manifest, supported version, required
-  tool set, or permission mode did not match the Hermes adapter contract.
+- **Incompatible** means the executable, Hermes-compatible minimum version,
+  manifest launch contract, or required tool set did not match the adapter.
 - **Accessibility health** is a separate, explicit diagnostic on Windows. Use
   **Recheck** in the UI or run `hermes-relay computer-use cua health`. A
   degraded result does not disable the runtime while the temporary workaround
@@ -156,7 +156,7 @@ hermes-relay computer-use status --json
   diagnosis.
 
 CUA is preferred for new structured-control sessions. If its executable,
-manifest, required tool set, daemon status, or safe permission mode is not
+manifest, required tool set, or direct standard-mode MCP launch is not
 ready before a session begins, Hermes can select the Windows input compatibility backend;
 it never changes backend in the middle of a control session. Re-check with
 `hermes-relay computer-use cua status`, repair explicitly with


### PR DESCRIPTION
## Summary

- Integrate the pending desktop daemon reconnect recovery and current CUA Driver contract alignment on the latest `dev`.
- Keep Hermes-Relay transport alive across interrupted and repeatedly failed reconnect attempts, and bound oversized desktop-tool responses instead of closing the shared socket.
- Accept current compatible CUA Driver releases and use the manifest-declared direct standard-mode runtime on Windows.
- Preserve the user docs and changelog entries for the next Desktop release.

## Verification

- `cd desktop && npm run verify`
  - 170 CLI tests passed
  - Type-check, build, and compiled Windows binary smoke passed
  - Tray formatting, Clippy, build, and check passed
  - 30 Rust tray tests passed

## Non-goals

- No version bump, tag, release, deployment, or installer publication.