### PR TITLE
fix(android): stabilize supervised parent relock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Returning from parent settings keeps Supervised Chat rendered.** Parent access now relocks without rebuilding the active navigation graph, and full Settings keeps a prominent shortcut back to Supervised Mode controls.
+
 ## [Android 1.13.1] - 2026-08-25
 
 ### Fixed

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -1198,12 +1199,12 @@ fun RelayApp() {
             parentAccessForCurrentRoute,
             currentRoute,
         ) {
-            if (shouldRedirectSupervisedRoute(
-                    supervisedEnabled = supervisedPolicy.enabled,
-                    parentAccessUnlocked = parentAccessForCurrentRoute,
-                    currentRoute = currentRoute,
-                )
-            ) {
+            val redirect = shouldRedirectSupervisedRoute(
+                supervisedEnabled = supervisedPolicy.enabled,
+                parentAccessUnlocked = parentAccessForCurrentRoute,
+                currentRoute = currentRoute,
+            )
+            if (redirect) {
                 navController.navigate(Screen.Chat.route(openAgentSheet = false)) {
                     popUpTo(navController.graph.findStartDestination().id) { inclusive = false }
                     launchSingleTop = true
@@ -1212,6 +1213,12 @@ fun RelayApp() {
         }
         LaunchedEffect(supervisedPolicy.enabled, parentAccessUnlocked, currentRoute) {
             if (shouldRelockParentAccess(supervisedPolicy.enabled, parentAccessUnlocked, currentRoute)) {
+                // Route-scoped authority is already false on Chat. Let Navigation
+                // finish committing the new destination before clearing the raw
+                // parent grant, otherwise the same-frame root recomposition can
+                // leave a themed but contentless surface.
+                withFrameNanos { }
+                withFrameNanos { }
                 parentAccessUnlocked = false
             }
         }
@@ -2606,7 +2613,7 @@ fun RelayApp() {
                         connectionViewModel = connectionViewModel,
                         chatViewModel = chatViewModel,
                         supervisedPolicy = supervisedPolicy,
-                        parentAccessUnlocked = parentAccessUnlocked,
+                        parentAccessUnlocked = parentAccessForCurrentRoute,
                         onRequestParentAccess = { parentAccessUnlocked = true },
                         onUpdateSupervisedPolicy = { policy ->
                             activeConnectionId?.let { connectionId ->
@@ -2620,6 +2627,9 @@ fun RelayApp() {
                         },
                         onNavigateToSupervisedAppearance = {
                             navController.navigate(Screen.SupervisedAppearanceSettings.route)
+                        },
+                        onNavigateToSupervisedControls = {
+                            navController.navigate(Screen.SupervisedControls.route)
                         },
                         onBack = { navController.popBackStack() },
                         // (The `onNavigateToChatWithAgentSheet` callback that
@@ -2696,7 +2706,7 @@ fun RelayApp() {
                     )
                 }
                 composable(Screen.AdvancedSettings.route) {
-                    if (!parentAccessUnlocked && supervisedPolicy.enabled) {
+                    if (!parentAccessForCurrentRoute && supervisedPolicy.enabled) {
                         LaunchedEffect(Unit) { navController.popBackStack() }
                     } else {
                         AdvancedSettingsScreen(
@@ -2709,7 +2719,7 @@ fun RelayApp() {
                     }
                 }
                 composable(Screen.SupervisedAppearanceSettings.route) {
-                    if (!supervisedPolicy.enabled && !parentAccessUnlocked) {
+                    if (!supervisedPolicy.enabled && !parentAccessForCurrentRoute) {
                         LaunchedEffect(Unit) { navController.popBackStack() }
                     } else {
                         SupervisedAppearanceSettingsScreen(
@@ -2727,7 +2737,7 @@ fun RelayApp() {
                     }
                 }
                 composable(Screen.SupervisedControls.route) {
-                    if (!parentAccessUnlocked && supervisedPolicy.enabled) {
+                    if (!parentAccessForCurrentRoute && supervisedPolicy.enabled) {
                         LaunchedEffect(Unit) { navController.popBackStack() }
                     } else {
                         SupervisedControlsScreen(
@@ -3239,7 +3249,7 @@ fun RelayApp() {
                     AboutScreen(
                         connectionViewModel = connectionViewModel,
                         onBack = { navController.popBackStack() },
-                        allowDeveloperUnlock = !supervisedPolicy.enabled || parentAccessUnlocked,
+                        allowDeveloperUnlock = !supervisedPolicy.enabled || parentAccessForCurrentRoute,
                     )
                 }
                 composable(

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/SettingsScreen.kt
@@ -165,6 +165,7 @@ fun SettingsScreen(
     onUpdateSupervisedPolicy: (SupervisedModePolicy) -> Unit = {},
     onNavigateToAdvancedSettings: () -> Unit = {},
     onNavigateToSupervisedAppearance: () -> Unit = {},
+    onNavigateToSupervisedControls: () -> Unit = {},
     // Needed by the Active Agent summary card at the top of the screen — it
     // reads the current personality pick so the subtitle can render
     // `connection · model · personality` without re-reading ChatViewModel
@@ -455,6 +456,20 @@ fun SettingsScreen(
                 .padding(horizontal = 16.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            if (supervisedPolicy?.enabled == true && parentAccessUnlocked) {
+                SettingsCategoryRow(
+                    icon = Icons.Filled.Security,
+                    title = "Supervised mode",
+                    subtitle = "On · ${supervisedPolicy.pinnedProfileName.orEmpty()}",
+                    badge = SettingsStatusPillModel(
+                        label = "On",
+                        tone = SettingsStatusTone.Good,
+                    ),
+                    onClick = onNavigateToSupervisedControls,
+                    isDarkTheme = isDarkTheme,
+                )
+            }
+
             // ── Active Agent summary ───────────────────────────────────
             // Mirrors the ChatScreen TopAppBar title block (avatar + name
             // + one-line `connection · model · personality` subtitle).

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/SupervisedSettingsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/SupervisedSettingsScreen.kt
@@ -388,6 +388,16 @@ fun SupervisedControlsScreen(
                 )
             }
 
+            if (policy.enabled) {
+                SupervisedNavigationRow(
+                    icon = Icons.Filled.Lock,
+                    title = "Return to supervised view",
+                    subtitle = "Lock parent access and open the pinned agent chat",
+                    onClick = onReturnToSupervisedView,
+                    isDarkTheme = isDarkTheme,
+                )
+            }
+
             Text(
                 "This mode restricts this Android client. The selected Hermes profile remains responsible for agent tools and content policy.",
                 style = MaterialTheme.typography.bodySmall,
@@ -746,15 +756,6 @@ fun SupervisedControlsScreen(
                 }
             }
 
-            if (policy.enabled) {
-                TextButton(
-                    onClick = onReturnToSupervisedView,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Icon(Icons.Filled.Lock, contentDescription = null)
-                    Text("Return to supervised view", modifier = Modifier.padding(start = 8.dp))
-                }
-            }
             Spacer(Modifier.height(16.dp))
         }
     }


### PR DESCRIPTION
## Summary

- Keep Supervised Chat rendered when parent access relocks after returning from full settings.
- Add a prominent Supervised Mode shortcut below the full Settings header and move the return action near the top of the policy editor.

## Changes

- Feed route-scoped parent access into NavHost destinations so clearing the raw parent grant does not rebuild the active navigation graph.
- Keep parent authority ineffective immediately on Chat, then clear the raw grant after Navigation commits the destination.
- Replace the full-Settings return shortcut with a Supervised Mode settings card.
- Replace the policy editor's bottom text link with a top-level navigation card for returning to the supervised view.

## Verification

- `./gradlew.bat :app:testSideloadDebugUnitTest --tests com.hermesandroid.relay.ui.SupervisedNavigationPolicyTest :app:assembleSideloadDebug` - passed.
- `./gradlew.bat :app:lintSideloadDebug` - passed.
- Physical SM-S938U: repeated Parent access -> Supervised Mode -> Return to supervised view; Chat remained visible after relock.
- Clean `1.13.1-sideload` APK installed with `adb install -r`; no `AndroidRuntime` crash.

## Lineage / contributor credit

- Source PR(s): #419
- Attribution preserved by: original repository commits

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` -> `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: lint and focused unit tests ran, or rationale is listed above
- [x] Translation changes: N/A; no resource catalogs changed
- [x] Server changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: N/A
- [x] UI changes were tested on emulator/device or desktop surface when applicable
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md updated (if user-facing)
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged work links the source PR and preserves contributor authorship, or N/A