### PR TITLE
feat(ci): automate conflict-free release backmerges

### DIFF
--- a/.github/scripts/classify-ci-paths.cjs
+++ b/.github/scripts/classify-ci-paths.cjs
@@ -3,8 +3,11 @@
 function classifyCiPaths(paths) {
   const forceAll = paths.some((path) => [
     '.github/workflows/ci-required.yml',
+    '.github/workflows/release-backmerge.yml',
     '.github/scripts/classify-ci-paths.cjs',
     '.github/scripts/classify-ci-paths.test.cjs',
+    'scripts/plan_release_backmerge.py',
+    'scripts/tests/plan_release_backmerge_test.py',
   ].includes(path));
   const exact = (values) => paths.some((path) => values.includes(path));
   const under = (prefixes) => paths.some((path) => prefixes.some((prefix) => path.startsWith(prefix)));

--- a/.github/scripts/classify-ci-paths.test.cjs
+++ b/.github/scripts/classify-ci-paths.test.cjs
@@ -30,5 +30,13 @@ assert.deepEqual(classifyCiPaths(['.github/workflows/ci-required.yml']), {
   contract: true,
   docs: true,
 });
+assert.deepEqual(classifyCiPaths(['.github/workflows/release-backmerge.yml']), {
+  android: true,
+  desktop: true,
+  plugin: true,
+  dashboard: true,
+  contract: true,
+  docs: true,
+});
 
 console.log('CI path classification tests passed.');

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
     branches: [main, dev]
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: "Exact base commit for a trusted release-backmerge candidate"
+        required: true
+        type: string
+      head_sha:
+        description: "Exact candidate commit to check"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -31,10 +41,18 @@ jobs:
       contract: ${{ steps.filter.outputs.contract }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - name: Checkout repository
+      - name: Checkout pull request merge
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v7
         with:
           fetch-depth: 2
+
+      - name: Checkout exact dispatched candidate
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.head_sha }}
 
       - name: Test path classifier
         run: node .github/scripts/classify-ci-paths.test.cjs
@@ -42,11 +60,44 @@ jobs:
       - name: Classify changed files
         id: filter
         uses: actions/github-script@v8
+        env:
+          DISPATCH_BASE_SHA: ${{ inputs.base_sha }}
+          DISPATCH_HEAD_SHA: ${{ inputs.head_sha }}
         with:
           script: |
