### PR TITLE
fix(android): keep unknown session activity neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Android session rows stay neutral when optional live activity is unavailable or still loading.** Directory refreshes no longer restore a persistent Checking state, and full-row activity borders are reserved for actual Starting or Working turns.
 - **Returning from parent settings keeps Supervised Chat rendered.** Parent access now relocks without rebuilding the active navigation graph, and full Settings keeps a prominent shortcut back to Supervised Mode controls.
 
 ## [Android 1.13.1] - 2026-08-25

--- a/app/src/main/kotlin/com/hermesandroid/relay/data/SessionActivityRegistry.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/SessionActivityRegistry.kt
@@ -90,10 +90,10 @@ data class SessionActivityRecord(
         }
     }
 
-    /** Presentation projection that never labels uncertain or background activity as Working. */
+    /** Presentation projection that never labels missing optional runtime data as session state. */
     fun presentationState(nowMillis: Long = Long.MIN_VALUE): SessionActivityState? = when (freshness) {
-        SessionActivityFreshness.Revalidating -> SessionActivityState.Checking
-        SessionActivityFreshness.Unavailable -> SessionActivityState.Unavailable
+        SessionActivityFreshness.Revalidating -> null
+        SessionActivityFreshness.Unavailable -> null
         SessionActivityFreshness.Confirmed -> when (phase(nowMillis)) {
             SessionActivityPhase.Starting -> SessionActivityState.Starting
             SessionActivityPhase.Working -> SessionActivityState.Working
@@ -294,7 +294,9 @@ data class SessionActivityRegistry(
 
     private fun observeOwner(update: SessionActivityUpdate.ObserveOwner): SessionActivityRegistry {
         val existing = records[update.owner]
-        if (existing?.freshness == SessionActivityFreshness.Confirmed) return this
+        // Directory rows establish ownership only. They are not live evidence and must not
+        // turn an unsupported/failed active-list probe back into a permanent Checking row.
+        if (existing != null) return this
         val observed = SessionActivityRecord(
             owner = update.owner,
             turnPhase = SessionActivityPhase.Idle,

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionDrawer.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionDrawer.kt
@@ -1770,19 +1770,9 @@ private fun Modifier.sessionActivityBorder(
     state: SessionActivityState?,
     animated: Boolean,
 ): Modifier {
-    if (state == null) return this
-    val color = when (state) {
-        SessionActivityState.Starting,
-        SessionActivityState.Working -> RelayRefresh.Relay
-        SessionActivityState.NeedsInput -> RelayRefresh.Amber
-        SessionActivityState.BackgroundWork,
-        SessionActivityState.Checking,
-        SessionActivityState.Unavailable,
-        -> MaterialTheme.colorScheme.onSurfaceVariant
-    }
-    val shouldRotate = animated && (
-        state == SessionActivityState.Starting || state == SessionActivityState.Working
-    )
+    if (!sessionActivityShowsRowBorder(state)) return this
+    val color = RelayRefresh.Relay
+    val shouldRotate = animated
     val phase = if (shouldRotate) {
         val transition = rememberInfiniteTransition(label = "session-activity")
         transition.animateFloat(

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionDrawerPolicy.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/SessionDrawerPolicy.kt
@@ -84,6 +84,10 @@ internal fun sessionDrawerStatus(
     null -> SessionDrawerStatus.Idle
 }
 
+/** Desktop-style row emphasis is reserved for an actual foreground turn. */
+internal fun sessionActivityShowsRowBorder(state: SessionActivityState?): Boolean =
+    state == SessionActivityState.Starting || state == SessionActivityState.Working
+
 /**
  * Normalizes live activity to the drawer's profile-scoped row identity.
  *

--- a/app/src/test/kotlin/com/hermesandroid/relay/data/SessionActivityRegistryTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/data/SessionActivityRegistryTest.kt
@@ -10,22 +10,35 @@ class SessionActivityRegistryTest {
     private val scope = SessionActivityScope.of("connection-a", "default")
 
     @Test
-    fun `directory owner is checking until status is unavailable or confirms idle`() {
+    fun `directory owner stays neutral until status confirms live activity`() {
         val checking = SessionActivityRegistry().reduce(
             SessionActivityUpdate.ObserveOwner(owner, generation = 1, observedAtMillis = 1),
         )
         assertEquals(SessionActivityPhase.Idle, checking.record(owner)?.phase())
-        assertEquals(SessionActivityState.Checking, checking.record(owner)?.presentationState())
+        assertEquals(SessionActivityFreshness.Revalidating, checking.record(owner)?.freshness)
+        assertNull(checking.record(owner)?.presentationState())
 
         val unavailable = checking.reduce(
             SessionActivityUpdate.StatusUnavailable(scope, generation = 1, observedAtMillis = 2),
         )
-        assertEquals(SessionActivityState.Unavailable, unavailable.record(owner)?.presentationState())
+        assertEquals(SessionActivityFreshness.Unavailable, unavailable.record(owner)?.freshness)
+        assertNull(unavailable.record(owner)?.presentationState())
 
         val confirmedIdle = checking.reduce(activeList(scope, generation = 1))
         assertEquals(SessionActivityPhase.Idle, confirmedIdle.record(owner)?.phase())
         assertEquals(SessionActivityFreshness.Confirmed, confirmedIdle.record(owner)?.freshness)
         assertNull(confirmedIdle.record(owner)?.presentationState())
+    }
+
+    @Test
+    fun `directory refresh cannot restore checking after active status is unavailable`() {
+        val state = SessionActivityRegistry()
+            .reduce(SessionActivityUpdate.ObserveOwner(owner, generation = 1, observedAtMillis = 1))
+            .reduce(SessionActivityUpdate.StatusUnavailable(scope, generation = 1, observedAtMillis = 2))
+            .reduce(SessionActivityUpdate.ObserveOwner(owner, generation = 1, observedAtMillis = 3))
+
+        assertEquals(SessionActivityFreshness.Unavailable, state.record(owner)?.freshness)
+        assertNull(state.record(owner)?.presentationState())
     }
 
     @Test
@@ -184,7 +197,7 @@ class SessionActivityRegistryTest {
     }
 
     @Test
-    fun `failed or unsupported status refresh is unavailable rather than idle`() {
+    fun `failed or unsupported status refresh preserves evidence but presents a neutral row`() {
         val state = SessionActivityRegistry()
             .reduce(
                 SessionActivityUpdate.LiveState(
@@ -206,7 +219,7 @@ class SessionActivityRegistryTest {
 
         assertEquals(SessionActivityPhase.Working, state.record(owner)?.phase())
         assertEquals(SessionActivityFreshness.Unavailable, state.record(owner)?.freshness)
-        assertEquals(SessionActivityState.Unavailable, state.record(owner)?.presentationState())
+        assertNull(state.record(owner)?.presentationState())
     }
 
     @Test
@@ -226,7 +239,7 @@ class SessionActivityRegistryTest {
     }
 
     @Test
-    fun `presentation keeps starting background and revalidation distinct from working`() {
+    fun `presentation keeps starting and background distinct while revalidation stays neutral`() {
         val starting = SessionActivityRegistry().reduce(
             SessionActivityUpdate.LocalSend(owner, generation = 1, observedAtMillis = 1),
         )
@@ -240,7 +253,7 @@ class SessionActivityRegistryTest {
         val checking = starting.reduce(
             SessionActivityUpdate.BeginGeneration(scope, generation = 2, observedAtMillis = 2),
         )
-        assertEquals(SessionActivityState.Checking, checking.record(owner)?.presentationState())
+        assertNull(checking.record(owner)?.presentationState())
     }
 
     @Test
@@ -287,7 +300,7 @@ class SessionActivityRegistryTest {
     }
 
     @Test
-    fun `restored needs-input checkpoint stays checking until live confirmation`() {
+    fun `restored needs-input checkpoint stays neutral until live confirmation`() {
         val state = SessionActivityRegistry().reduce(
             SessionActivityUpdate.RestoreCheckpoint(
                 owner = owner,
@@ -298,7 +311,7 @@ class SessionActivityRegistryTest {
             ),
         )
 
-        assertEquals(SessionActivityState.Checking, state.record(owner)?.presentationState())
+        assertNull(state.record(owner)?.presentationState())
     }
 
     @Test
@@ -323,7 +336,7 @@ class SessionActivityRegistryTest {
                 ),
             )
 
-        assertEquals(SessionActivityState.Checking, state.record(owner)?.presentationState())
+        assertNull(state.record(owner)?.presentationState())
 
         state = state.reduce(
             SessionActivityUpdate.PendingInputOpened(

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/SessionDrawerPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/SessionDrawerPolicyTest.kt
@@ -5,6 +5,7 @@ import com.hermesandroid.relay.data.ChatSession
 import com.hermesandroid.relay.data.SessionActivityState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionDrawerPolicyTest {
@@ -142,6 +143,17 @@ class SessionDrawerPolicyTest {
                 ).map { it.session.sessionId },
             )
         }
+    }
+
+    @Test
+    fun `full row border is limited to foreground live work`() {
+        assertTrue(sessionActivityShowsRowBorder(SessionActivityState.Starting))
+        assertTrue(sessionActivityShowsRowBorder(SessionActivityState.Working))
+        assertFalse(sessionActivityShowsRowBorder(SessionActivityState.NeedsInput))
+        assertFalse(sessionActivityShowsRowBorder(SessionActivityState.BackgroundWork))
+        assertFalse(sessionActivityShowsRowBorder(SessionActivityState.Checking))
+        assertFalse(sessionActivityShowsRowBorder(SessionActivityState.Unavailable))
+        assertFalse(sessionActivityShowsRowBorder(null))
     }
 
     @Test

--- a/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModelGatewayInboundTurnTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModelGatewayInboundTurnTest.kt
@@ -333,7 +333,7 @@ class ChatViewModelGatewayInboundTurnTest {
     }
 
     @Test
-    fun unsupportedActiveListProjectsUnavailableInsteadOfRestWorking() {
+    fun unsupportedActiveListLeavesRowsNeutralAcrossDirectoryRefresh() {
         bindActivityTestDirectory()
         handler.updateSessions(
             listOf(SessionItem(id = STORED_SESSION_ID, title = "Recent", isActive = true)),
@@ -344,9 +344,14 @@ class ChatViewModelGatewayInboundTurnTest {
         gatewayHarness.awaitRpc("session.active_list")
 
         awaitCondition {
-            viewModel.backgroundSessionActivityStates.value["default:$STORED_SESSION_ID"] ==
-                SessionActivityState.Unavailable
+            "default:$STORED_SESSION_ID" !in viewModel.backgroundSessionActivityStates.value
         }
+
+        viewModel.updateSessionActivityDirectory(
+            rows = listOf("default" to STORED_SESSION_ID),
+        )
+
+        assertFalse("default:$STORED_SESSION_ID" in viewModel.backgroundSessionActivityStates.value)
     }
 
     @Test


### PR DESCRIPTION
## Summary  Follow-up to #434: Android could leave most session rows outlined and labeled **Checking** after an activity refresh.  The cause was client-side reconciliation, not a missing Gateway method. A session-directory refresh was treating row ownership as new activity evidence and replacing an already-settled unavailable result with a revalidating state. Android now keeps optional activity that is unavailable or still loading visually neutral, matching upstream Desktop behavior.  ## Changes  - Preserve an existing session activity record when the directory observes the same owner again. - Keep internal revalidating/unavailable freshness without exposing `Checking` or `Unavailable` as per-row activity. - Reserve full-row activity borders for actual `Starting` and `Working` turns. - Keep compact needs-input and background-work indicators unchanged. - Add reducer, drawer-policy, and unsupported-RPC ordering regressions. - Document the user-visible fix in the Unreleased changelog.  ## Compatibility  Current upstream and deployed Gateway revisions already implement `session.active_list`; updating the Gateway is not required for this fix. If optional activity data is unavailable, Android leaves the row neutral instead of inventing activity.  ## Verification  - `.\gradlew.bat --no-daemon --max-workers=1 -Pkotlin.compiler.execution.strategy=in-process :app:clean :app:testSideloadDebugUnitTest --tests "com.hermesandroid.relay.data.SessionActivityRegistryTest" --tests "com.hermesandroid.relay.ui.components.SessionDrawerPolicyTest" --tests "com.hermesandroid.relay.viewmodel.ChatViewModelGatewayInboundTurnTest.unsupportedActiveListLeavesRowsNeutralAcrossDirectoryRefresh"` — passed (35 tests) - `.\gradlew.bat --no-daemon --max-workers=1 -Pkotlin.compiler.execution.strategy=in-process :app:lintSideloadDebug :app:assembleSideloadDebug` — passed - `python scripts/check-android-collection-apis.py` — passed - `git diff --check` — passed - Physical SM-S938U: session drawer no longer shows persistent Checking outlines — passed.  ## Lineage / contributor credit  - Source PR(s): #434 - Attribution preserved by: N/A — original follow-up work  ## Checklist  - [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main` - [x] Android changes: lint and focused unit tests ran, or rationale is listed above - [x] Translation changes: N/A — no resource catalogs changed - [x] Server changes: N/A - [x] Desktop changes: N/A - [x] Docs/site changes: N/A - [x] UI changes were tested on a physical SM-S938U - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) - [x] CHANGELOG.md updated (if user-facing) - [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration - [x] Salvaged work links the source PR and preserves contributor authorship, or N/A 