### PR TITLE
fix(android): render bot chat history after binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android Git State can browse and manage host repositories exposed by the optional Hermes-Relay plugin.** Repository status, branches, diffs, and files are readable after enabling the plugin; staging, commits, sync, checkout, discard, and stash-switch remain behind scoped write grants and confirmations.
 - **Hermes-Relay Plugin provides a bounded Git workspace API for authenticated Dashboard clients.** Configured repository roots, path validation, scoped write grants, and explicit confirmation protect repository reads and mutations.
 
+### Fixed
+
+- **Android Bot Chats render loaded history immediately.** Route-owned chat screens now observe their own message state instead of remaining subscribed to an empty pre-bind fallback until navigation begins.
+
 ## [Android 1.13.2] - 2026-08-25
 
 ### Added

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/BotChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/BotChatScreen.kt
@@ -76,10 +76,14 @@ fun BotChatScreen(
 ) {
     val handler = remember(route.key) { ChatHandler() }
     val context = LocalContext.current
-    val messages by chatViewModel.messages.collectAsState()
-    val isStreaming by chatViewModel.isStreaming.collectAsState()
+    // This screen owns its handler, but ChatViewModel binds it from a
+    // DisposableEffect after the first composition. Collecting the ViewModel's
+    // fallback flows here can therefore leave the screen permanently empty when
+    // a fast history load completes before Compose schedules another frame.
+    val messages by handler.messages.collectAsState()
+    val isStreaming by handler.isStreaming.collectAsState()
     val isLoading by chatViewModel.isLoadingHistory.collectAsState()
-    val error by chatViewModel.error.collectAsState()
+    val error by handler.error.collectAsState()
     val iconPath by connectionViewModel
         .profileIconFlow(route.connectionId, route.profileName)
         .collectAsState(initial = null)


### PR DESCRIPTION
## Summary

- collect Bot Chat messages, streaming state, and errors from the route-owned ChatHandler
- avoid retaining ChatViewModel empty fallback flows before DisposableEffect binds the handler
- document the user-visible fix in the unreleased changelog

## Root cause

BotChatScreen reads ChatViewModel delegated flows during its first composition, before DisposableEffect binds the screen-owned ChatHandler. When history loading completes before another Compose frame, the screen can remain subscribed to empty fallback flows. Navigation triggers a recomposition, which explains why the transcript briefly flashes while going back.

## Verification

- git diff --check
- ANDROID_HOME=/home/layerflex/android-sdk ANDROID_SDK_ROOT=/home/layerflex/android-sdk JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew lint testDebugUnitTest --console=plain
- BUILD SUCCESSFUL (102 actionable tasks)