### PR TITLE
fix(server): bound provider usage profile errors

### DIFF
--- a/plugin/relay/server.py
+++ b/plugin/relay/server.py
@@ -1185,7 +1185,7 @@ async def handle_provider_usage(request: web.Request) -> web.Response:
             request.query.get("profile"),
         )
     except ValueError as exc:
-        raise web.HTTPBadRequest(text=str(exc)) from exc
+        raise web.HTTPBadRequest(text="invalid or unknown profile") from exc
     return web.json_response(
         await collect_provider_usage(
             profile_home=profile_home,

--- a/plugin/tests/test_provider_usage.py
+++ b/plugin/tests/test_provider_usage.py
@@ -258,6 +258,19 @@ class ProviderUsageEndpointTests(AioHTTPTestCase):
         response = await self.client.get("/usage/providers")
         self.assertEqual(response.status, 401)
 
+    async def test_invalid_profile_error_does_not_reflect_request_input(self) -> None:
+        token = await self._mint()
+        response = await self.client.get(
+            "/usage/providers?profile=../private-token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        body = await response.text()
+        self.assertEqual(response.status, 400 if self.usage_enabled else 404)
+        if self.usage_enabled:
+            self.assertEqual(body, "invalid or unknown profile")
+        self.assertNotIn("private-token", body)
+
     @mock.patch(
         "plugin.relay.server.collect_provider_usage",
         new=mock.AsyncMock(return_value={"schema_version": 1, "providers": []}),


### PR DESCRIPTION
## Summary
Return one fixed public error for invalid provider-usage profile selectors instead of serializing an exception message across the HTTP boundary.

## Security validation
The selector is regex-gated and the current `ValueError` messages are constants, so the CodeQL finding did not expose a stack trace in the observed implementation. This patch removes the brittle exception-string sink entirely and proves malicious profile text is not reflected.

## Test Plan
- [x] Provider usage suite: 13 passed
- [x] `python -m py_compile plugin/relay/server.py`

## Release note
This changes the frozen release tree. Android Play preflight will be rerun after merge. PR #419 remains excluded.