### PR TITLE
test(desktop): refresh release screenshot fingerprint

### DIFF
--- a/docs/media/desktop-ui-screenshots.json
+++ b/docs/media/desktop-ui-screenshots.json
@@ -51,7 +51,7 @@
   "sourceFingerprint": {
     "algorithm": "sha256",
     "normalization": "text-lf-v1",
-    "digest": "07cf8f3be17b2029f79bcbd4c291ce81986e8ce6e2ed08aad261bf8c80ce41f5",
+    "digest": "8cf00c04da9e80621b439563145be49ede9539ac95ab903b1903763004e370bc",
     "files": [
       "desktop/tray/ui/App.tsx",
       "desktop/tray/ui/main.tsx",


### PR DESCRIPTION
## Summary
Refresh the deterministic Desktop UI source fingerprint after the CLI+UI beta.5 version bump.

The version bump does not change the visible UI, so the approved canonical screenshots are retained byte-for-byte. The Website asset pipeline now recognizes those references as current.

## Test Plan
- [x] Compared the two initially recaptured images with the approved references.
- [x] Retained the approved pixels after catching a nondeterministic clipped capture.
- [x] `node website/scripts/desktop-ui-assets.mjs sync`
- [x] `npm --prefix website run build`

## Release note
This changes the frozen release tree, so Android Play preflight will be rerun after merge. PR #419 remains excluded.