### PR TITLE
docs: document bounded issue triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,18 @@ PR; never resolve those cases by choosing a side automatically.
 - Prioritize findings that warrant holding the merge. State the impacted path
   and the concrete failure mode.
 
+## Automated public issue triage
+
+New public issues may receive one clearly labeled **Hermes-Relay automated
+triage** reply. That first response may classify the report with existing
+type/area labels, point to related issues or current code/docs, ask for safe
+sanitized diagnostics, and flag the thread for maintainer review.
+
+The automated lane never closes, assigns, milestones, prioritizes, promises a
+fix/release/timeline, or continues replying after its first response. A related
+issue is not automatically a duplicate. Human maintainer comments and decisions
+remain authoritative; read the complete live thread before acting on an issue.
+
 ## Public-repo writing hygiene
 
 Everything committed is public. In CHANGELOG, DEVLOG, README, docs, and release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,20 @@ The legacy `relay_server/` directory is a thin compatibility shim around `plugin
 | **CI/CD** | GitHub Actions (lint, build, test, signed APK artifacts) |
 | **Min SDK** | 26 (Android 8.0) / Target SDK 36 |
 
+## Issues and automated triage
+
+New issues may receive one first response headed **Hermes-Relay automated
+triage**. It reads the live report against current code, documentation, related
+issues, and public release state; it may add existing type/area labels and ask
+for a focused, safe diagnostic such as the app version, interaction mode, or a
+sanitized log excerpt.
+
+That reply is an acknowledgement and initial analysis, not a maintainer
+decision. The automated path does not close issues, assign work, set milestones
+or priority, promise a fix or release, or continue the conversation. It will
+say when a maintainer needs to review the remaining question, and a maintainer
+will follow up on the thread.
+
 ## Running the Relay Locally
 
 Only needed if you're working on the bridge, voice, notifications, or media features. Chat alone doesn't need the relay.

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,19 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-26 — Bounded public issue triage contract
+
+New GitHub issues may receive one clearly identified Hermes-Relay automated
+triage response grounded in the live report, current code and documentation,
+related open/closed issues, and verified public release state. The lane may add
+existing type/area labels, request focused sanitized diagnostics, and flag a
+thread for maintainer review.
+
+The automated path is intentionally not an issue-lifecycle owner: it cannot
+close, assign, milestone, prioritize, promise a fix/release/timeline, or continue
+replying after the first response. Replies identify themselves as automated and
+explicitly hand the remaining decision to a maintainer. Contributor guidance and
+agent instructions carry the same boundary.
+
 ## 2026-08-24 — Single dev integration authority
 
 `origin/dev` is the sole integration authority. Primary local `dev` checkouts are

--- a/TODO.md
+++ b/TODO.md
@@ -756,8 +756,10 @@ cancels). Ranked next increments, in value-per-complexity order:
 
 Plan: `docs/plans/2026-07-06-open-issue-resolution.md` (13 open issues triaged;
 fix-state claims verified against tags with `git merge-base --is-ancestor`).
-**Automation never posts to GitHub** — every comment/close/label below is an
-owner action, deliberately queued here:
+This historical batch remains owner-controlled. The bounded new-issue triage
+lane may post one clearly identified first response and basic type/area labels,
+but it does not execute backlog actions. Every comment, close, relabel, and
+milestone below remains an owner action deliberately queued here:
 
 - [ ] **#131** — close: fixed by `3573ba8` (PR #136), shipped android-v1.2.5
       (reporter was on 1.2.3). Optionally re-check Play vitals for the


### PR DESCRIPTION
## Summary

- Document the clearly identified one-response automated triage path for new issues.
- Explain which labels and safe diagnostics it may use.
- Keep closure, assignment, prioritization, release promises, duplicate decisions, and follow-up replies under maintainer control.
- Clarify that the historical open-issue resolution batch remains owner-operated.

## Test Plan

- [x] `git diff --check`
- [x] Diff-only public leakage scan