+            let diffArgs;
+            if (context.eventName === 'workflow_dispatch') {
+              const base = process.env.DISPATCH_BASE_SHA || '';
+              const head = process.env.DISPATCH_HEAD_SHA || '';
+              const shaPattern = /^[0-9a-f]{40}$/;
+              if (!shaPattern.test(base) || !shaPattern.test(head)) {
+                core.setFailed('Exact-tree dispatch requires full 40-character base/head SHAs.');
+                return;
+              }
+              const { stdout: checkedOut } = await exec.getExecOutput(
+                'git',
+                ['rev-parse', 'HEAD'],
+              );
+              if (checkedOut.trim() !== head) {
+                core.setFailed(`Checked out ${checkedOut.trim()}, expected ${head}.`);
+                return;
+              }
+              const ancestry = await exec.exec(
+                'git',
+                ['merge-base', '--is-ancestor', base, head],
+                { ignoreReturnCode: true },
+              );
+              if (ancestry !== 0) {
+                core.setFailed(`Candidate ${head} does not descend from base ${base}.`);
+                return;
+              }
+              diffArgs = ['diff', '--name-only', base, head];
+            } else {
+              diffArgs = ['diff', '--name-only', 'HEAD^1', 'HEAD^2'];
+            }
             const { stdout } = await exec.getExecOutput(
               'git',
-              ['diff', '--name-only', 'HEAD^1', 'HEAD^2'],
+              diffArgs,
             );
             const paths = stdout.split(/\r?\n/).filter(Boolean);
             const { classifyCiPaths } = require(

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -365,3 +365,22 @@ jobs:
           find app/build/outputs/apk -name '*.apk' -exec ls -la {} + >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
           find app/build/outputs/bundle -name '*.aab' -exec ls -la {} + >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  request-backmerge:
+    name: Request stable release backmerge
+    needs: [validate, release]
+    if: needs.validate.outputs.prerelease != 'true'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch fail-closed release reconciliation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: android-v${{ needs.validate.outputs.version }}
+        run: |
+          gh workflow run release-backmerge.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f release_tag="$RELEASE_TAG"

--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -1,0 +1,267 @@
+# Reconcile a completed stable hotfix into dev without adding a ceremonial PR
+# merge commit. Normal dev -> main releases are detected and intentionally no-op.
+# A conflicted merge, failed exact-tree CI, stale dev ref, or denied branch update
+# stops without mutating dev and falls back to the normal reconciliation PR path.
+
+name: Release Backmerge
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published stable tag to reconcile (android-v*, server-v*, or desktop-v*)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-backmerge-dev
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare exact backmerge candidate
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      outcome: ${{ steps.prepare.outputs.outcome }}
+      base_dev_sha: ${{ steps.prepare.outputs.base_dev_sha }}
+      candidate_branch: ${{ steps.prepare.outputs.candidate_branch }}
+      candidate_sha: ${{ steps.prepare.outputs.candidate_sha }}
+      release_commit: ${{ steps.prepare.outputs.release_commit }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Validate release and prepare merge commit
+        id: prepare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^(android|server|desktop)-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release Backmerge accepts stable SemVer production tags only; got $RELEASE_TAG"
+            exit 1
+          fi
+
+          git fetch origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/dev:refs/remotes/origin/dev" \
+            "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          release_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          base_dev_sha="$(git rev-parse origin/dev)"
+          echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
+          echo "base_dev_sha=$base_dev_sha" >> "$GITHUB_OUTPUT"
+
+          if ! git merge-base --is-ancestor "$release_commit" origin/main; then
+            echo "::error::$RELEASE_TAG ($release_commit) is not contained in origin/main"
+            exit 1
+          fi
+
+          read -r is_draft is_prerelease < <(
+            gh release view "$RELEASE_TAG" --json isDraft,isPrerelease \
+              --jq '[.isDraft, .isPrerelease] | @tsv'
+          )
+          if [ "$is_draft" != "false" ] || [ "$is_prerelease" != "false" ]; then
+            echo "::error::$RELEASE_TAG is not a published stable GitHub release"
+            exit 1
+          fi
+
+          plan="$(
+            python3 scripts/plan_release_backmerge.py \
+              --release-commit "$release_commit" \
+              --dev-commit "$base_dev_sha"
+          )"
+          case "$plan" in
+            already-contained)
+              echo "outcome=noop" >> "$GITHUB_OUTPUT"
+              echo "## Release backmerge not needed" >> "$GITHUB_STEP_SUMMARY"
+              echo "\`$RELEASE_TAG\` is already contained in \`dev\`." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+            normal-release)
+              echo "outcome=noop" >> "$GITHUB_OUTPUT"
+              echo "## Normal release: no backmerge" >> "$GITHUB_STEP_SUMMARY"
+              echo "The released merge's integration parent is already contained in \`dev\`." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+            hotfix) ;;
+            *)
+              echo "::error::Unknown release-backmerge plan: $plan"
+              exit 1
+              ;;
+          esac
+
+          candidate_branch="chore/release-backmerge/${RELEASE_TAG}-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch --detach "$base_dev_sha"
+
+          set +e
+          git merge --no-ff -m "chore: back-merge ${RELEASE_TAG}" "$release_commit"
+          merge_status=$?
+          set -e
+          if [ "$merge_status" -ne 0 ]; then
+            conflicts="$(git diff --name-only --diff-filter=U | paste -sd ', ' -)"
+            echo "outcome=conflict" >> "$GITHUB_OUTPUT"
+            echo "::error::Automatic backmerge conflicts: ${conflicts:-unknown}. Open a reconciliation PR."
+            echo "## Manual reconciliation PR required" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`$RELEASE_TAG\` conflicts with current \`dev\`: ${conflicts:-unknown}." >> "$GITHUB_STEP_SUMMARY"
+            git merge --abort || true
+            exit 1
+          fi
+
+          candidate_sha="$(git rev-parse HEAD)"
+          first_parent="$(git rev-parse HEAD^1)"
+          second_parent="$(git rev-parse HEAD^2)"
+          if [ "$first_parent" != "$base_dev_sha" ] || [ "$second_parent" != "$release_commit" ]; then
+            echo "::error::Candidate parents do not match dev + release commit"
+            exit 1
+          fi
+
+          git push origin "$candidate_sha:refs/heads/$candidate_branch"
+          echo "outcome=candidate" >> "$GITHUB_OUTPUT"
+          echo "candidate_branch=$candidate_branch" >> "$GITHUB_OUTPUT"
+          echo "candidate_sha=$candidate_sha" >> "$GITHUB_OUTPUT"
+
+          echo "## Backmerge candidate prepared" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Release: \`$RELEASE_TAG\` (\`$release_commit\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dev base: \`$base_dev_sha\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Candidate: \`$candidate_sha\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Temporary ref: \`$candidate_branch\`" >> "$GITHUB_STEP_SUMMARY"
+
+  gate:
+    name: Run exact-tree required checks
+    needs: prepare
+    if: needs.prepare.outputs.outcome == 'candidate'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      check_run_id: ${{ steps.gate.outputs.check_run_id }}
+    steps:
+      - name: Dispatch and await Required checks
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_DEV_SHA: ${{ needs.prepare.outputs.base_dev_sha }}
+          CANDIDATE_BRANCH: ${{ needs.prepare.outputs.candidate_branch }}
+          CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run ci-required.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$CANDIDATE_BRANCH" \
+            -f base_sha="$BASE_DEV_SHA" \
+            -f head_sha="$CANDIDATE_SHA"
+
+          check_run_id=""
+          for _ in {1..20}; do
+            check_run_id="$(
+              gh run list \
+                --repo "$GITHUB_REPOSITORY" \
+                --workflow ci-required.yml \
+                --branch "$CANDIDATE_BRANCH" \
+                --event workflow_dispatch \
+                --limit 20 \
+                --json databaseId,headSha \
+                --jq ".[] | select(.headSha == \"$CANDIDATE_SHA\") | .databaseId" \
+                | head -n 1
+            )"
+            if [ -n "$check_run_id" ]; then
+              break
+            fi
+            sleep 3
+          done
+          if [ -z "$check_run_id" ]; then
+            echo "::error::Required checks dispatch was not observed for $CANDIDATE_SHA"
+            exit 1
+          fi
+
+          echo "check_run_id=$check_run_id" >> "$GITHUB_OUTPUT"
+          gh run watch "$check_run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+
+  promote:
+    name: Compare-and-swap dev
+    needs: [prepare, gate]
+    if: needs.prepare.outputs.outcome == 'candidate' && needs.gate.result == 'success'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Fast-forward dev to the tested candidate
+        env:
+          BASE_DEV_SHA: ${{ needs.prepare.outputs.base_dev_sha }}
+          CANDIDATE_BRANCH: ${{ needs.prepare.outputs.candidate_branch }}
+          CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+          RELEASE_COMMIT: ${{ needs.prepare.outputs.release_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin --no-tags \
+            "+refs/heads/dev:refs/remotes/origin/dev" \
+            "+refs/heads/$CANDIDATE_BRANCH:refs/remotes/origin/$CANDIDATE_BRANCH"
+          current_dev="$(git rev-parse origin/dev)"
+          remote_candidate="$(git rev-parse "origin/$CANDIDATE_BRANCH")"
+
+          if [ "$current_dev" != "$BASE_DEV_SHA" ]; then
+            echo "::error::dev moved from $BASE_DEV_SHA to $current_dev; rerun or open a reconciliation PR"
+            exit 1
+          fi
+          if [ "$remote_candidate" != "$CANDIDATE_SHA" ]; then
+            echo "::error::Candidate ref moved from $CANDIDATE_SHA to $remote_candidate"
+            exit 1
+          fi
+          if [ "$(git rev-parse "$CANDIDATE_SHA^1")" != "$BASE_DEV_SHA" ] || \
+             [ "$(git rev-parse "$CANDIDATE_SHA^2")" != "$RELEASE_COMMIT" ]; then
+            echo "::error::Candidate ancestry changed after verification"
+            exit 1
+          fi
+
+          # The explicit lease is the atomic stale-base guard. The update is a
+          # fast-forward from BASE_DEV_SHA; no unrelated history can be replaced.
+          git push \
+            --force-with-lease="refs/heads/dev:$BASE_DEV_SHA" \
+            origin "$CANDIDATE_SHA:refs/heads/dev"
+
+          git push origin --delete "$CANDIDATE_BRANCH" || \
+            echo "::warning::Could not remove temporary branch $CANDIDATE_BRANCH"
+
+          echo "## Release backmerge complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "Fast-forwarded \`dev\` from \`$BASE_DEV_SHA\` to tested merge \`$CANDIDATE_SHA\`." >> "$GITHUB_STEP_SUMMARY"
+
+  fallback:
+    name: Report PR fallback
+    needs: [prepare, gate, promote]
+    if: always() && needs.prepare.outputs.outcome == 'candidate' && needs.promote.result != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Preserve safe fallback instructions
+        env:
+          CANDIDATE_BRANCH: ${{ needs.prepare.outputs.candidate_branch }}
+          CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+          CHECK_RUN_ID: ${{ needs.gate.outputs.check_run_id }}
+        run: |
+          echo "## Automatic backmerge stopped" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`dev\` was not updated. Open or refresh a reconciliation PR after addressing the failed/stale gate." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Candidate ref: \`${CANDIDATE_BRANCH:-not-created}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Candidate SHA: \`${CANDIDATE_SHA:-n/a}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Required-check run: \`${CHECK_RUN_ID:-n/a}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -539,3 +539,22 @@ jobs:
             release-assets/cli-binaries/hermes-relay-darwin-arm64
             release-assets/cli-windows-installer/hermes-relay-windows-x64-setup.exe
             release-assets/SHA256SUMS.txt
+
+  request-backmerge:
+    name: Request stable release backmerge
+    needs: [validate-release, publish-release]
+    if: ${{ !contains(needs.validate-release.outputs.version, '-') }}
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch fail-closed release reconciliation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: desktop-v${{ needs.validate-release.outputs.version }}
+        run: |
+          gh workflow run release-backmerge.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f release_tag="$RELEASE_TAG"

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -138,3 +138,22 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/SHA256SUMS.txt
+
+  request-backmerge:
+    name: Request stable release backmerge
+    needs: [validate, package]
+    if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch fail-closed release reconciliation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: server-v${{ needs.validate.outputs.version }}
+        run: |
+          gh workflow run release-backmerge.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f release_tag="$RELEASE_TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ not redefine the branch, release, or hotfix policy here and in `RELEASE.md`.
 | Staging source | An exact tested `dev` SHA or release-candidate tag; staging is an environment, never a branch |
 | Production source | Immutable `android-v*`, `server-v*`, or `desktop-v*` tags, selected by surface |
 | Hotfix base | The immutable production tag for the affected surface |
-| Back-merge target | `dev`; merge `main` back immediately after every hotfix |
+| Back-merge target | `dev`; stable hotfixes reconcile automatically when the exact tested merge is conflict-free, otherwise through a PR |
 
 Feature completion means merged and verified on `dev`; it does not mean
 released. A release train is separate work owned by a Forge release
@@ -36,6 +36,14 @@ issue/session: reconcile only the affected surface version and notes on `dev`,
 open the `dev` → `main` release PR, tag the resulting `main` tip, publish the
 surface artifacts, deploy or roll out, and verify the live result. Never create
 a staging branch.
+
+A normal `dev` → `main` release needs no back-merge: the released integration
+parent is already in `dev`. A production-tag hotfix is different. After its
+stable release succeeds, `Release Backmerge` prepares a `dev`-first merge
+commit, runs the same path-aware required checks on that exact SHA, verifies
+that `dev` has not moved, and fast-forwards `dev`. Conflicts, failed checks,
+stale refs, or denied branch updates fail closed and require a reconciliation
+PR; never resolve those cases by choosing a side automatically.
 
 ### Local integration discipline
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -200,6 +200,11 @@ never create a staging branch. Stable production tags are cut only from the new
 10. Build and publish that surface's artifacts, roll out or deploy from the
     immutable tag, and verify the release and live environment.
 
+Do not back-merge a normal release. The `main` release merge already has the
+released `dev` tip as its integration parent, so merging it back only adds
+history noise. The release-backmerge workflow detects this topology and exits
+successfully without changing `dev`.
+
 ### Branch names
 
 | Prefix | When | Example |
@@ -258,7 +263,9 @@ The intended settings are:
 - **`main`** — PRs required; `Required checks` required and current; force push
   and deletion blocked. Normal work does not target this branch.
 - **`dev`** — PRs and `Required checks` required; force push and deletion
-  blocked. This is the normal contribution target.
+  blocked. This is the normal contribution target. The release-backmerge
+  workflow is the sole exception: its automation identity may compare-and-swap
+  `dev` to an exact checked merge commit after a stable hotfix release.
 - **Merge policy** — merge commits allowed; squash and rebase merges disabled so
   the no-ff contract cannot be bypassed in the GitHub UI.
 - **Default branch** — `main`, which remains the release-history branch and the
@@ -922,8 +929,23 @@ When production has a bug, use the same invariant for every surface:
 4. Open the focused hotfix PR into `main` and merge with a merge commit/no-ff.
 5. Tag the new `main` tip with the affected surface's patch tag.
 6. Verify the artifacts and production rollout or deployment.
-7. Merge `main` back into `dev` immediately so integration inherits the fix and
-   version history.
+7. Let the stable release workflow dispatch `Release Backmerge`. A
+   conflict-free candidate runs the same path-aware `Required checks` against
+   its exact SHA, then compare-and-swaps `dev` only if the base ref is unchanged.
+   Conflicts, failed checks, stale refs, or a denied update require a normal
+   reconciliation PR.
+
+`Release Backmerge` accepts only published stable `android-v*`, `server-v*`, or
+`desktop-v*` SemVer tags contained in `main`. It exits without mutation for a
+normal release whose integration parent is already in `dev`. For a selective
+hotfix, it pushes a temporary merge ref, dispatches `Required checks` with full
+base/head SHAs, and updates `dev` with an explicit force-with-lease only after
+that exact candidate passes. The lease is a compare-and-swap guard, not
+permission to rewrite history: the candidate's first parent must be the
+unchanged `dev` tip and its second parent the released commit. The repository
+ruleset must allow this workflow's automation identity to perform that one
+checked branch update; if it does not, the workflow fails closed and the
+reconciliation uses a PR.
 
 For an Android app hotfix:
 
@@ -938,21 +960,21 @@ For an Android app hotfix:
 6. `git tag android-v0.6.2` from the new `main` tip and `git push origin android-v0.6.2`
    so Android release CI builds and publishes.
 7. Verify the automated Play submission, GitHub artifacts, and rollout.
-8. Merge `main` back into `dev` (`git checkout dev && git merge --no-ff main`)
-   so `dev` picks up the hotfix and the versionCode bump. Without this,
-   `dev`'s `appVersionCode` lags behind `main` and the next app release
-   bump collides.
+8. Verify the automated release backmerge completed. If it stopped, open a
+   reconciliation PR so `dev` picks up the hotfix and versionCode bump. Without
+   reconciliation, `dev`'s `appVersionCode` lags behind `main` and the next app
+   release bump collides.
 
 For a Plugin hotfix, branch from the affected `server-v*` tag, apply
 the fix, run `bash scripts/bump-plugin-version.sh <next-version>`, merge to
-`main`, tag `server-v<next-version>`, verify the package/deployment, and merge
-`main` back to `dev`. Do not touch
+`main`, tag `server-v<next-version>`, verify the package/deployment, and verify
+the automated release backmerge. Do not touch
 `gradle/libs.versions.toml` unless an Android app release is also shipping.
 
 For a CLI+UI hotfix, branch from the affected `desktop-v*` tag, update only
 `desktop/package.json` and its generated lock/runtime/tray metadata, merge to
 `main`, tag `desktop-v<next-version>`, verify all binaries and the installer,
-then merge `main` back to `dev`.
+then verify the automated release backmerge or use the PR fallback.
 
 ## Troubleshooting
 

--- a/scripts/plan_release_backmerge.py
+++ b/scripts/plan_release_backmerge.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Classify whether a stable release commit needs reconciliation into dev."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from collections.abc import Callable, Sequence
+
+
+def classify_release(
+    release_commit: str,
+    dev_commit: str,
+    parents: Sequence[str],
+    is_ancestor: Callable[[str, str], bool],
+) -> str:
+    """Return already-contained, normal-release, or hotfix."""
+    if is_ancestor(release_commit, dev_commit):
+        return "already-contained"
+    if len(parents) < 2:
+        raise ValueError("stable release commit is not a release/hotfix merge commit")
+    if is_ancestor(parents[1], dev_commit):
+        return "normal-release"
+    return "hotfix"
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def git_is_ancestor(older: str, newer: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", older, newer],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in {0, 1}:
+        raise RuntimeError(result.stderr.strip() or "git merge-base failed")
+    return result.returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-commit", required=True)
+    parser.add_argument("--dev-commit", required=True)
+    args = parser.parse_args()
+
+    release_commit = git("rev-parse", f"{args.release_commit}^{{commit}}")
+    dev_commit = git("rev-parse", f"{args.dev_commit}^{{commit}}")
+    parents = git("show", "-s", "--format=%P", release_commit).split()
+    print(
+        classify_release(
+            release_commit,
+            dev_commit,
+            parents,
+            git_is_ancestor,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/plan_release_backmerge_test.py
+++ b/scripts/tests/plan_release_backmerge_test.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.plan_release_backmerge import classify_release
+
+
+class ReleaseBackmergePlanTest(unittest.TestCase):
+    def test_already_contained_release_is_a_noop(self) -> None:
+        ancestry = {("release", "dev")}
+        self.assertEqual(
+            classify_release(
+                "release",
+                "dev",
+                ["main", "topic"],
+                lambda older, newer: (older, newer) in ancestry,
+            ),
+            "already-contained",
+        )
+
+    def test_normal_release_with_dev_parent_is_a_noop(self) -> None:
+        ancestry = {("released-dev", "dev")}
+        self.assertEqual(
+            classify_release(
+                "release",
+                "dev",
+                ["previous-main", "released-dev"],
+                lambda older, newer: (older, newer) in ancestry,
+            ),
+            "normal-release",
+        )
+
+    def test_selective_hotfix_requires_backmerge(self) -> None:
+        self.assertEqual(
+            classify_release(
+                "release",
+                "dev",
+                ["previous-main", "hotfix-topic"],
+                lambda _older, _newer: False,
+            ),
+            "hotfix",
+        )
+
+    def test_non_merge_release_commit_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not a release/hotfix merge commit"):
+            classify_release("release", "dev", ["parent"], lambda _older, _newer: False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Automate the inherent `main` → `dev` reconciliation after stable hotfix releases without adding a ceremonial PR merge commit.

Normal `dev` → `main` releases remain no-ops. Selective hotfixes prepare a `dev`-first merge candidate, run the existing path-aware required checks against its exact SHA, and update `dev` only when the checked base is unchanged.

## Changes

- Add a fail-closed `Release Backmerge` workflow for stable Android, Plugin, and CLI+UI releases.
- Add exact base/head workflow-dispatch support to `Required checks`.
- Detect normal releases, already-reconciled releases, and selective hotfixes with a tested ancestry helper.
- Fall back to a reconciliation PR on conflicts, failed checks, stale refs, or denied branch updates.
- Document the normal-release and hotfix policies in `AGENTS.md` and `RELEASE.md`.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `python -m unittest scripts.tests.plan_release_backmerge_test`
- `node .github/scripts/classify-ci-paths.test.cjs`
- Parsed every workflow with PyYAML
- `python scripts/check-version-tracks.py`
- Codex Security diff scan — complete coverage, no reportable findings
- Live branch mutation was intentionally not exercised; the workflow validates refs and fails closed if repository rules deny the checked update.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Android changes: N/A — workflow-only
- [x] Translation changes: N/A
- [x] Server changes: N/A — workflow-only
- [x] Desktop changes: N/A — workflow-only
- [x] Docs/site changes: policy documentation only
- [x] UI changes were tested on emulator/device or desktop surface when applicable — N/A, no visual change
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md updated — N/A, no shipped product behavior
- [x] Public writing hygiene checked
- [x] Salvaged work links the source PR and preserves contributor authorship — N/A