### PR TITLE
fix(android): auto-recover wake listener after transient mic failure

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/wake/WakeWordForegroundService.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/wake/WakeWordForegroundService.kt
@@ -155,6 +155,13 @@ class WakeWordForegroundService : Service() {
         val lease = MicrophoneOwnershipCoordinator.tryAcquire(MicrophoneOwner.WakeWord)
         if (lease == null) {
             setRuntimeState(WakeWordRuntimeState.PausedForVoice)
+            // Mirror HermesVoiceInteractionService.scheduleRetry: another relay
+            // surface (voice overlay, barge-in) currently holds the mic. Recover
+            // automatically once it releases, instead of waiting for the user to
+            // toggle Auto Mode.
+            if (!stopRequested.get() && currentPreferences.enabled && !voiceSessionActive) {
+                scheduleRetry()
+            }
             return
         }
         microphoneLease = lease
@@ -222,6 +229,16 @@ class WakeWordForegroundService : Service() {
                 if (!stopRequested.get()) {
                     Log.w(TAG, "wake listening failed", t)
                     fail(t.message ?: "Wake-word listener failed")
+                    // Auto Mode (Android Auto) frequently contends with other mic
+                    // holders (Chrome, dialer, media apps): AudioRecord returns
+                    // STATE_UNINITIALIZED and the listener dies. The legacy
+                    // HermesVoiceInteractionService handles this with
+                    // scheduleRetry() — the foreground service was missing it,
+                    // so a single transient conflict stranded the listener in
+                    // Error until the user toggled Auto Mode off→on.
+                    if (currentPreferences.enabled && !voiceSessionActive) {
+                        scheduleRetry()
+                    }
                 }
             } finally {
                 runCatching { unattachedDetector?.close() }
@@ -344,6 +361,33 @@ class WakeWordForegroundService : Service() {
         }
     }
 
+    /**
+     * Recover after a transient mic failure by re-arming the listener once
+     * another mic holder has likely released the OS handle. Mirrors the
+     * scheduleRetry() in HermesVoiceInteractionService — the foreground
+     * service had no equivalent, which is why a single transient contention
+     * (Chrome, dialer, media app) stranded the wake listener in Error until
+     * the user toggled Auto Mode off→on.
+     *
+     * The retry is single-shot per failure: it replaces the failed job, waits
+     * [RETRY_DELAY_MS], then re-attempts startRecognition(). If that also
+     * fails, its own catch will schedule another retry. This avoids both a
+     * tight loop (no delay) and silent permanent death (no retry).
+     */
+    private fun scheduleRetry() {
+        if (recognitionJob?.isActive == true || voiceSessionActive) return
+        recognitionJob = scope.launch {
+            delay(RETRY_DELAY_MS)
+            recognitionJob = null
+            if (!voiceSessionActive &&
+                !stopRequested.get() &&
+                currentPreferences.enabled
+            ) {
+                startRecognition(currentPreferences)
+            }
+        }
+    }
+
     private fun onWakeDetected(preferences: WakeWordPreferences) {
         // releaseRecognitionResources() has completed before this callback.
         Log.i(TAG, "wake phrase detected; microphone released before activation")
@@ -457,6 +501,11 @@ class WakeWordForegroundService : Service() {
         private const val SAMPLE_RATE = 16_000
         private const val FRAME_SAMPLES = 1_600
         private const val TEST_DURATION_MS = 10_000L
+        // Mirrors HermesVoiceInteractionService.RETRY_DELAY_MS — see that file
+        // for the original rationale. Short enough to feel responsive to the
+        // user (~500ms = ~one missed wake), long enough that we don't spin when
+        // another app still holds the OS-level mic handle.
+        private const val RETRY_DELAY_MS = 500L
 
         private val _runtimeState = MutableStateFlow(WakeWordRuntimeState.Stopped)
         val runtimeState: StateFlow<WakeWordRuntimeState> = _runtimeState.asStateFlow()


### PR DESCRIPTION
## Lineage

- Replaces #451, which targeted `main` (wrong base) and used a
  `wake:` commit prefix (not Conventional Commits). Closed without
  merge; that PR had no review feedback, so nothing is lost.
- Rebased on current `origin/dev` (69347ad), so the diff includes the
  `c76d0bf3 fix(android): stabilize local wake activation` ancestor
  cleanly — no conflicts. Verified with `git diff origin/dev --stat`
  → 1 file, +49.

## Problem

WakeWordForegroundService has no retry path for transient microphone
acquisition failures. When another app (Chrome, the dialer, a media
player) briefly holds the OS-level mic handle, `AudioRecord.Builder().build()`
returns `STATE_UNINITIALIZED` and the recognition coroutine throws. The
catch calls `fail()` — set state to `Error`, cleared `recognitionJob`,
and stopped. Nothing re-armed the listener.

So a single transient contention — even one that lasted a few hundred ms —
stranded Auto Mode permanently. Users had to toggle Auto Mode off then
back on to recover, which is the symptom reported as "the microphone
thing again" while Auto Mode is on.

## Root cause

`WakeWordForegroundService.startRecognition()` had three dead-end paths,
none of which rescheduled:

1. `tryAcquire(WakeWord) == null` → `setRuntimeState(PausedForVoice)`,
   return. When another relay surface (voice overlay, barge-in listener)
   held the mic, wake listening went to sleep and stayed there.
2. `AudioRecord.state != STATE_INITIALIZED` → throw `"Wake-word
   microphone failed to initialize"`, caught and `fail()` called.
3. Any other `Throwable` from the listener loop → same `fail()` path.

The lease accounting is correct in every mic owner — `tryAcquire` calls
in `VoiceRecorder`, `BargeInListener`, `RealtimePcmRecorder`, and this
service are all paired with `release` in `finally`. The issue is purely
missing recovery, not missing cleanup.

The legacy `HermesVoiceInteractionService` already handles this exact
situation with `scheduleRetry()` (line 242) and `RETRY_DELAY_MS = 500L`.
The newer foreground service was missing the equivalent.

## Fix

Mirrors `HermesVoiceInteractionService.scheduleRetry()` onto the
foreground service:

- New `private fun scheduleRetry()` that re-runs
  `startRecognition(currentPreferences)` after a 500 ms single-shot delay.
- Called from two failure paths:
  - The `tryAcquire == null` branch — recovers from `PausedForVoice` once
    another relay surface releases the mic lease.
  - The catch block in the listener coroutine — recovers from mic-init
    failures and any other transient listener error.
- Guarded by `currentPreferences.enabled`, `!voiceSessionActive`, and
  the existing `recognitionJob?.isActive` check, so user-initiated Auto
  Mode off still wins and concurrent retries don't pile up.
- `RETRY_DELAY_MS = 500L` matches the legacy service.

If the retry also fails, the new catch schedules another retry. Single
shot per failure → no tight loop, no silent permanent death.

## What this does NOT change

- The mic lease API (`MicrophoneOwnershipCoordinator`) — already correct.
- The `RelayErrorClassifier` already maps `"cannot create audiorecord"`
  / `"audiorecord failed to initialize"` to a `HumanError(retryable=true)`
  snackbar. The retry makes that promise real instead of just declarative.
- Issue #444 (sherpa-onnx JNI crash on sideload builds) is separate and
  unaffected.

## Verification

- `git diff origin/dev` is 49 insertions, 0 deletions, single file changed.
- All guards are no-ops on the happy path — `scheduleRetry()` only runs
  from inside the two failure branches.
- Symmetric to `HermesVoiceInteractionService.scheduleRetry()`, so the
  retry contract is identical across both wake-word code paths.
- No Android SDK / JDK 17 toolchain was available in this worktree to
  run `./scripts/dev.sh prepush` (the repo's pre-push gate, per
  CONTRIBUTING.md). Reviewer should run that locally before merge.
  Hosted CI (`.github/workflows/ci-android.yml`) is the exhaustive gate.

Diff:
```
app/src/main/kotlin/com/hermesandroid/relay/wake/WakeWordForegroundService.kt | 49 +++++++++
1 file changed, 49 insertions(+)
```