### PR TITLE
docs: identify automated triage bot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,9 @@ triage** reply. That first response may classify the report with existing
 type/area labels, point to related issues or current code/docs, ask for safe
 sanitized diagnostics, and flag the thread for maintainer review.
 
+GitHub attributes that reply to the repository-scoped
+`hermes-relay-triage[bot]` App, never to a maintainer's personal account.
+
 The automated lane never closes, assigns, milestones, prioritizes, promises a
 fix/release/timeline, or continues replying after its first response. A related
 issue is not automatically a duplicate. Human maintainer comments and decisions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,9 @@ issues, and public release state; it may add existing type/area labels and ask
 for a focused, safe diagnostic such as the app version, interaction mode, or a
 sanitized log excerpt.
 
+GitHub displays the response as authored by `hermes-relay-triage[bot]`, a
+repository-scoped App rather than a maintainer's personal account.
+
 That reply is an acknowledgement and initial analysis, not a maintainer
 decision. The automated path does not close issues, assign work, set milestones
 or priority, promise a fix or release, or continue the conversation. It will

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -14,6 +14,10 @@ replying after the first response. Replies identify themselves as automated and
 explicitly hand the remaining decision to a maintainer. Contributor guidance and
 agent instructions carry the same boundary.
 
+Public labels and comments are attributed to the repository-scoped
+`hermes-relay-triage[bot]` GitHub App rather than a maintainer's personal
+account. The App identity does not expand the bounded action contract.
+
 ## 2026-08-24 — Single dev integration authority
 
 `origin/dev` is the sole integration authority. Primary local `dev` checkouts are


### PR DESCRIPTION
## Summary

- Document that automated issue labels and first replies are attributed to `hermes-relay-triage[bot]`.
- Clarify that the repository-scoped App never posts under a maintainer’s personal account.
- Keep the existing bounded triage authority unchanged.

## Test Plan

- [x] `git diff --check`
- [x] Diff-only public leakage scan
