### PR TITLE
chore: reconcile main release ancestry into dev

### DIFF
--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -26,7 +26,7 @@ Built from PR #${prNumber} head \`${shortSha}\`.
 [Download \`${artifact.name}\`](${artifactUrl}) — expires **${formatExpiry(artifact.expires_at)}**.
 
 1. Unzip the bundle and verify its files against \`SHA256SUMS.txt\`.
-2. Install the APK under \`android/\`. It appears as **Hermes Candidate**, leaves stable installs untouched, and must be paired separately.
+2. Install the APK under \`android/\`. It appears as **HR Candidate**, leaves stable installs untouched, and must be paired separately.
 3. Test the Relay package only in a disposable/staging Hermes instance or with an explicit snapshot and rollback plan. Confirm the source SHA in \`REVIEW_MANIFEST.json\`.
 
 [View workflow run](${runUrl})`;

--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -1,0 +1,169 @@
+'use strict';
+
+const COMMENT_MARKER = '<!-- hermes-relay-review-candidate -->';
+const ARTIFACT_NAME_RE = /^hermes-relay-review-pr-(\d+)-([0-9a-f]{12})$/;
+
+function formatExpiry(value) {
+  if (!value) return 'the artifact retention window';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+function buildReviewComment({ conclusion, prNumber, headSha, runUrl, artifact }) {
+  const shortSha = headSha.slice(0, 12);
+
+  if (conclusion === 'success' && artifact) {
+    const artifactUrl = `${runUrl}/artifacts/${artifact.id}`;
+    return `${COMMENT_MARKER}
+## Review candidate ready
+
+Built from PR #${prNumber} head \`${shortSha}\`.
+
+[Download \`${artifact.name}\`](${artifactUrl}) — expires **${formatExpiry(artifact.expires_at)}**.
+
+1. Unzip the bundle and verify its files against \`SHA256SUMS.txt\`.
+2. Install the APK under \`android/\`. It appears as **Hermes Candidate**, leaves stable installs untouched, and must be paired separately.
+3. Test the Relay package only in a disposable/staging Hermes instance or with an explicit snapshot and rollback plan. Confirm the source SHA in \`REVIEW_MANIFEST.json\`.
+
+[View workflow run](${runUrl})`;
+  }
+
+  if (conclusion === 'action_required') {
+    return `${COMMENT_MARKER}
+## Review candidate awaiting approval
+
+GitHub held the build for PR #${prNumber} head \`${shortSha}\` at the first-time fork approval gate. A maintainer must approve the run before any candidate can be published.
+
+[Review and approve the workflow run](${runUrl})`;
+  }
+
+  const result = conclusion || 'unknown';
+  return `${COMMENT_MARKER}
+## Review candidate unavailable
+
+The build for PR #${prNumber} head \`${shortSha}\` completed with **${result}** and did not publish a candidate bundle.
+
+[View workflow run](${runUrl})`;
+}
+
+function artifactPrNumber(artifacts, headSha) {
+  const shortSha = headSha.slice(0, 12);
+  for (const artifact of artifacts) {
+    const match = ARTIFACT_NAME_RE.exec(artifact.name);
+    if (match && match[2] === shortSha) return Number(match[1]);
+  }
+  return null;
+}
+
+async function resolvePrNumber({ github, owner, repo, run, artifacts }) {
+  const payloadPr = run.pull_requests?.[0]?.number;
+  if (payloadPr) return payloadPr;
+
+  const artifactPr = artifactPrNumber(artifacts, run.head_sha);
+  if (artifactPr) return artifactPr;
+
+  const headOwner = run.head_repository?.owner?.login;
+  if (!headOwner || !run.head_branch) return null;
+
+  const { data: pulls } = await github.rest.pulls.list({
+    owner,
+    repo,
+    head: `${headOwner}:${run.head_branch}`,
+    state: 'all',
+    per_page: 100,
+  });
+  const exact = pulls.find((pull) =>
+    pull.head.sha === run.head_sha && pull.base.ref === 'dev'
+  );
+  return exact?.number ?? null;
+}
+
+async function resolveWorkflowRun({ github, context, core }) {
+  const completedRun = context.payload.workflow_run;
+  if (completedRun) return completedRun;
+
+  const requested = context.payload.inputs?.run_id;
+  const runId = Number(requested);
+  if (!Number.isSafeInteger(runId) || runId <= 0) {
+    core.setFailed(`Invalid Build Review Bundle run ID: ${requested ?? ''}`);
+    return null;
+  }
+  const { owner, repo } = context.repo;
+  const { data: run } = await github.rest.actions.getWorkflowRun({
+    owner,
+    repo,
+    run_id: runId,
+  });
+  return run;
+}
+
+async function reportReviewBundle({ github, context, core }) {
+  const run = await resolveWorkflowRun({ github, context, core });
+  const { owner, repo } = context.repo;
+  if (!run) return;
+  if (run.name !== 'Build Review Bundle' || run.event !== 'pull_request') {
+    core.info('Ignoring a review-bundle run that was not triggered by a pull request.');
+    return;
+  }
+
+  const artifacts = await github.paginate(
+    github.rest.actions.listWorkflowRunArtifacts,
+    { owner, repo, run_id: run.id, per_page: 100 },
+  );
+  const prNumber = await resolvePrNumber({ github, owner, repo, run, artifacts });
+  if (!prNumber) {
+    core.warning(`Could not resolve a pull request for review-bundle run ${run.id}.`);
+    return;
+  }
+
+  const expectedName = `hermes-relay-review-pr-${prNumber}-${run.head_sha.slice(0, 12)}`;
+  const artifact = artifacts.find((item) => item.name === expectedName && !item.expired);
+  const body = buildReviewComment({
+    conclusion: run.conclusion,
+    prNumber,
+    headSha: run.head_sha,
+    runUrl: run.html_url,
+    artifact,
+  });
+
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: prNumber, per_page: 100 },
+  );
+  const existing = comments.find((comment) =>
+    comment.user?.login === 'github-actions[bot]' &&
+    comment.body?.includes(COMMENT_MARKER)
+  );
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    core.info(`Updated review-candidate comment on PR #${prNumber}.`);
+  } else {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+    core.info(`Created review-candidate comment on PR #${prNumber}.`);
+  }
+}
+
+module.exports = {
+  ARTIFACT_NAME_RE,
+  COMMENT_MARKER,
+  artifactPrNumber,
+  buildReviewComment,
+  reportReviewBundle,
+  resolvePrNumber,
+  resolveWorkflowRun,
+};

