### PR TITLE
docs: limit PR intake to external contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,11 +122,13 @@ authoritative; read the complete live thread before acting on an issue.
 
 ## Automated public PR intake
 
-New non-draft pull requests may receive one clearly labeled **Hermes-Relay
-automated PR intake** reply from `hermes-relay-triage[bot]`. The intake compares
-the live PR metadata/body and changed-path list with trusted `origin/dev` policy
-and `.github/pull_request_template.md` without checking out or executing
-contributor code. It may add genuine area labels plus `documentation`, `ci`, or
+New external-contributor, non-draft pull requests may receive one clearly
+labeled **Hermes-Relay automated PR intake** reply from
+`hermes-relay-triage[bot]`. Owner-authored `Codename-11` PRs and bot PRs are
+dropped before model dispatch. For eligible PRs, the intake compares the live PR
+metadata/body and changed-path list with trusted `origin/dev` policy and
+`.github/pull_request_template.md` without checking out or executing contributor
+code. It may add genuine area labels plus `documentation`, `ci`, or
 `needs-maintainer-review` and point out missing intake evidence.
 
 The automated lane never approves, requests changes, merges, closes, assigns,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,13 +170,15 @@ risk, and preserve contributor lineage when replacing or salvaging prior work.
 Check an item when it is satisfied or when its N/A rationale is written in the
 body; do not use checked boxes as a substitute for evidence.
 
-New non-draft pull requests may receive one **Hermes-Relay automated PR intake**
-reply from `hermes-relay-triage[bot]`. The bot checks the live body, base branch,
-changed-path areas, template completeness, stated verification, visual proof,
-and lineage without checking out or executing contributor code. It may add
-bounded area/intake labels and identify missing evidence, but it does not review
-code correctness, approve, request changes, merge, close, assign, request
-reviewers, push commits, edit the PR, rerun workflows, or select review bundles.
+New external-contributor, non-draft pull requests may receive one
+**Hermes-Relay automated PR intake** reply from `hermes-relay-triage[bot]`.
+Owner-authored `Codename-11` PRs and bot PRs skip this lane. For eligible PRs,
+the bot checks the live body, base branch, changed-path areas, template
+completeness, stated verification, visual proof, and lineage without checking
+out or executing contributor code. It may add bounded area/intake labels and
+identify missing evidence, but it does not review code correctness, approve,
+request changes, merge, close, assign, request reviewers, push commits, edit the
+PR, rerun workflows, or select review bundles.
 
 `origin/dev` is the canonical integration ref. Keep local `dev` as a clean,
 fast-forward-only mirror and create each task in its own branch/worktree from the

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -7,12 +7,14 @@ maintainer is absent. The assignee is fixed in the write wrapper rather than
 chosen by webhook or model output, and represents follow-up ownership only—not
 acceptance, priority, implementation, or a release promise.
 
-A separate pull-request route now handles non-bot, non-draft `opened`,
-`reopened`, and `ready_for_review` events. It reads live PR metadata and trusted
-`dev` policy/template without executing contributor code, applies only bounded
-area/intake labels, and posts one App-authored intake reply. It cannot approve,
-request changes, merge, close, assign, request reviewers, push, edit PR text,
-rerun CI, select `review-candidate`, or claim correctness. The first production
+A separate pull-request route now handles external-contributor, non-bot,
+non-draft `opened`, `reopened`, and `ready_for_review` events. Owner-authored
+`Codename-11` PRs are dropped before model dispatch. Eligible PRs are read from
+live metadata plus trusted `dev` policy/template without executing contributor
+code; the route applies only bounded area/intake labels and posts one
+App-authored intake reply. It cannot approve, request changes, merge, close,
+assign, request reviewers, push, edit PR text, rerun CI, select
+`review-candidate`, or claim correctness. The external-contributor production
 canary retained its exact head/base/open state and proved marker idempotency.
 
 ## 2026-08-26 — Canonical pull request intake contract


### PR DESCRIPTION
## Summary

- Limit automated PR intake to external contributors.
- Skip `Codename-11` owner-authored and bot PRs before model dispatch.
- Reconcile the public agent contract, contributor guide, and engineering log with the verified runtime filter.

## Changes

- Narrow `AGENTS.md` to the external-contributor intake lane.
- Clarify eligible PRs in `CONTRIBUTING.md`.
- Record the owner-filter correction in `DEVLOG.md`.

## Verification

- Managed PR-intake/filter suite — 7 tests passed, including owner-authored PR rejection.
- Signed owner-authored #460 replay — `200 ignored` before model dispatch.
- Removed the prior #460 bot comment and its three bot-added labels; preserved the unrelated GitHub Actions comment.
- External-contributor canary #453 remains App-authored and idempotent.
- `git diff --check` — passed.
- Diff-only public leakage scan — passed.

## Screenshots

No visual change.

## Compatibility / risk

Documentation-only repository change. Runtime behavior was already narrowed and verified before this PR.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Scope is focused
- [x] Android changes: N/A — documentation-only
- [x] Translation changes: N/A
- [x] Server/plugin changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: diff and leakage checks passed
- [x] UI changes: N/A — no visual change
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md`: N/A — contributor-process documentation only
- [x] Public writing hygiene checked
- [x] Salvaged/replacement work: N/A
