### PR TITLE
chore(ci): promote HR Candidate reporter wording

### DIFF
--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -26,7 +26,7 @@ Built from PR #${prNumber} head \`${shortSha}\`.
 [Download \`${artifact.name}\`](${artifactUrl}) — expires **${formatExpiry(artifact.expires_at)}**.
 
 1. Unzip the bundle and verify its files against \`SHA256SUMS.txt\`.
-2. Install the APK under \`android/\`. It appears as **Hermes Candidate**, leaves stable installs untouched, and must be paired separately.
+2. Install the APK under \`android/\`. It appears as **HR Candidate**, leaves stable installs untouched, and must be paired separately.
 3. Test the Relay package only in a disposable/staging Hermes instance or with an explicit snapshot and rollback plan. Confirm the source SHA in \`REVIEW_MANIFEST.json\`.
 
 [View workflow run](${runUrl})`;

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -37,7 +37,8 @@ const successBody = buildReviewComment({
 assert.match(successBody, /## Review candidate ready/);
 assert.match(successBody, /hermes-relay-review-pr-398-90ab705a883c/);
 assert.match(successBody, /expires \*\*August 31, 2026\*\*/);
-assert.match(successBody, /Hermes Candidate/);
+assert.match(successBody, /HR Candidate/);
+assert.ok(!successBody.includes(['Hermes', 'Candidate'].join(' ')));
 assert.match(successBody, /REVIEW_MANIFEST\.json/);
 
 const blockedBody = buildReviewComment({


### PR DESCRIPTION
## Summary

Promote the reviewed **HR Candidate** handoff wording to the trusted default-branch reporter.

## Changes

- replace the old candidate launcher name in the PR artifact instructions
- update the reporter regression to require `HR Candidate` and reject the old name

## Why this targets main

GitHub executes the write-capable reporter from the default branch. The Android manifest, review workflow, release workflow, and full documentation merged to `dev` in #407; this promotion contains only the trusted reporter copy and test.

## Verification

- `node .github/scripts/review-bundle-report.test.cjs` - passed
- `git diff --check` - passed

## Lineage / contributor credit

- Source PR(s): #407, #412
- Attribution preserved by: original maintainer commits

## Checklist

- [x] Focused default-branch automation promotion
- [x] Product, release, Android, Plugin, CLI+UI, docs, and UI changes: N/A
- [x] Commit follows Conventional Commits
- [x] Public writing hygiene checked