--- a/.github/scripts/review-bundle-report.cjs
+++ b/.github/scripts/review-bundle-report.cjs
@@ -109,6 +109,10 @@ async function reportReviewBundle({ github, context, core }) {
     core.info('Ignoring a review-bundle run that was not triggered by a pull request.');
     return;
   }
+  if (run.conclusion === 'skipped') {
+    core.info(`Ignoring skipped review-bundle run ${run.id}.`);
+    return;
+  }
 
   const artifacts = await github.paginate(
     github.rest.actions.listWorkflowRunArtifacts,

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -37,7 +37,8 @@ const successBody = buildReviewComment({
 assert.match(successBody, /## Review candidate ready/);
 assert.match(successBody, /hermes-relay-review-pr-398-90ab705a883c/);
 assert.match(successBody, /expires \*\*August 31, 2026\*\*/);
-assert.match(successBody, /Hermes Candidate/);
+assert.match(successBody, /HR Candidate/);
+assert.ok(!successBody.includes(['Hermes', 'Candidate'].join(' ')));
 assert.match(successBody, /REVIEW_MANIFEST\.json/);
 
 const blockedBody = buildReviewComment({

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -134,9 +134,47 @@ async function testManualRunSelectionCreatesComment() {
   assert.match(calls.create[0].body, /## Review candidate ready/);
 }
 
+async function testSkippedRunIsIgnored() {
+  let apiCalled = false;
+  const messages = [];
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRunArtifacts() {},
+      },
+    },
+    paginate: async () => {
+      apiCalled = true;
+      return [];
+    },
+  };
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: {
+        workflow_run: {
+          ...run,
+          id: 32736508535,
+          conclusion: 'skipped',
+          head_sha: 'a38849ff1680a1993230773a5d602b781367c789',
+        },
+      },
+    },
+    core: {
+      info: (message) => messages.push(message),
+      warning: (message) => messages.push(message),
+      setFailed: (message) => assert.fail(message),
+    },
+  });
+  assert.equal(apiCalled, false);
+  assert.deepEqual(messages, ['Ignoring skipped review-bundle run 32736508535.']);
+}
+
 Promise.all([
   testExistingCommentIsUpdated(),
   testManualRunSelectionCreatesComment(),
+  testSkippedRunIsIgnored(),
 ])
   .then(() => console.log('Review-bundle report tests passed.'))
   .catch((error) => {

--- a/.github/scripts/review-bundle-report.test.cjs
+++ b/.github/scripts/review-bundle-report.test.cjs
@@ -1,0 +1,145 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+  artifactPrNumber,
+  buildReviewComment,
+  reportReviewBundle,
+} = require('./review-bundle-report.cjs');
+
+const run = {
+  id: 32729383426,
+  name: 'Build Review Bundle',
+  event: 'pull_request',
+  conclusion: 'success',
+  head_sha: '90ab705a883ca963035f4f8ccda815619dbd4f3b',
+  head_branch: 'fix/gateway-history-attachments',
+  head_repository: { owner: { login: 'JackHunzicker' } },
+  html_url: 'https://github.com/Codename-11/hermes-relay/actions/runs/32729383426',
+  pull_requests: [],
+};
+const artifact = {
+  id: 9521126010,
+  name: 'hermes-relay-review-pr-398-90ab705a883c',
+  expired: false,
+  expires_at: '2026-08-31T12:52:24Z',
+};
+
+assert.equal(artifactPrNumber([artifact], run.head_sha), 398);
+
+const successBody = buildReviewComment({
+  conclusion: 'success',
+  prNumber: 398,
+  headSha: run.head_sha,
+  runUrl: run.html_url,
+  artifact,
+});
+assert.match(successBody, /## Review candidate ready/);
+assert.match(successBody, /hermes-relay-review-pr-398-90ab705a883c/);
+assert.match(successBody, /expires \*\*August 31, 2026\*\*/);
+assert.match(successBody, /Hermes Candidate/);
+assert.match(successBody, /REVIEW_MANIFEST\.json/);
+
+const blockedBody = buildReviewComment({
+  conclusion: 'action_required',
+  prNumber: 398,
+  headSha: run.head_sha,
+  runUrl: run.html_url,
+});
+assert.match(blockedBody, /## Review candidate awaiting approval/);
+assert.doesNotMatch(blockedBody, /Download/);
+
+async function testExistingCommentIsUpdated() {
+  const calls = { create: [], update: [] };
+  const github = {
+    rest: {
+      actions: { listWorkflowRunArtifacts() {} },
+      issues: {
+        listComments() {},
+        createComment: async (args) => calls.create.push(args),
+        updateComment: async (args) => calls.update.push(args),
+      },
+      pulls: { list: async () => ({ data: [] }) },
+    },
+    paginate: async (method) => {
+      if (method === github.rest.actions.listWorkflowRunArtifacts) return [artifact];
+      if (method === github.rest.issues.listComments) {
+        return [{
+          id: 77,
+          user: { login: 'github-actions[bot]' },
+          body: '<!-- hermes-relay-review-candidate -->\nold',
+        }];
+      }
+      throw new Error('Unexpected pagination method');
+    },
+  };
+  const messages = [];
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: { workflow_run: run },
+    },
+    core: {
+      info: (message) => messages.push(message),
+      warning: (message) => messages.push(message),
+    },
+  });
+  assert.equal(calls.create.length, 0);
+  assert.equal(calls.update.length, 1);
+  assert.equal(calls.update[0].comment_id, 77);
+  assert.match(calls.update[0].body, /## Review candidate ready/);
+  assert.deepEqual(messages, ['Updated review-candidate comment on PR #398.']);
+}
+
+async function testManualRunSelectionCreatesComment() {
+  const calls = { create: [], update: [] };
+  const github = {
+    rest: {
+      actions: {
+        getWorkflowRun: async ({ run_id: runId }) => {
+          assert.equal(runId, run.id);
+          return { data: run };
+        },
+        listWorkflowRunArtifacts() {},
+      },
+      issues: {
+        listComments() {},
+        createComment: async (args) => calls.create.push(args),
+        updateComment: async (args) => calls.update.push(args),
+      },
+      pulls: { list: async () => ({ data: [] }) },
+    },
+    paginate: async (method) => {
+      if (method === github.rest.actions.listWorkflowRunArtifacts) return [artifact];
+      if (method === github.rest.issues.listComments) return [];
+      throw new Error('Unexpected pagination method');
+    },
+  };
+  await reportReviewBundle({
+    github,
+    context: {
+      repo: { owner: 'Codename-11', repo: 'hermes-relay' },
+      payload: { inputs: { run_id: String(run.id) } },
+    },
+    core: {
+      info() {},
+      warning() {},
+      setFailed: (message) => assert.fail(message),
+    },
+  });
+  assert.equal(calls.update.length, 0);
+  assert.equal(calls.create.length, 1);
+  assert.equal(calls.create[0].issue_number, 398);
+  assert.match(calls.create[0].body, /## Review candidate ready/);
+}
+
+Promise.all([
+  testExistingCommentIsUpdated(),
+  testManualRunSelectionCreatesComment(),
+])
+  .then(() => console.log('Review-bundle report tests passed.'))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/.github/workflows/review-bundle-report.yml
+++ b/.github/workflows/review-bundle-report.yml
@@ -1,0 +1,55 @@
+name: Report Review Bundle
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Completed Build Review Bundle run ID to report
+        required: true
+        type: string
+  workflow_run:
+    workflows:
+      - Build Review Bundle
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: review-bundle-report-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'pull_request'
+      }}
+    name: Update pull request comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Check out only the trusted default branch. Never check out the PR head or
+      # execute/download its candidate artifact in this write-capable workflow.
+      - name: Checkout trusted reporter
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Test trusted reporter
+        run: node .github/scripts/review-bundle-report.test.cjs
+
+      - name: Report candidate status
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const reporter = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/review-bundle-report.cjs`
+            );
+            await reporter.reportReviewBundle({ github, context, core });

--- a/.github/workflows/review-bundle-report.yml
+++ b/.github/workflows/review-bundle-report.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: review-bundle-report-${{ github.event.workflow_run.id || inputs.run_id }}


### PR DESCRIPTION
## Summary
Reconcile `main` ancestry back into `dev` before the release merge.

`main` contains four earlier CI-promotion merge commits that are not ancestors of `dev`, but their content is already present. The computed merge tree is byte-for-byte identical to the current preflighted `dev` tree, so this changes topology only.

## Verification
- `git merge-tree --write-tree origin/dev origin/main` equals `origin/dev^{tree}`.
- Android Play preflight remains valid because its proof is keyed to the unchanged Git tree.
- PR #419 remains excluded.