### PR TITLE
fix(android): keep visible sphere motion smooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android Git State can browse and manage host repositories exposed by the optional Hermes-Relay plugin.** Repository status, branches, diffs, and files are readable after enabling the plugin; staging, commits, sync, checkout, discard, and stash-switch remain behind scoped write grants and confirmations.
 - **Hermes-Relay Plugin provides a bounded Git workspace API for authenticated Dashboard clients.** Configured repository roots, path validation, scoped write grants, and explicit confirmation protect repository reads and mutations.
 
+### Fixed
+
+- **The visible Android Sphere keeps its smooth procedural motion across startup and chat.** Backgrounded and motion-disabled surfaces remain still without reducing foreground animation to a stepped ambient pulse.
+
 ## [Android 1.13.2] - 2026-08-25
 
 ### Added

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MorphingSphere.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MorphingSphere.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
@@ -26,8 +25,6 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hermesandroid.relay.ui.theme.LocalBrand
-import kotlinx.coroutines.delay
-import kotlin.math.sin
 
 /**
  * ASCII morphing sphere — the visual embodiment of the AI agent.
@@ -56,19 +53,13 @@ import kotlin.math.sin
 private const val SPHERE_TIME_UNITS_PER_SEC = 1f
 private const val SPHERE_TWO_PI = 6.2832f
 private const val SPHERE_COLOR_RADIANS_PER_SEC = 0.7854f
-private const val SPHERE_IDLE_BREATH_RADIANS_PER_SEC = 0.72f
-private const val SPHERE_IDLE_BREATH_SCALE = 0.012f
-private const val SPHERE_IDLE_LAYER_FRAME_INTERVAL_MS = 184L
 
 internal enum class SphereMotionMode {
     Still,
-    AmbientLayer,
     Procedural,
 }
 
 internal fun sphereMotionMode(
-    state: SphereState,
-    voiceMode: Boolean,
     motionVisible: Boolean,
     fixedTime: Float?,
     fixedColorPhase: Float?,
@@ -76,11 +67,7 @@ internal fun sphereMotionMode(
     if (!motionVisible || fixedTime != null || fixedColorPhase != null) {
         return SphereMotionMode.Still
     }
-    return if (state == SphereState.Idle && !voiceMode) {
-        SphereMotionMode.AmbientLayer
-    } else {
-        SphereMotionMode.Procedural
-    }
+    return SphereMotionMode.Procedural
 }
 
 @Composable
@@ -134,15 +121,12 @@ fun MorphingSphere(
     val cg2 by animateFloatAsState(targetC.g2, spec, label = "cg2")
     val cb2 by animateFloatAsState(targetC.b2, spec, label = "cb2")
 
-    // Active states retain the full procedural animation. Visible Idle uses a
-    // lightweight graphics-layer breath: redrawing the 58x34 glyph grid just
-    // for ambient drift was the measured screen-on hotspot, while transforming
-    // its cached layer preserves the intended living Sphere at far lower cost.
+    // Every visible Sphere uses the same display-synced procedural loop so
+    // startup, chat, and voice all feel equally smooth. Backgrounded and
+    // explicitly paused/reduced-motion renderers still pin a static frame.
     val animatedTime = remember { mutableFloatStateOf(0f) }
     val animatedColorPhase = remember { mutableFloatStateOf(0f) }
     val motionMode = sphereMotionMode(
-        state = state,
-        voiceMode = effVoiceMode,
         motionVisible = motionVisible,
         fixedTime = fixedTime,
         fixedColorPhase = fixedColorPhase,
@@ -162,25 +146,6 @@ fun MorphingSphere(
             }
         }
     }
-    val idleBreathPhase = remember { mutableFloatStateOf(0f) }
-    LaunchedEffect(motionMode) {
-        if (motionMode != SphereMotionMode.AmbientLayer) {
-            idleBreathPhase.floatValue = 0f
-            return@LaunchedEffect
-        }
-        var lastNanos = withFrameNanos { it }
-        while (true) {
-            val now = withFrameNanos { it }
-            val dtSec = (now - lastNanos).coerceAtLeast(0L) / 1_000_000_000f
-            lastNanos = now
-            idleBreathPhase.floatValue =
-                (idleBreathPhase.floatValue + dtSec * SPHERE_IDLE_BREATH_RADIANS_PER_SEC) %
-                SPHERE_TWO_PI
-            // The frame wait plus this delay caps the gentle layer-only pulse
-            // near 5fps while active procedural states retain display-rate motion.
-            delay(SPHERE_IDLE_LAYER_FRAME_INTERVAL_MS)
-        }
-    }
 
     val time = fixedTime ?: animatedTime.floatValue
     val colorPhase = fixedColorPhase ?: animatedColorPhase.floatValue
@@ -192,18 +157,7 @@ fun MorphingSphere(
     val textMeasurer = rememberTextMeasurer(cacheSize = 64)
     val glyphStrings = remember { HashMap<Char, String>(32) }
 
-    Canvas(
-        modifier = modifier
-            .fillMaxSize()
-            .graphicsLayer {
-                if (motionMode == SphereMotionMode.AmbientLayer) {
-                    val scale = 1f + sin(idleBreathPhase.floatValue) * SPHERE_IDLE_BREATH_SCALE
-                    scaleX = scale
-                    scaleY = scale
-                }
-            }
-            .clipToBounds(),
-    ) {
+    Canvas(modifier = modifier.fillMaxSize().clipToBounds()) {
         val canvasW = size.width
         val canvasH = size.height
         val cellW = canvasW / cols

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/MorphingSphereMotionPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/MorphingSphereMotionPolicyTest.kt
@@ -5,12 +5,10 @@ import org.junit.Test
 
 class MorphingSphereMotionPolicyTest {
     @Test
-    fun `visible idle sphere uses lightweight ambient motion`() {
+    fun `every visible sphere uses smooth procedural motion`() {
         assertEquals(
-            SphereMotionMode.AmbientLayer,
+            SphereMotionMode.Procedural,
             sphereMotionMode(
-                state = SphereState.Idle,
-                voiceMode = false,
                 motionVisible = true,
                 fixedTime = null,
                 fixedColorPhase = null,
@@ -19,26 +17,14 @@ class MorphingSphereMotionPolicyTest {
     }
 
     @Test
-    fun `hidden or paused idle sphere is still`() {
+    fun `hidden or paused sphere is still`() {
         assertEquals(
             SphereMotionMode.Still,
-            sphereMotionMode(SphereState.Idle, false, false, null, null),
+            sphereMotionMode(false, null, null),
         )
         assertEquals(
             SphereMotionMode.Still,
-            sphereMotionMode(SphereState.Idle, false, true, 0f, 0f),
-        )
-    }
-
-    @Test
-    fun `visible active and voice states keep procedural motion`() {
-        assertEquals(
-            SphereMotionMode.Procedural,
-            sphereMotionMode(SphereState.Thinking, false, true, null, null),
-        )
-        assertEquals(
-            SphereMotionMode.Procedural,
-            sphereMotionMode(SphereState.Idle, true, true, null, null),
+            sphereMotionMode(true, 0f, 0f),
         )
     }
 }


### PR DESCRIPTION
## Summary

Keep the visible Android Sphere smooth across startup, chat, and voice while preserving background and reduced-motion pauses.

## Changes

- Run every visible Sphere through the display-synced procedural animation loop.
- Remove the stepped idle-only ambient layer.
- Keep backgrounded and motion-disabled surfaces static.
- Update the motion-policy test and public changelog.

## Verification

- `./gradlew :app:testSideloadDebugUnitTest --tests "com.hermesandroid.relay.ui.components.MorphingSphereMotionPolicyTest" :app:lintSideloadDebug`
- Sideload debug APK reviewed on a physical Android device across startup, chat, and voice.
- Translation changes: N/A
- Server changes: N/A
- Desktop changes: N/A
- Docs/site changes: N/A

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: lint and focused unit tests ran, or rationale is listed above
- [x] Translation changes: locale status/review references are accurate, `python scripts/check-android-locales.py` ran, and device/emulator review is documented, or N/A
- [x] Server changes: focused `python -m unittest ...` checks ran, or rationale is listed above
- [x] Desktop changes: `npm run build` or a narrower documented check ran, or rationale is listed above
- [x] Docs/site changes: docs build or link check ran, or rationale is listed above
- [x] UI changes were tested on emulator/device or desktop surface when applicable
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md updated (if user-facing)
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged work links the source PR and preserves contributor authorship, or N/A