### PR TITLE
docs: add canonical pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- Describe the user/developer outcome and why this change is needed. Link related issues, e.g. Closes #123. -->
+
+## Changes
+
+<!-- List the focused implementation changes. Avoid repeating the commit log. -->
+
+-
+
+## Verification
+
+<!-- List exact commands and results. Say explicitly when a check was not run or when device/UI proof remains outstanding. -->
+
+-
+
+## Screenshots
+
+<!-- UI change: include screenshots/video plus device, viewport, or emulator details. Otherwise write: No visual change. -->
+
+## Compatibility / risk
+
+<!-- Note Standard Hermes/upstream compatibility, migrations/state changes, security/privacy impact, rollout/rollback, or write N/A. -->
+
+## Lineage / contributor credit
+
+<!-- Preserve prior contributor work when replacing, salvaging, or rebuilding another PR. -->
+
+- Source PR(s): N/A
+- Attribution preserved by: N/A
+
+## Checklist
+
+<!-- Check an item when satisfied or when its N/A rationale is stated above. -->
+
+- [ ] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
+- [ ] Scope is focused and related issues/PRs are linked
+- [ ] Android changes: lint and focused tests ran, or rationale is listed above
+- [ ] Translation changes: locale validation/review ran, or N/A is listed above
+- [ ] Server/plugin changes: focused tests ran, or N/A/rationale is listed above
+- [ ] Desktop changes: build/tests ran, or N/A/rationale is listed above
+- [ ] Docs/site changes: build or link/route checks ran, or N/A/rationale is listed above
+- [ ] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `CHANGELOG.md` is updated for user-visible changes, or N/A is listed above
+- [ ] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
+- [ ] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,13 @@ documentation fixes.
 `main` is release history, not the normal contribution target; it receives
 approved release PRs from `dev` and focused hotfix PRs based on production tags.
 
+Pull requests use [the repository template](.github/pull_request_template.md).
+Keep the body grounded: describe the outcome and focused changes, list exact
+verification, include visual evidence when applicable, state compatibility or
+risk, and preserve contributor lineage when replacing or salvaging prior work.
+Check an item when it is satisfied or when its N/A rationale is written in the
+body; do not use checked boxes as a substitute for evidence.
+
 `origin/dev` is the canonical integration ref. Keep local `dev` as a clean,
 fast-forward-only mirror and create each task in its own branch/worktree from the
 current `origin/dev`. Do not accumulate unpublished commits on local `dev`. If a

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,18 @@
 # Hermes-Relay — Dev Log
 
+## 2026-08-26 — Canonical pull request intake contract
+
+The repository now supplies one pull request template derived from the structure
+already used by successful Android, plugin, desktop, docs, release, and salvage
+PRs. It asks for a concise summary, focused changes, exact verification, visual
+evidence when applicable, compatibility/risk notes, contributor lineage, and the
+existing cross-surface checklist.
+
+Checkboxes require evidence or an explicit N/A rationale. The template does not
+turn every surface into a mandatory test lane, does not replace CI or maintainer
+review, and keeps normal work targeting `dev` while preserving the documented
+release/hotfix exceptions.
+
 ## 2026-08-26 — Bounded public issue triage contract
 
 New GitHub issues may receive one clearly identified Hermes-Relay automated


### PR DESCRIPTION
## Summary

- Add a default pull request template based on the structure already used by successful Hermes-Relay PRs.
- Require concrete verification or an explicit N/A rationale instead of checkbox-only claims.
- Document the template in the contributor guide and engineering log.

## Changes

- Add `.github/pull_request_template.md` with Summary, Changes, Verification, Screenshots, Compatibility / risk, Lineage, and Checklist sections.
- Link the template from `CONTRIBUTING.md`.
- Record the canonical intake contract in `DEVLOG.md`.

## Verification

- Template structure check — 7/7 required headings present.
- Checklist structure check — 12 items present.
- Contributor-guide link check — passed.
- `git diff --check` — passed.
- Diff-only public leakage scan — passed.
- Android, translations, server/plugin, and desktop checks: N/A — documentation-only change.

## Screenshots

No visual change.

## Compatibility / risk

Documentation-only. No runtime, release, API, application-state, security, or migration behavior changes.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A — documentation-only
- [x] Translation changes: N/A — no catalogs changed
- [x] Server/plugin changes: N/A — documentation-only
- [x] Desktop changes: N/A — documentation-only
- [x] Docs/site changes: structure, link, diff, and leakage checks passed
- [x] UI changes: N/A — no visual change
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md`: N/A — contributor-process documentation only
- [x] Public writing hygiene checked
- [x] Salvaged/replacement work: N/A
