### PR TITLE
fix(android): gate connection setup behind parent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Supervised connection setup stays blocked until parent access is unlocked.** The Add Connection flow now follows the supervised navigation gate consistently, and the locale registry refresh keeps shipped translation hashes current.
 - **The visible Android Sphere keeps its smooth procedural motion across startup and chat.** Backgrounded and motion-disabled surfaces remain still without reducing foreground animation to a stepped ambient pulse.
 
 ### Removed

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
@@ -3054,14 +3054,24 @@ fun RelayApp() {
                         onOpenConnection = { id ->
                             navController.navigate(Screen.ConnectionDetail.route(id))
                         },
+                        addConnectionEnabled = mayStartAddConnection(
+                            supervisedEnabled = supervisedPolicy.enabled,
+                            parentAccessUnlocked = parentAccessForCurrentRoute,
+                        ),
                         onAddConnection = {
                             val id = java.util.UUID.randomUUID().toString()
-                            // Draw step 1 immediately. Placeholder persistence
-                            // and the heavy connection-context switch continue
-                            // underneath the discovery UI instead of blocking
-                            // navigation on encrypted-store/client setup.
-                            navController.navigate(Screen.Pair.route(connectionId = id))
-                            prepareAddConnection(id, false)
+                            runAddConnectionAction(
+                                supervisedEnabled = supervisedPolicy.enabled,
+                                parentAccessUnlocked = parentAccessForCurrentRoute,
+                                navigateToPair = {
+                                    // Draw step 1 immediately. Placeholder persistence
+                                    // and the heavy connection-context switch continue
+                                    // underneath the discovery UI instead of blocking
+                                    // navigation on encrypted-store/client setup.
+                                    navController.navigate(Screen.Pair.route(connectionId = id))
+                                },
+                                prepareConnection = { prepareAddConnection(id, false) },
+                            )
                         },
                         onBack = { navController.popBackStack() },
                         // Pass the VM so the list cards can read live status

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicy.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicy.kt
@@ -12,6 +12,33 @@ internal fun isSupervisedRouteAllowed(route: String?, parentAccessUnlocked: Bool
         normalized == Screen.SupervisedAppearanceSettings.route
 }
 
+/**
+ * Creating a connection navigates to Pair and then activates an empty placeholder.
+ * In locked supervised mode Pair is forbidden, so starting that mutation would
+ * redirect to Chat and strand the placeholder before setup can be shown.
+ */
+internal fun mayStartAddConnection(
+    supervisedEnabled: Boolean,
+    parentAccessUnlocked: Boolean,
+): Boolean = !supervisedEnabled || parentAccessUnlocked
+
+/**
+ * Runs the complete Add Connection side-effect sequence behind the same policy
+ * decision used by the UI. Keeping the guard and both effects in one function
+ * makes it impossible for a locked click to navigate or prepare a placeholder.
+ */
+internal inline fun runAddConnectionAction(
+    supervisedEnabled: Boolean,
+    parentAccessUnlocked: Boolean,
+    navigateToPair: () -> Unit,
+    prepareConnection: () -> Unit,
+): Boolean {
+    if (!mayStartAddConnection(supervisedEnabled, parentAccessUnlocked)) return false
+    navigateToPair()
+    prepareConnection()
+    return true
+}
+
 /** Do not inspect or mutate a NavController until its first destination exists. */
 internal fun shouldRedirectSupervisedRoute(
     supervisedEnabled: Boolean,

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ConnectionsSettingsScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ConnectionsSettingsScreen.kt
@@ -107,6 +107,7 @@ fun ConnectionsSettingsScreen(
     activeRelayUiState: RelayUiState,
     onOpenConnection: (id: String) -> Unit,
     onAddConnection: () -> Unit,
+    addConnectionEnabled: Boolean = true,
     onBack: () -> Unit,
     // `null` means no VM wired (test harness / @Preview); the active card's
     // live summary falls back to the static pairing metadata.
@@ -245,6 +246,7 @@ fun ConnectionsSettingsScreen(
                 item {
                     Button(
                         onClick = onAddConnection,
+                        enabled = addConnectionEnabled,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 8.dp),
@@ -253,6 +255,14 @@ fun ConnectionsSettingsScreen(
                         Text(
                             text = stringResource(R.string.conn_add_connection),
                             modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                    if (!addConnectionEnabled) {
+                        Text(
+                            text = stringResource(R.string.conn_add_requires_parent_access),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                         )
                     }
                 }

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -781,6 +781,7 @@
     <string name="conn_back">Voltar</string>
     <string name="conn_title">Conexões</string>
     <string name="conn_add_connection">Adicionar conexão</string>
+    <string name="conn_add_requires_parent_access">Desbloqueie o acesso dos responsáveis antes de adicionar uma conexão.</string>
     <string name="conn_no_connections">Ainda não há conexões</string>
     <string name="conn_no_connections_desc">Toque em Adicionar conexão para se conectar ao Hermes.</string>
     <string name="conn_active">Ativa</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -822,6 +822,7 @@
     <string name="conn_back">返回</string>
     <string name="conn_title">连接</string>
     <string name="conn_add_connection">添加连接</string>
+    <string name="conn_add_requires_parent_access">添加连接前，请先解锁家长访问权限。</string>
     <string name="conn_no_connections">暂无连接</string>
     <string name="conn_no_connections_desc">点击添加连接以连接到 Hermes。</string>
     <string name="conn_active">活跃</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -824,6 +824,7 @@
     <string name="conn_back">Zurück</string>
     <string name="conn_title">Verbindungen</string>
     <string name="conn_add_connection">Verbindung hinzufügen</string>
+    <string name="conn_add_requires_parent_access">Entsperre den Elternzugriff, bevor du eine Verbindung hinzufügst.</string>
     <string name="conn_no_connections">Noch keine Verbindungen</string>
     <string name="conn_no_connections_desc">Tippe auf Verbindung hinzufügen, um dich mit Hermes zu verbinden.</string>
     <string name="conn_active">Aktiv</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -747,6 +747,7 @@
     <string name="conn_back">Atrás</string>
     <string name="conn_title">Conexiones</string>
     <string name="conn_add_connection">Agregar conexión</string>
+    <string name="conn_add_requires_parent_access">Desbloquea el acceso parental antes de agregar una conexión.</string>
     <string name="conn_no_connections">Aún no hay conexiones</string>
     <string name="conn_no_connections_desc">Toque Agregar conexión para conectarse a Hermes.</string>
     <string name="conn_active">Activo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -822,6 +822,7 @@
     <string name="conn_back">戻る</string>
     <string name="conn_title">接続</string>
     <string name="conn_add_connection">接続の追加</string>
+    <string name="conn_add_requires_parent_access">接続を追加する前に、保護者アクセスのロックを解除してください。</string>
     <string name="conn_no_connections">まだ接続がありません</string>
     <string name="conn_no_connections_desc">[接続の追加] をタップして Hermes に接続します。</string>
     <string name="conn_active">アクティブ</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -794,6 +794,7 @@
     <string name="conn_back">Назад</string>
     <string name="conn_title">Подключения</string>
     <string name="conn_add_connection">Добавить подключение</string>
+    <string name="conn_add_requires_parent_access">Разблокируйте родительский доступ, прежде чем добавлять подключение.</string>
     <string name="conn_no_connections">Еще нет подключений</string>
     <string name="conn_no_connections_desc">Нажмите Добавить подключение, чтобы подключиться к Гермесу.</string>
     <string name="conn_active">Активный</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -872,6 +872,7 @@
     <string name="conn_back">Back</string>
     <string name="conn_title">Connections</string>
     <string name="conn_add_connection">Add connection</string>
+    <string name="conn_add_requires_parent_access">Unlock parent access before adding a connection.</string>
     <string name="conn_no_connections">No connections yet</string>
     <string name="conn_no_connections_desc">Tap Add connection to connect to Hermes.</string>
     <string name="conn_active">Active</string>

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicyTest.kt
@@ -27,6 +27,51 @@ class SupervisedNavigationPolicyTest {
         assertTrue(isSupervisedRouteAllowed(Screen.AdvancedSettings.route, true))
     }
 
+    @Test fun `locked supervised mode blocks add connection before placeholder creation`() {
+        assertFalse(mayStartAddConnection(supervisedEnabled = true, parentAccessUnlocked = false))
+        assertFalse(
+            isSupervisedRouteAllowed(
+                Screen.Pair.route(connectionId = "new-placeholder"),
+                parentAccessUnlocked = false,
+            ),
+        )
+    }
+
+    @Test fun `parent access or ordinary mode permits add connection`() {
+        assertTrue(mayStartAddConnection(supervisedEnabled = true, parentAccessUnlocked = true))
+        assertTrue(mayStartAddConnection(supervisedEnabled = false, parentAccessUnlocked = false))
+    }
+
+    @Test fun `locked add action neither navigates nor prepares a placeholder`() {
+        var navigated = false
+        var prepared = false
+
+        val started = runAddConnectionAction(
+            supervisedEnabled = true,
+            parentAccessUnlocked = false,
+            navigateToPair = { navigated = true },
+            prepareConnection = { prepared = true },
+        )
+
+        assertFalse(started)
+        assertFalse(navigated)
+        assertFalse(prepared)
+    }
+
+    @Test fun `allowed add action navigates before preparing the connection`() {
+        val actions = mutableListOf<String>()
+
+        val started = runAddConnectionAction(
+            supervisedEnabled = true,
+            parentAccessUnlocked = true,
+            navigateToPair = { actions += "navigate" },
+            prepareConnection = { actions += "prepare" },
+        )
+
+        assertTrue(started)
+        assertTrue(actions == listOf("navigate", "prepare"))
+    }
+
     @Test fun `supervised redirect waits until the navigation graph has a route`() {
         assertFalse(shouldRedirectSupervisedRoute(true, false, null))
         assertTrue(isSupervisedRouteContentAllowed(true, false, null))

--- a/docs/localization-status.json
+++ b/docs/localization-status.json
@@ -13,7 +13,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "28d58a3b9803968124ea6581fd9dbb3a0ce2a9ee1c946228bb6f0b79f987a24a",
+        "main": "5e4c6b6608b9681d3e7f53cef7059b51aaa93df9b4695d353ec64aef4157bed3",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -48,7 +48,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "28d58a3b9803968124ea6581fd9dbb3a0ce2a9ee1c946228bb6f0b79f987a24a",
+        "main": "5e4c6b6608b9681d3e7f53cef7059b51aaa93df9b4695d353ec64aef4157bed3",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -72,7 +72,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "28d58a3b9803968124ea6581fd9dbb3a0ce2a9ee1c946228bb6f0b79f987a24a",
+        "main": "5e4c6b6608b9681d3e7f53cef7059b51aaa93df9b4695d353ec64aef4157bed3",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -96,7 +96,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "28d58a3b9803968124ea6581fd9dbb3a0ce2a9ee1c946228bb6f0b79f987a24a",
+        "main": "5e4c6b6608b9681d3e7f53cef7059b51aaa93df9b4695d353ec64aef4157bed3",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -120,7 +120,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "28d58a3b9803968124ea6581fd9dbb3a0ce2a9ee1c946228bb6f0b79f987a24a",
+        "main": "5e4c6b6608b9681d3e7f53cef7059b51aaa93df9b4695d353ec64aef4157bed3",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {
@@ -135,7 +135,7 @@
       "verification": "ai-translated",
       "review_refs": [],
       "source_sha256": {
-        "main": "28d58a3b9803968124ea6581fd9dbb3a0ce2a9ee1c946228bb6f0b79f987a24a",
+        "main": "5e4c6b6608b9681d3e7f53cef7059b51aaa93df9b4695d353ec64aef4157bed3",
         "sideload": "4abff4f1069091ec2de735c3037a7ec7d77699cb4321e8511a622437bceaf7c2"
       },
       "surfaces": {


### PR DESCRIPTION
## Summary

Prevent Android supervised mode from starting connection setup while parent access is locked. The Add connection action is disabled with localized unlock guidance, and both Pair navigation and placeholder creation are guarded by the same parent-access policy.

Closes #466.

## Changes

- Disable Add connection while supervised mode is locked and explain how to unlock it in every shipped Android locale.
- Guard Pair navigation and placeholder preparation behind the same policy.
- Cover denied side effects and allowed navigation ordering with regression tests.
- Add an Unreleased changelog entry and refresh Android locale source hashes without changing their verification levels.

## Verification

- `./gradlew lint` → passed.
- `./gradlew :app:testGooglePlayDebugUnitTest --tests 'com.hermesandroid.relay.ui.SupervisedNavigationPolicyTest'` → 12 tests, 0 failures/errors.
- `./gradlew :app:testSideloadDebugUnitTest --tests 'com.hermesandroid.relay.ui.SupervisedNavigationPolicyTest'` → 12 tests, 0 failures/errors.
- `./gradlew :app:testSideloadDebugUnitTest --rerun-tasks` → 2552 tests total: 2536 passed, 12 skipped, 4 failed. Two timing-sensitive `ChatViewModelGatewayInboundTurnTest` failures passed when rerun in isolation. The two `GitStateWriteViewModelTest` failures reproduced unchanged on a clean `origin/dev` worktree.
- `python scripts/check-android-locales.py` → passed: `Android locale validation passed (12 catalog(s))`.
- Locale review status: all translated catalogs have key/format parity and refreshed source hashes; their existing `ai-translated` verification level remains unchanged. No fluent review is claimed.
- GitHub Actions for the current head report `action_required` without starting jobs because workflows from the fork still require maintainer approval.

## Screenshots

This changes visible Android UI behavior: Add connection becomes disabled and localized unlock guidance is shown while supervised mode is locked. Device/emulator screenshots and manual UI proof remain outstanding.

## Compatibility / risk

- Standard Hermes and non-supervised Android connection setup remain unchanged.
- No server/plugin, desktop, API, migration, persistent-state, permission, or privacy changes.
- Security impact is limited and positive: the existing parent-access boundary now also blocks Pair navigation and placeholder creation.
- Changelog and localization-status edits do not change documentation routes or site behavior, so docs/site build checks are N/A.
- Rollback is a revert of the two PR commits; no data migration is required.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: lint and focused tests ran, or rationale is listed above
- [x] Translation changes: locale validation/review ran, or N/A is listed above
- [x] Server/plugin changes: focused tests ran, or N/A/rationale is listed above
- [x] Desktop changes: build/tests ran, or N/A/rationale is listed above
- [x] Docs/site changes: build or link/route checks ran, or N/A/rationale is listed above
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md` is updated for user-visible changes, or N/A is listed above
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above
