### PR TITLE
fix(android): restore Voice Focus stop and overlay controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Android Continuous voice waits for barge-in microphone teardown before listening again.** Multi-turn hands-free conversations no longer lose the microphone after a response finishes with barge-in enabled. (#464)
 - **The visible Android Sphere keeps its smooth procedural motion across startup and chat.** Backgrounded and motion-disabled surfaces remain still without reducing foreground animation to a stepped ambient pulse.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Android Continuous voice waits for barge-in microphone teardown before listening again.** Multi-turn hands-free conversations no longer lose the microphone after a response finishes with barge-in enabled. (#464)
 - **The visible Android Sphere keeps its smooth procedural motion across startup and chat.** Backgrounded and motion-disabled surfaces remain still without reducing foreground animation to a stepped ambient pulse.
+- **Android Voice Focus keeps Stop and immediate spoken steering available across every interaction mode.** Hold-to-talk now interrupts Thinking and Transcribing turns before capturing the replacement direction, floating voice controls preserve press-and-release behavior, and Google Play no longer offers the sideload-only system overlay action.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Android Continuous voice waits for barge-in microphone teardown before listening again.** Multi-turn hands-free conversations no longer lose the microphone after a response finishes with barge-in enabled. (#464)
 - **The visible Android Sphere keeps its smooth procedural motion across startup and chat.** Backgrounded and motion-disabled surfaces remain still without reducing foreground animation to a stepped ambient pulse.
-- **Android Voice Focus keeps Stop and immediate spoken steering available across every interaction mode.** Hold-to-talk now interrupts Thinking and Transcribing turns before capturing the replacement direction, floating voice controls preserve press-and-release behavior, and Google Play no longer offers the sideload-only system overlay action.
+- **Android Voice Focus keeps Stop and immediate spoken steering available across every interaction mode.** Hold-to-talk now interrupts Thinking and Transcribing turns before capturing the replacement direction, remains operable through TalkBack, Switch Access, and keyboard controls, preserves pointer press-and-release behavior across floating controls, and Google Play no longer offers the sideload-only system overlay action.
 
 ### Removed
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlay.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlay.kt
@@ -152,6 +152,7 @@ fun VoiceModeOverlay(
     voiceOutputEnabled: Boolean? = null,
     voiceOutputFallbackEnabled: Boolean? = null,
     onOverlayRequest: () -> Unit = {},
+    systemOverlayAvailable: Boolean = true,
     presentationMode: VoicePresentationMode = VoicePresentationMode.Focus,
     onPresentationModeChange: (VoicePresentationMode) -> Unit = {},
     // === END PHASE3-voice-mode-transcript ===
@@ -238,6 +239,7 @@ fun VoiceModeOverlay(
                 onInterrupt = onInterrupt,
                 onPauseAutoMode = onPauseAutoMode,
                 onOverlayRequest = onOverlayRequest,
+                systemOverlayAvailable = systemOverlayAvailable,
                 onOpenSettings = onOpenSettings,
                 onExit = onDismiss,
                 modifier = Modifier
@@ -622,6 +624,22 @@ private fun VoiceMicButton(
 ) {
     if (!visible) return
 
+    val micActionDescription = when (uiState.state) {
+        VoiceState.Idle, VoiceState.Error -> stringResource(R.string.voice_overlay_tap_action_idle)
+        VoiceState.Listening ->
+            if (uiState.interactionMode == InteractionMode.Continuous) {
+                stringResource(R.string.voice_overlay_tap_action_pause)
+            } else {
+                stringResource(R.string.voice_overlay_tap_action_listening)
+            }
+        VoiceState.Transcribing, VoiceState.Thinking, VoiceState.Speaking ->
+            if (uiState.interactionMode == InteractionMode.Continuous) {
+                stringResource(R.string.voice_overlay_tap_action_pause)
+            } else {
+                stringResource(R.string.voice_overlay_tap_action_interrupt)
+            }
+    }
+
     val pulseScale by animateFloatAsState(
         targetValue = when (uiState.state) {
             VoiceState.Listening -> 1f + uiState.amplitude * 0.15f
@@ -656,28 +674,12 @@ private fun VoiceMicButton(
         else -> Icons.Filled.Mic
     }
 
-    val currentOnTap by rememberUpdatedState(onTap)
-    val currentOnHoldPress by rememberUpdatedState(onHoldPress)
-    val currentOnHoldRelease by rememberUpdatedState(onHoldRelease)
-
     val gestureModifier = when (uiState.interactionMode) {
-        InteractionMode.HoldToTalk -> Modifier.pointerInput(Unit) {
-            awaitEachGesture {
-                awaitFirstDown(requireUnconsumed = false)
-                currentOnHoldPress()
-                // Hold until the finger genuinely lifts. Don't use
-                // waitForUpOrCancellation(): it ends the hold on ANY cancel — a
-                // consumed move event or the finger drifting just off the small
-                // circle — which made the button feel like it released by
-                // accident. Loop until no pointer is still pressed so drift and
-                // minor consumption don't cut the recording short.
-                do {
-                    val event = awaitPointerEvent()
-                } while (event.changes.any { it.pressed })
-                currentOnHoldRelease()
-            }
-        }
-        else -> Modifier.clickable { currentOnTap() }
+        InteractionMode.HoldToTalk -> Modifier.voiceHoldGesture(
+            onPress = onHoldPress,
+            onRelease = onHoldRelease,
+        )
+        else -> Modifier.clickable(onClick = onTap)
     }
 
     Surface(
@@ -692,12 +694,44 @@ private fun VoiceMicButton(
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = icon,
-                contentDescription = stringResource(R.string.voice_overlay_mic_cd),
+                contentDescription = micActionDescription,
                 tint = Color.White,
                 modifier = Modifier.size(iconSize.dp),
             )
         }
     }
+}
+
+/**
+ * Shared Hold-to-talk gesture for in-app and system-overlay voice controls.
+ * The callback refs update across recomposition without restarting the active
+ * gesture when its press changes VoiceUiState to Listening.
+ */
+@Composable
+internal fun Modifier.voiceHoldGesture(
+    onPress: () -> Unit,
+    onRelease: () -> Unit,
+): Modifier {
+    val currentOnPress by rememberUpdatedState(onPress)
+    val currentOnRelease by rememberUpdatedState(onRelease)
+    return then(
+        Modifier.pointerInput(Unit) {
+            awaitEachGesture {
+                awaitFirstDown(requireUnconsumed = false)
+                currentOnPress()
+                // Hold until the finger genuinely lifts. Don't use
+                // waitForUpOrCancellation(): it ends the hold on ANY cancel — a
+                // consumed move event or the finger drifting just off the small
+                // circle — which made the button feel like it released by
+                // accident. Loop until no pointer is still pressed so drift and
+                // minor consumption don't cut the recording short.
+                do {
+                    val event = awaitPointerEvent()
+                } while (event.changes.any { it.pressed })
+                currentOnRelease()
+            }
+        },
+    )
 }
 
 private fun voiceStateToSphereState(state: VoiceState): SphereState = when (state) {
@@ -773,6 +807,7 @@ fun ConversationVoiceDock(
     onOverlayRequest: () -> Unit,
     onOpenSettings: () -> Unit,
     onExit: () -> Unit,
+    systemOverlayAvailable: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -816,17 +851,19 @@ fun ConversationVoiceDock(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    TextButton(
-                        onClick = onOverlayRequest,
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(40.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.voice_overlay_overlay),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                    if (systemOverlayAvailable) {
+                        TextButton(
+                            onClick = onOverlayRequest,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(40.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.voice_overlay_overlay),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
                     TextButton(
                         onClick = onExit,
@@ -1006,6 +1043,7 @@ private fun VoiceSessionPill(
     onInterrupt: () -> Unit,
     onPauseAutoMode: () -> Unit,
     onOverlayRequest: () -> Unit,
+    systemOverlayAvailable: Boolean,
     onOpenSettings: () -> Unit,
     onExit: () -> Unit,
     modifier: Modifier = Modifier,
@@ -1158,21 +1196,23 @@ private fun VoiceSessionPill(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
-                        TextButton(
-                            onClick = {
-                                onFocusModeChange(false)
-                                onOverlayRequest()
-                            },
-                            modifier = Modifier
-                                .weight(0.95f)
-                                .height(40.dp),
-                        ) {
-                            Text(
-                                stringResource(R.string.voice_overlay_overlay),
-                                style = MaterialTheme.typography.labelMedium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                        if (systemOverlayAvailable) {
+                            TextButton(
+                                onClick = {
+                                    onFocusModeChange(false)
+                                    onOverlayRequest()
+                                },
+                                modifier = Modifier
+                                    .weight(0.95f)
+                                    .height(40.dp),
+                            ) {
+                                Text(
+                                    stringResource(R.string.voice_overlay_overlay),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
                         TextButton(
                             onClick = onExit,
@@ -1289,8 +1329,9 @@ internal fun dispatchVoiceMicHoldPress(
 ) {
     when (uiState.state) {
         VoiceState.Idle, VoiceState.Error -> onStartListening()
-        VoiceState.Speaking -> onInterruptAndStart()
-        VoiceState.Listening, VoiceState.Transcribing, VoiceState.Thinking -> Unit
+        VoiceState.Speaking, VoiceState.Transcribing, VoiceState.Thinking ->
+            onInterruptAndStart()
+        VoiceState.Listening -> Unit
     }
 }
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlay.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlay.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
@@ -63,13 +64,20 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -102,6 +110,8 @@ import java.io.File
 import androidx.compose.ui.res.stringResource
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.ui.theme.appearanceRoundedCornerShape
+
+internal const val VOICE_MODE_MIC_TEST_TAG = "voiceModeMic"
 
 /**
  * Full-screen voice-mode overlay. Renders the MorphingSphere in its voiceMode
@@ -676,6 +686,9 @@ private fun VoiceMicButton(
 
     val gestureModifier = when (uiState.interactionMode) {
         InteractionMode.HoldToTalk -> Modifier.voiceHoldGesture(
+            state = uiState.state,
+            inactiveActionLabel = micActionDescription,
+            activeActionLabel = stringResource(R.string.voice_overlay_tap_action_listening),
             onPress = onHoldPress,
             onRelease = onHoldRelease,
         )
@@ -686,6 +699,7 @@ private fun VoiceMicButton(
         modifier = modifier
             .size((baseSize * pulseScale).dp)
             .clip(CircleShape)
+            .testTag(VOICE_MODE_MIC_TEST_TAG)
             .then(gestureModifier),
         shape = CircleShape,
         color = containerColor,
@@ -694,7 +708,11 @@ private fun VoiceMicButton(
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = icon,
-                contentDescription = micActionDescription,
+                contentDescription = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
+                    null
+                } else {
+                    micActionDescription
+                },
                 tint = Color.White,
                 modifier = Modifier.size(iconSize.dp),
             )
@@ -707,31 +725,89 @@ private fun VoiceMicButton(
  * The callback refs update across recomposition without restarting the active
  * gesture when its press changes VoiceUiState to Listening.
  */
-@Composable
 internal fun Modifier.voiceHoldGesture(
+    state: VoiceState,
+    inactiveActionLabel: String,
+    activeActionLabel: String,
     onPress: () -> Unit,
     onRelease: () -> Unit,
-): Modifier {
+    inactiveContentDescription: String = inactiveActionLabel,
+    activeContentDescription: String = activeActionLabel,
+): Modifier = composed {
     val currentOnPress by rememberUpdatedState(onPress)
     val currentOnRelease by rememberUpdatedState(onRelease)
-    return then(
-        Modifier.pointerInput(Unit) {
-            awaitEachGesture {
-                awaitFirstDown(requireUnconsumed = false)
-                currentOnPress()
-                // Hold until the finger genuinely lifts. Don't use
-                // waitForUpOrCancellation(): it ends the hold on ANY cancel — a
-                // consumed move event or the finger drifting just off the small
-                // circle — which made the button feel like it released by
-                // accident. Loop until no pointer is still pressed so drift and
-                // minor consumption don't cut the recording short.
-                do {
-                    val event = awaitPointerEvent()
-                } while (event.changes.any { it.pressed })
-                currentOnRelease()
+    var semanticHoldActive by remember { mutableStateOf(state == VoiceState.Listening) }
+    var semanticCaptureStarted by remember { mutableStateOf(state == VoiceState.Listening) }
+
+    LaunchedEffect(state) {
+        when {
+            state == VoiceState.Listening -> {
+                semanticHoldActive = true
+                semanticCaptureStarted = true
             }
-        },
-    )
+            semanticCaptureStarted -> {
+                semanticHoldActive = false
+                semanticCaptureStarted = false
+            }
+            state == VoiceState.Error -> semanticHoldActive = false
+        }
+    }
+
+    val semanticToggle = {
+        if (semanticHoldActive) {
+            semanticHoldActive = false
+            semanticCaptureStarted = false
+            currentOnRelease()
+        } else {
+            semanticHoldActive = true
+            currentOnPress()
+        }
+    }
+    Modifier
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                contentDescription = if (semanticHoldActive) {
+                    activeContentDescription
+                } else {
+                    inactiveContentDescription
+                }
+                onClick(
+                    label = if (semanticHoldActive) activeActionLabel else inactiveActionLabel,
+                ) {
+                    semanticToggle()
+                    true
+                }
+            }
+            .onPreviewKeyEvent { event ->
+                val native = event.nativeKeyEvent
+                val activationKey = native.keyCode == android.view.KeyEvent.KEYCODE_ENTER ||
+                    native.keyCode == android.view.KeyEvent.KEYCODE_NUMPAD_ENTER ||
+                    native.keyCode == android.view.KeyEvent.KEYCODE_SPACE ||
+                    native.keyCode == android.view.KeyEvent.KEYCODE_DPAD_CENTER
+                if (native.action == android.view.KeyEvent.ACTION_UP && activationKey) {
+                    semanticToggle()
+                    true
+                } else {
+                    false
+                }
+            }
+            .focusable()
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false)
+                    currentOnPress()
+                    // Hold until the finger genuinely lifts. Don't use
+                    // waitForUpOrCancellation(): it ends the hold on ANY cancel — a
+                    // consumed move event or the finger drifting just off the small
+                    // circle — which made the button feel like it released by
+                    // accident. Loop until no pointer is still pressed so drift and
+                    // minor consumption don't cut the recording short.
+                    do {
+                        val event = awaitPointerEvent()
+                    } while (event.changes.any { it.pressed })
+                    currentOnRelease()
+                }
+            }
 }
 
 private fun voiceStateToSphereState(state: VoiceState): SphereState = when (state) {

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -169,6 +169,7 @@ import com.hermesandroid.relay.util.AttachmentTooLargeException
 import com.hermesandroid.relay.util.readBase64Bounded
 import com.hermesandroid.relay.data.ChatComposerDraftKey
 import com.hermesandroid.relay.data.ChatQuoteReference
+import com.hermesandroid.relay.data.BuildFlavor
 import com.hermesandroid.relay.data.LARGE_PASTE_THRESHOLD_CHARS
 import com.hermesandroid.relay.data.buildChatQuotedPrompt
 import com.hermesandroid.relay.data.largePasteAttachment
@@ -1559,8 +1560,11 @@ fun ChatScreen(
         voiceOutputConfig?.enabled
     }
 
+    val voiceSystemOverlayAvailable = BuildFlavor.isSideload
     val showVoiceSystemOverlay: () -> Unit = {
-        if (assistantSessionActive) {
+        if (!voiceSystemOverlayAvailable) {
+            pendingVoiceOverlayPermission = false
+        } else if (assistantSessionActive) {
             voiceOverlayHost.hide()
         } else if (!voiceOverlayHost.hasOverlayPermission()) {
             pendingVoiceOverlayPermission = true
@@ -4656,6 +4660,7 @@ fun ChatScreen(
                             setVoicePresentationMode(VoicePresentationMode.Focus)
                         },
                         onOverlayRequest = showVoiceSystemOverlay,
+                        systemOverlayAvailable = voiceSystemOverlayAvailable,
                         onOpenSettings = onNavigateToVoiceSettings,
                         onExit = { voiceViewModel.exitVoiceMode() },
                     )
@@ -4812,6 +4817,7 @@ fun ChatScreen(
                 presentationMode = effectiveVoicePresentationMode,
                 onPresentationModeChange = setVoicePresentationMode,
                 onOverlayRequest = showVoiceSystemOverlay,
+                systemOverlayAvailable = voiceSystemOverlayAvailable,
                 // Gear button in the overlay's expanded controls. The overlay
                 // exits voice mode before invoking this, so navigation lands
                 // on Voice Settings with no overlay left on top.

--- a/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/util/RelayErrorClassifier.kt
@@ -257,7 +257,10 @@ private fun classifyErrorInternal(t: Throwable?, context: String?, ctx: Context?
 
     val msg = t.message.orEmpty().lowercase()
 
-    if ("cannot create audiorecord" in msg || "audiorecord failed to initialize" in msg) {
+    if ("cannot create audiorecord" in msg ||
+        "audiorecord failed to initialize" in msg ||
+        "microphone is in use by another voice feature" in msg
+    ) {
         return HumanError(
             title = ctx?.getString(R.string.error_classify_mic_unavailable) ?: "Microphone unavailable",
             body = ctx?.getString(R.string.error_classify_mic_unavailable_body)

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -2094,8 +2094,11 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             !continuousListeningPaused
     }
 
-    private fun startVoiceCapture(rec: VoiceRecorder) {
-        try {
+    private fun startVoiceCapture(
+        rec: VoiceRecorder,
+        bargeInCapture: Boolean = false,
+    ): Boolean {
+        return try {
             rec.startRecording()
             listeningStartedAtMs = System.currentTimeMillis()
             _uiState.update {
@@ -2110,16 +2113,20 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                     handoffStatus = null,
                 )
             }
-            // 2026-04-18: arm silence-based auto-stop. HoldToTalk skips
-            // this — the physical release is the authoritative stop.
-            if (_uiState.value.interactionMode != InteractionMode.HoldToTalk) {
+            // A normal Hold-to-talk capture ends on physical release. A
+            // barge-in capture is VAD-owned instead, so it always needs the
+            // silence watchdog even when Hold-to-talk is the saved mode;
+            // otherwise the steering utterance remains open indefinitely.
+            if (shouldArmVoiceSilenceWatchdog(_uiState.value.interactionMode, bargeInCapture)) {
                 startSilenceWatchdog()
             }
+            true
         } catch (e: Exception) {
             listeningStartedAtMs = 0L
             Log.e(TAG, "startListening failed: ${e.message}")
             // SecurityException path becomes "Permission needed" via the classifier.
             surfaceError(e, context = "record")
+            false
         }
     }
 
@@ -6074,12 +6081,17 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                     return@launch
                 }
                 val rec = recorder ?: error("Recorder not initialized")
-                if (!rec.isRecording()) {
-                    rec.startRecording()
+                val captureStarted = rec.isRecording() ||
+                    startVoiceCapture(rec, bargeInCapture = true)
+                if (!captureStarted) {
+                    abandonBargeInCaptureIfCurrent(captureEpoch)
+                    return@launch
                 }
                 if (canStartBargeInCapture(captureEpoch, interruptedMode, interruptedEngine)) {
                     scheduleResumeWatchdog()
                 } else {
+                    silenceWatchdogJob?.cancel()
+                    silenceWatchdogJob = null
                     try { rec.cancel() } catch (_: Throwable) { /* ignore */ }
                     abandonBargeInCaptureIfCurrent(captureEpoch)
                 }
@@ -6981,6 +6993,11 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     }
 
 }
+
+internal fun shouldArmVoiceSilenceWatchdog(
+    interactionMode: InteractionMode,
+    bargeInCapture: Boolean,
+): Boolean = bargeInCapture || interactionMode != InteractionMode.HoldToTalk
 
 // -------------------------------------------------------------------------
 // Voice capture guards and sentence-boundary detection (top-level so they're

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -90,6 +90,7 @@ import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import com.hermesandroid.relay.data.VoicePreferencesRepository
 import com.hermesandroid.relay.data.VoiceAudioRoute
 
@@ -1037,6 +1038,14 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     private var bargeInListener: BargeInListener? = null
     private var bargeInListenerJob: Job? = null
     private var bargeInVadEngine: VadEngine? = null
+    /**
+     * The most recent asynchronous AudioRecord shutdown still releasing the
+     * process-wide BargeIn microphone lease. Teardown is intentionally
+     * idempotent, so completion paths may call [stopBargeInListener] after the
+     * listener reference has already been cleared. Retaining this fence makes
+     * every subsequent VoiceCapture start join the same ownership handoff.
+     */
+    private val pendingBargeInReaderRelease = AtomicReference<Job?>(null)
     private val bargeInTurnEpoch = AtomicLong(0L)
     @Volatile private var activeBargeInTurnEpoch: Long = 0L
 
@@ -1374,6 +1383,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         }
 
         if (mode != InteractionMode.Continuous) {
+            cancelPendingListeningStart()
             continuousLoopArmed = false
             continuousListeningPaused = false
             continuousResumeJob?.cancel()
@@ -1844,6 +1854,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun exitVoiceMode() {
+        cancelPendingListeningStart()
         // Idempotence guard — added 2026-04-21 after logcat showed the voice-
         // exit chime playing on every Add-connection tap.
         //
@@ -1995,6 +2006,10 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     // ---------------------------------------------------------------------
 
     fun startListening() {
+        startListening(requireContinuousLoop = false)
+    }
+
+    private fun startListening(requireContinuousLoop: Boolean) {
         // A direct mic tap starts a normal capture. Only the recorder opened by
         // onBargeInDetected may carry response-interruption command context.
         responseInterruptedForVoiceCommand = false
@@ -2003,6 +2018,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             setError("Recorder not initialized")
             return
         }
+        if (requireContinuousLoop && !canStartContinuousCapture()) return
         if (pendingListeningStartJob?.isActive == true) return
         if (rec.isRecording()) return
         if (_uiState.value.state == VoiceState.Listening) {
@@ -2037,7 +2053,9 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         try { realtimePcmPlayer?.stop() } catch (_: Exception) { /* ignore */ }
 
         if (microphoneRelease == null || microphoneRelease.isCompleted) {
-            startVoiceCapture(rec)
+            if (!requireContinuousLoop || canStartContinuousCapture()) {
+                startVoiceCapture(rec)
+            }
             return
         }
 
@@ -2045,7 +2063,9 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         val pendingStart = viewModelScope.launch(start = CoroutineStart.LAZY) {
             try {
                 microphoneRelease.join()
-                if (listeningStartEpoch == startEpoch) {
+                if (listeningStartEpoch == startEpoch &&
+                    (!requireContinuousLoop || canStartContinuousCapture())
+                ) {
                     startVoiceCapture(rec)
                 }
             } finally {
@@ -2056,6 +2076,15 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         }
         pendingListeningStartJob = pendingStart
         pendingStart.start()
+    }
+
+    private fun canStartContinuousCapture(): Boolean {
+        val state = _uiState.value
+        return state.voiceMode &&
+            state.interactionMode == InteractionMode.Continuous &&
+            state.state == VoiceState.Idle &&
+            continuousLoopArmed &&
+            !continuousListeningPaused
     }
 
     private fun startVoiceCapture(rec: VoiceRecorder) {
@@ -2218,6 +2247,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
      * listening turn; until then, idle queue-drain callbacks are ignored.
      */
     fun pauseContinuousMode() {
+        cancelPendingListeningStart()
         continuousLoopArmed = false
         continuousListeningPaused = _uiState.value.interactionMode == InteractionMode.Continuous
         continuousResumeJob?.cancel()
@@ -5760,7 +5790,7 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             continuousLoopArmed &&
             _uiState.value.state == VoiceState.Idle
         ) {
-            startListening()
+            startListening(requireContinuousLoop = true)
         }
     }
 
@@ -5825,6 +5855,29 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             )
             return
         }
+        if (!activeResponseOwnsBargeIn()) {
+            Log.i(TAG, "Barge-in listener skipped; no active voice response owns the microphone")
+            return
+        }
+
+        val pendingReaderRelease = pendingBargeInReaderRelease.get()?.takeUnless { it.isCompleted }
+        if (pendingReaderRelease != null) {
+            // A late playback/realtime callback may request the next turn's
+            // listener while the previous AudioRecord is still unwinding.
+            // Join the same ownership fence as VoiceCapture, then re-check the
+            // turn epoch so stale generations cannot reopen the microphone.
+            activeBargeInTurnEpoch = epoch
+            viewModelScope.launch {
+                pendingReaderRelease.join()
+                if (activeBargeInTurnEpoch == epoch &&
+                    bargeInListener == null &&
+                    activeResponseOwnsBargeIn()
+                ) {
+                    startBargeInListenerIfEnabled(epoch = epoch)
+                }
+            }
+            return
+        }
 
         val vad = try {
             vadFactory().also { it.setSensitivity(prefs.sensitivity) }
@@ -5873,6 +5926,12 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    private fun activeResponseOwnsBargeIn(): Boolean {
+        val state = _uiState.value
+        return state.voiceMode &&
+            (state.state == VoiceState.Thinking || state.state == VoiceState.Speaking)
+    }
+
     /**
      * Tear down the active [BargeInListener], cancel its event subscribers,
      * unduck the player (in case a ducking watchdog hadn't yet restored
@@ -5906,7 +5965,13 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             try { realtimePcmPlayer?.unduck() } catch (_: Throwable) { /* ignore */ }
             isDucked = false
         }
-        return stoppedReaderJob
+        if (stoppedReaderJob != null) {
+            pendingBargeInReaderRelease.set(stoppedReaderJob)
+            stoppedReaderJob.invokeOnCompletion {
+                pendingBargeInReaderRelease.compareAndSet(stoppedReaderJob, null)
+            }
+        }
+        return pendingBargeInReaderRelease.get()?.takeUnless { it.isCompleted }
     }
 
     private fun markBargeInPlaybackStarted(graceMs: Long) {
@@ -6315,8 +6380,16 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     @androidx.annotation.VisibleForTesting
+    internal fun stopBargeInListenerForTest(): Job? = stopBargeInListener()
+
+    @androidx.annotation.VisibleForTesting
+    internal fun finishAgentAudioOutputForTest() {
+        finishAgentAudioOutput()
+    }
+
+    @androidx.annotation.VisibleForTesting
     internal fun beginBargeInTurnForTest() {
-        _uiState.update { it.copy(state = VoiceState.Thinking) }
+        _uiState.update { it.copy(voiceMode = true, state = VoiceState.Thinking) }
         beginBargeInTurnIfEnabled()
     }
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/VoiceViewModel.kt
@@ -1382,8 +1382,12 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             return
         }
 
+        // A mode change supersedes any capture that is still waiting for the
+        // previous microphone owner to release. The selected mode below may
+        // start a fresh Continuous capture with its own generation.
+        cancelPendingListeningStart()
+
         if (mode != InteractionMode.Continuous) {
-            cancelPendingListeningStart()
             continuousLoopArmed = false
             continuousListeningPaused = false
             continuousResumeJob?.cancel()
@@ -2019,7 +2023,10 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
             return
         }
         if (requireContinuousLoop && !canStartContinuousCapture()) return
-        if (pendingListeningStartJob?.isActive == true) return
+        // A direct/new capture request supersedes a stale handoff waiter. It
+        // will join the same retained microphone-release fence under a fresh
+        // epoch below instead of being silently dropped.
+        cancelPendingListeningStart()
         if (rec.isRecording()) return
         if (_uiState.value.state == VoiceState.Listening) {
             // Listening is reserved for a live AudioRecord. Reconcile a stale
@@ -6023,6 +6030,8 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
      */
     internal fun onBargeInDetected() {
         if (isBargeInStartupGuardActive()) return
+        val interruptedMode = _uiState.value.interactionMode
+        val interruptedEngine = voiceEngineMode
         val interruptedSpokenReply = _uiState.value.outputAudioActive
         if (interruptedSpokenReply) spokenInterruptionLatch.mark()
         duckingWatchdog?.cancel(); duckingWatchdog = null
@@ -6056,18 +6065,63 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
                 responseText = "",
             )
         }
-        viewModelScope.launch {
+        val captureEpoch = ++listeningStartEpoch
+        val pendingStart = viewModelScope.launch(start = CoroutineStart.LAZY) {
             try {
                 microphoneRelease?.join()
-                val rec = recorder
-                if (rec != null && !rec.isRecording()) {
+                if (!canStartBargeInCapture(captureEpoch, interruptedMode, interruptedEngine)) {
+                    abandonBargeInCaptureIfCurrent(captureEpoch)
+                    return@launch
+                }
+                val rec = recorder ?: error("Recorder not initialized")
+                if (!rec.isRecording()) {
                     rec.startRecording()
                 }
-                scheduleResumeWatchdog()
+                if (canStartBargeInCapture(captureEpoch, interruptedMode, interruptedEngine)) {
+                    scheduleResumeWatchdog()
+                } else {
+                    try { rec.cancel() } catch (_: Throwable) { /* ignore */ }
+                    abandonBargeInCaptureIfCurrent(captureEpoch)
+                }
+            } catch (t: CancellationException) {
+                abandonBargeInCaptureIfCurrent(captureEpoch)
+                throw t
             } catch (t: Throwable) {
-                responseInterruptedForVoiceCommand = false
-                Log.w(TAG, "barge-in microphone handoff failed: ${t.message}")
-                surfaceError(t, context = "record")
+                if (listeningStartEpoch == captureEpoch) {
+                    responseInterruptedForVoiceCommand = false
+                    Log.w(TAG, "barge-in microphone handoff failed: ${t.message}")
+                    surfaceError(t, context = "record")
+                }
+            } finally {
+                if (listeningStartEpoch == captureEpoch) {
+                    pendingListeningStartJob = null
+                }
+            }
+        }
+        pendingListeningStartJob = pendingStart
+        pendingStart.start()
+    }
+
+    private fun canStartBargeInCapture(
+        captureEpoch: Long,
+        interruptedMode: InteractionMode,
+        interruptedEngine: VoiceEngineMode,
+    ): Boolean {
+        val state = _uiState.value
+        return listeningStartEpoch == captureEpoch &&
+            state.voiceMode &&
+            state.state == VoiceState.Listening &&
+            state.interactionMode == interruptedMode &&
+            voiceEngineMode == interruptedEngine &&
+            responseInterruptedForVoiceCommand
+    }
+
+    private fun abandonBargeInCaptureIfCurrent(captureEpoch: Long) {
+        if (listeningStartEpoch != captureEpoch) return
+        responseInterruptedForVoiceCommand = false
+        if (_uiState.value.state == VoiceState.Listening && recorder?.isRecording() != true) {
+            _uiState.update {
+                it.copy(state = VoiceState.Idle, amplitude = 0f, outputAudioActive = false)
             }
         }
     }
@@ -6385,6 +6439,11 @@ class VoiceViewModel(application: Application) : AndroidViewModel(application) {
     @androidx.annotation.VisibleForTesting
     internal fun finishAgentAudioOutputForTest() {
         finishAgentAudioOutput()
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun setVoiceEngineModeForTest(mode: VoiceEngineMode) {
+        voiceEngineMode = mode
     }
 
     @androidx.annotation.VisibleForTesting

--- a/app/src/main/kotlin/com/hermesandroid/relay/voice/VoiceOverlayHost.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/voice/VoiceOverlayHost.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -109,6 +110,8 @@ import kotlin.math.sin
 
 private const val TWO_PI = 6.2831855f
 private const val HALF_PI = 1.5707964f
+internal const val VOICE_FLOATING_OVERLAY_MIC_TEST_TAG = "voiceFloatingOverlayMic"
+internal const val VOICE_OVERLAY_MIC_CONTROL_TEST_TAG = "voiceOverlayMicControl"
 
 // Matches the in-app VoiceWaveform palette so minimized overlay mode reads as
 // the same voice surface, just wrapped around the mic control.
@@ -641,7 +644,7 @@ private fun overlayPrimaryText(uiState: VoiceUiState, fallback: String): String 
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun VoiceFloatingOverlayBubble(
+internal fun VoiceFloatingOverlayBubble(
     uiState: VoiceUiState,
     stateText: String,
     onExpand: () -> Unit,
@@ -661,6 +664,9 @@ private fun VoiceFloatingOverlayBubble(
         VoiceState.Transcribing, VoiceState.Thinking ->
             if (uiState.interactionMode == InteractionMode.Continuous) stringResource(R.string.voice_overlay_tap_action_pause) else stringResource(R.string.voice_overlay_tap_action_interrupt)
     }
+    val holdStopAction = stringResource(R.string.voice_overlay_tap_action_listening)
+    val inactiveHoldDescription = stringResource(R.string.voice_overlay_a11y, stateText, tapAction)
+    val activeHoldDescription = stringResource(R.string.voice_overlay_a11y, stateText, holdStopAction)
     val containerColor = when (uiState.state) {
         VoiceState.Listening, VoiceState.Speaking -> Color(0xFFE53935)
         VoiceState.Transcribing, VoiceState.Thinking -> Color(0xFFE53935)
@@ -674,6 +680,9 @@ private fun VoiceFloatingOverlayBubble(
     }
     val bubbleGesture = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
         Modifier.voiceHoldGesture(
+            state = uiState.state,
+            inactiveActionLabel = tapAction,
+            activeActionLabel = holdStopAction,
             onPress = {
                 dispatchVoiceMicHoldPress(
                     uiState = uiState,
@@ -685,6 +694,8 @@ private fun VoiceFloatingOverlayBubble(
                 )
             },
             onRelease = onStopListening,
+            inactiveContentDescription = inactiveHoldDescription,
+            activeContentDescription = activeHoldDescription,
         )
     } else {
         Modifier.combinedClickable(
@@ -723,6 +734,7 @@ private fun VoiceFloatingOverlayBubble(
             modifier = Modifier
                 .size(70.dp)
                 .clip(CircleShape)
+                .testTag(VOICE_FLOATING_OVERLAY_MIC_TEST_TAG)
                 .then(bubbleGesture),
             shape = CircleShape,
             color = containerColor.copy(alpha = if (isHot) 0.96f else 0.92f),
@@ -736,7 +748,11 @@ private fun VoiceFloatingOverlayBubble(
             ) {
                 Icon(
                     imageVector = icon,
-                    contentDescription = stringResource(R.string.voice_overlay_a11y, stateText, tapAction),
+                    contentDescription = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
+                        null
+                    } else {
+                        stringResource(R.string.voice_overlay_a11y, stateText, tapAction)
+                    },
                     tint = Color.White,
                     modifier = Modifier.size(23.dp),
                 )
@@ -888,7 +904,7 @@ private fun overlayBubbleStateLabel(state: VoiceState): String = when (state) {
 }
 
 @Composable
-private fun MicControlButton(
+internal fun MicControlButton(
     uiState: VoiceUiState,
     onStartListening: () -> Unit,
     onStopListening: () -> Unit,
@@ -915,8 +931,12 @@ private fun MicControlButton(
                 stringResource(R.string.voice_overlay_tap_action_interrupt)
             }
     }
+    val holdStopDescription = stringResource(R.string.voice_overlay_tap_action_listening)
     val gestureModifier = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
         Modifier.voiceHoldGesture(
+            state = uiState.state,
+            inactiveActionLabel = actionDescription,
+            activeActionLabel = holdStopDescription,
             onPress = {
                 dispatchVoiceMicHoldPress(
                     uiState = uiState,
@@ -944,6 +964,7 @@ private fun MicControlButton(
         modifier = Modifier
             .size(size)
             .clip(CircleShape)
+            .testTag(VOICE_OVERLAY_MIC_CONTROL_TEST_TAG)
             .then(gestureModifier),
         shape = CircleShape,
         color = when {
@@ -963,7 +984,11 @@ private fun MicControlButton(
                         Icons.Filled.Stop
                     else -> Icons.Filled.Mic
                 },
-                contentDescription = actionDescription,
+                contentDescription = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
+                    null
+                } else {
+                    actionDescription
+                },
                 tint = Color.White,
                 modifier = Modifier.size(22.dp),
             )

--- a/app/src/main/kotlin/com/hermesandroid/relay/voice/VoiceOverlayHost.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/voice/VoiceOverlayHost.kt
@@ -91,6 +91,9 @@ import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.ui.components.distinctVoiceRouteParts
+import com.hermesandroid.relay.ui.components.dispatchVoiceMicHoldPress
+import com.hermesandroid.relay.ui.components.dispatchVoiceMicTap
+import com.hermesandroid.relay.ui.components.voiceHoldGesture
 import com.hermesandroid.relay.ui.components.voiceRouteDisplayLabel
 import com.hermesandroid.relay.ui.theme.PersistedHermesRelayTheme
 import com.hermesandroid.relay.viewmodel.InteractionMode
@@ -669,6 +672,35 @@ private fun VoiceFloatingOverlayBubble(
         VoiceState.Transcribing, VoiceState.Thinking -> Icons.Filled.Stop
         VoiceState.Idle, VoiceState.Error -> Icons.Filled.Mic
     }
+    val bubbleGesture = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
+        Modifier.voiceHoldGesture(
+            onPress = {
+                dispatchVoiceMicHoldPress(
+                    uiState = uiState,
+                    onStartListening = onStartListening,
+                    onInterruptAndStart = {
+                        onInterrupt()
+                        onStartListening()
+                    },
+                )
+            },
+            onRelease = onStopListening,
+        )
+    } else {
+        Modifier.combinedClickable(
+            onClick = {
+                dispatchVoiceMicTap(
+                    uiState = uiState,
+                    onStartListening = onStartListening,
+                    onStopListening = onStopListening,
+                    onInterrupt = onInterrupt,
+                    onPauseAutoMode = onPauseAutoMode,
+                )
+            },
+            onLongClick = onExpand,
+            onDoubleClick = onExpand,
+        )
+    }
 
     Box(
         modifier = Modifier
@@ -691,19 +723,7 @@ private fun VoiceFloatingOverlayBubble(
             modifier = Modifier
                 .size(70.dp)
                 .clip(CircleShape)
-            .combinedClickable(
-                onClick = {
-                    dispatchMicAction(
-                        uiState = uiState,
-                        onStartListening = onStartListening,
-                        onStopListening = onStopListening,
-                        onInterrupt = onInterrupt,
-                        onPauseAutoMode = onPauseAutoMode,
-                    )
-                },
-                onLongClick = onExpand,
-                onDoubleClick = onExpand,
-            ),
+                .then(bubbleGesture),
             shape = CircleShape,
             color = containerColor.copy(alpha = if (isHot) 0.96f else 0.92f),
             shadowElevation = 8.dp,
@@ -727,6 +747,22 @@ private fun VoiceFloatingOverlayBubble(
                     color = Color.White,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (uiState.interactionMode == InteractionMode.HoldToTalk) {
+            IconButton(
+                onClick = onExpand,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(30.dp)
+                    .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.ExpandMore,
+                    contentDescription = stringResource(R.string.voice_overlay_expand_cd),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
                 )
             }
         }
@@ -864,19 +900,51 @@ private fun MicControlButton(
         uiState.state == VoiceState.Speaking ||
         uiState.state == VoiceState.Transcribing ||
         uiState.state == VoiceState.Thinking
+    val actionDescription = when (uiState.state) {
+        VoiceState.Idle, VoiceState.Error -> stringResource(R.string.voice_overlay_tap_action_idle)
+        VoiceState.Listening ->
+            if (uiState.interactionMode == InteractionMode.Continuous) {
+                stringResource(R.string.voice_overlay_tap_action_pause)
+            } else {
+                stringResource(R.string.voice_overlay_tap_action_listening)
+            }
+        VoiceState.Transcribing, VoiceState.Thinking, VoiceState.Speaking ->
+            if (uiState.interactionMode == InteractionMode.Continuous) {
+                stringResource(R.string.voice_overlay_tap_action_pause)
+            } else {
+                stringResource(R.string.voice_overlay_tap_action_interrupt)
+            }
+    }
+    val gestureModifier = if (uiState.interactionMode == InteractionMode.HoldToTalk) {
+        Modifier.voiceHoldGesture(
+            onPress = {
+                dispatchVoiceMicHoldPress(
+                    uiState = uiState,
+                    onStartListening = onStartListening,
+                    onInterruptAndStart = {
+                        onInterrupt()
+                        onStartListening()
+                    },
+                )
+            },
+            onRelease = onStopListening,
+        )
+    } else {
+        Modifier.clickable {
+            dispatchVoiceMicTap(
+                uiState = uiState,
+                onStartListening = onStartListening,
+                onStopListening = onStopListening,
+                onInterrupt = onInterrupt,
+                onPauseAutoMode = onPauseAutoMode,
+            )
+        }
+    }
     Surface(
         modifier = Modifier
             .size(size)
             .clip(CircleShape)
-            .clickable {
-                dispatchMicAction(
-                    uiState = uiState,
-                    onStartListening = onStartListening,
-                    onStopListening = onStopListening,
-                    onInterrupt = onInterrupt,
-                    onPauseAutoMode = onPauseAutoMode,
-                )
-        },
+            .then(gestureModifier),
         shape = CircleShape,
         color = when {
             isStopAction -> Color(0xFFE53935)
@@ -895,44 +963,11 @@ private fun MicControlButton(
                         Icons.Filled.Stop
                     else -> Icons.Filled.Mic
                 },
-                contentDescription = stringResource(R.string.voice_overlay_mic_a11y),
+                contentDescription = actionDescription,
                 tint = Color.White,
                 modifier = Modifier.size(22.dp),
             )
         }
-    }
-}
-
-private fun dispatchMicAction(
-    uiState: VoiceUiState,
-    onStartListening: () -> Unit,
-    onStopListening: () -> Unit,
-    onInterrupt: () -> Unit,
-    onPauseAutoMode: () -> Unit,
-) {
-    when (uiState.state) {
-        VoiceState.Listening -> {
-            if (uiState.interactionMode == InteractionMode.Continuous) {
-                onPauseAutoMode()
-            } else {
-                onStopListening()
-            }
-        }
-        VoiceState.Speaking -> {
-            if (uiState.interactionMode == InteractionMode.Continuous) {
-                onPauseAutoMode()
-            } else {
-                onInterrupt()
-            }
-        }
-        VoiceState.Transcribing, VoiceState.Thinking -> {
-            if (uiState.interactionMode == InteractionMode.Continuous) {
-                onPauseAutoMode()
-            } else {
-                onInterrupt()
-            }
-        }
-        VoiceState.Idle, VoiceState.Error -> onStartListening()
     }
 }
 

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayInteractionTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayInteractionTest.kt
@@ -4,14 +4,28 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.click
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.hermesandroid.relay.viewmodel.InteractionMode
@@ -126,6 +140,156 @@ class VoiceModeOverlayInteractionTest {
         compose.mainClock.advanceTimeBy(500)
 
         compose.onNodeWithText("Overlay").assertDoesNotExist()
+    }
+
+    @Test
+    fun focusMode_holdSemanticActionTogglesStartAndStopWithoutTouch() {
+        var uiState by mutableStateOf(
+            VoiceUiState(
+                voiceMode = true,
+                state = VoiceState.Idle,
+                interactionMode = InteractionMode.HoldToTalk,
+            ),
+        )
+        var starts = 0
+        var stops = 0
+        compose.mainClock.autoAdvance = false
+
+        compose.setContent {
+            MaterialTheme {
+                VoiceModeOverlay(
+                    uiState = uiState,
+                    onMicTap = {
+                        starts += 1
+                        uiState = uiState.copy(state = VoiceState.Listening)
+                    },
+                    onMicRelease = {
+                        stops += 1
+                        uiState = uiState.copy(state = VoiceState.Idle)
+                    },
+                    onInterrupt = {},
+                    onDismiss = {},
+                    onModeChange = {},
+                    onClearError = {},
+                )
+            }
+        }
+
+        compose.onNodeWithTag(VOICE_MODE_MIC_TEST_TAG)
+            .assertHasClickAction()
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+            .performSemanticsAction(SemanticsActions.OnClick)
+        compose.mainClock.advanceTimeByFrame()
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(0, stops)
+            assertEquals(VoiceState.Listening, uiState.state)
+        }
+
+        compose.onNodeWithTag(VOICE_MODE_MIC_TEST_TAG)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        compose.mainClock.advanceTimeByFrame()
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(1, stops)
+            assertEquals(VoiceState.Idle, uiState.state)
+        }
+    }
+
+    @Test
+    fun focusMode_holdSemanticActionStopsCaptureStillWaitingForMicrophone() {
+        val uiState = VoiceUiState(
+            voiceMode = true,
+            state = VoiceState.Idle,
+            interactionMode = InteractionMode.HoldToTalk,
+        )
+        var starts = 0
+        var stops = 0
+        compose.mainClock.autoAdvance = false
+
+        compose.setContent {
+            MaterialTheme {
+                VoiceModeOverlay(
+                    uiState = uiState,
+                    onMicTap = { starts += 1 },
+                    onMicRelease = { stops += 1 },
+                    onInterrupt = {},
+                    onDismiss = {},
+                    onModeChange = {},
+                    onClearError = {},
+                )
+            }
+        }
+
+        val mic = compose.onNodeWithTag(VOICE_MODE_MIC_TEST_TAG)
+            .assertHasClickAction()
+            .assertContentDescriptionEquals("start listening")
+        mic.performSemanticsAction(SemanticsActions.OnClick)
+        compose.mainClock.advanceTimeBy(100)
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(0, stops)
+        }
+        mic.assertContentDescriptionEquals("stop listening")
+
+        mic.performSemanticsAction(SemanticsActions.OnClick)
+        compose.mainClock.advanceTimeBy(100)
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(1, stops)
+        }
+        mic.assertContentDescriptionEquals("start listening")
+    }
+
+    @Test
+    fun focusMode_holdKeyboardEnterAndSpaceToggleStartAndStop() {
+        var uiState by mutableStateOf(
+            VoiceUiState(
+                voiceMode = true,
+                state = VoiceState.Idle,
+                interactionMode = InteractionMode.HoldToTalk,
+            ),
+        )
+        var starts = 0
+        var stops = 0
+        compose.mainClock.autoAdvance = false
+
+        compose.setContent {
+            MaterialTheme {
+                VoiceModeOverlay(
+                    uiState = uiState,
+                    onMicTap = {
+                        starts += 1
+                        uiState = uiState.copy(state = VoiceState.Listening)
+                    },
+                    onMicRelease = {
+                        stops += 1
+                        uiState = uiState.copy(state = VoiceState.Idle)
+                    },
+                    onInterrupt = {},
+                    onDismiss = {},
+                    onModeChange = {},
+                    onClearError = {},
+                )
+            }
+        }
+
+        val mic = compose.onNodeWithTag(VOICE_MODE_MIC_TEST_TAG)
+        mic.performSemanticsAction(SemanticsActions.RequestFocus)
+        mic.performKeyInput { pressKey(Key.Enter) }
+        compose.mainClock.advanceTimeByFrame()
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(0, stops)
+        }
+
+        mic.performKeyInput { pressKey(Key.Spacebar) }
+        compose.mainClock.advanceTimeByFrame()
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(1, stops)
+        }
     }
 
     private fun idleVoiceState() = VoiceUiState(

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayInteractionTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayInteractionTest.kt
@@ -53,7 +53,7 @@ class VoiceModeOverlayInteractionTest {
             }
         }
 
-        compose.onNodeWithContentDescription("Voice mic")
+        compose.onNodeWithContentDescription("start listening")
             .performTouchInput { click() }
         compose.onNodeWithContentDescription("Expand voice controls")
             .performTouchInput { click() }
@@ -101,6 +101,31 @@ class VoiceModeOverlayInteractionTest {
             .performTouchInput { click(Offset(1f, center.y)) }
 
         compose.runOnIdle { assertEquals(0, backgroundTaps) }
+    }
+
+    @Test
+    fun unavailableSystemOverlayActionIsNotOffered() {
+        compose.mainClock.autoAdvance = false
+        compose.setContent {
+            MaterialTheme {
+                VoiceModeOverlay(
+                    uiState = idleVoiceState(),
+                    onMicTap = {},
+                    onMicRelease = {},
+                    onInterrupt = {},
+                    onDismiss = {},
+                    onModeChange = {},
+                    onClearError = {},
+                    systemOverlayAvailable = false,
+                )
+            }
+        }
+
+        compose.onNodeWithContentDescription("Expand voice controls")
+            .performTouchInput { click() }
+        compose.mainClock.advanceTimeBy(500)
+
+        compose.onNodeWithText("Overlay").assertDoesNotExist()
     }
 
     private fun idleVoiceState() = VoiceUiState(

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayStateTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/VoiceModeOverlayStateTest.kt
@@ -15,6 +15,7 @@ import com.hermesandroid.relay.viewmodel.preserveRealtimeTurnOnStop
 import com.hermesandroid.relay.viewmodel.realtimeTranscriptState
 import com.hermesandroid.relay.viewmodel.realtimeTurnActiveAfterPromotion
 import com.hermesandroid.relay.viewmodel.voiceSessionExitState
+import com.hermesandroid.relay.viewmodel.shouldArmVoiceSilenceWatchdog
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -292,5 +293,44 @@ class VoiceModeOverlayStateTest {
         )
 
         assertEquals(listOf("interrupt", "start"), calls)
+    }
+
+    @Test
+    fun holdPress_interruptsAndCapturesSteeringAcrossBusyTurnStates() {
+        listOf(VoiceState.Transcribing, VoiceState.Thinking, VoiceState.Speaking).forEach { state ->
+            val calls = mutableListOf<String>()
+
+            dispatchVoiceMicHoldPress(
+                uiState = VoiceUiState(
+                    state = state,
+                    interactionMode = InteractionMode.HoldToTalk,
+                ),
+                onStartListening = { calls += "start" },
+                onInterruptAndStart = {
+                    calls += "interrupt"
+                    calls += "start"
+                },
+            )
+
+            assertEquals("Hold-to-talk dispatch for $state", listOf("interrupt", "start"), calls)
+        }
+    }
+
+    @Test
+    fun bargeInCaptureAlwaysArmsSilenceCompletion() {
+        InteractionMode.values().forEach { mode ->
+            assertEquals(
+                "Barge-in capture for $mode must auto-complete without a physical release",
+                true,
+                shouldArmVoiceSilenceWatchdog(mode, bargeInCapture = true),
+            )
+        }
+        assertEquals(
+            false,
+            shouldArmVoiceSilenceWatchdog(
+                InteractionMode.HoldToTalk,
+                bargeInCapture = false,
+            ),
+        )
     }
 }

--- a/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/util/RelayErrorClassifierTest.kt
@@ -152,4 +152,15 @@ class RelayErrorClassifierTest {
         assertEquals("Microphone unavailable", err.title)
         assertTrue(err.retryable)
     }
+
+    @Test
+    fun microphoneOwnershipConflictMapsToRetryableMicUnavailableHint() {
+        val err = classifyError(
+            IllegalStateException("Microphone is in use by another voice feature"),
+            context = "record",
+        )
+
+        assertEquals("Microphone unavailable", err.title)
+        assertTrue(err.retryable)
+    }
 }

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceOverlayHostInteractionTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceOverlayHostInteractionTest.kt
@@ -1,0 +1,117 @@
+package com.hermesandroid.relay.voice
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.hermesandroid.relay.viewmodel.InteractionMode
+import com.hermesandroid.relay.viewmodel.VoiceState
+import com.hermesandroid.relay.viewmodel.VoiceUiState
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h720dp-xxhdpi")
+class VoiceOverlayHostInteractionTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun expandedOverlay_holdSemanticActionTogglesStartAndStopWithoutTouch() {
+        assertHoldSemanticToggle(VOICE_OVERLAY_MIC_CONTROL_TEST_TAG) { state, start, stop ->
+            MicControlButton(
+                uiState = state,
+                onStartListening = start,
+                onStopListening = stop,
+                onInterrupt = {},
+                onPauseAutoMode = {},
+            )
+        }
+    }
+
+    @Test
+    fun minimizedOverlay_holdSemanticActionTogglesStartAndStopWithoutTouch() {
+        assertHoldSemanticToggle(VOICE_FLOATING_OVERLAY_MIC_TEST_TAG) { state, start, stop ->
+            VoiceFloatingOverlayBubble(
+                uiState = state,
+                stateText = state.state.name,
+                onExpand = {},
+                onStartListening = start,
+                onStopListening = stop,
+                onInterrupt = {},
+                onPauseAutoMode = {},
+                onDragBy = { _, _ -> },
+            )
+        }
+    }
+
+    private fun assertHoldSemanticToggle(
+        tag: String,
+        content: @Composable (VoiceUiState, () -> Unit, () -> Unit) -> Unit,
+    ) {
+        var uiState by mutableStateOf(
+            VoiceUiState(
+                voiceMode = true,
+                state = VoiceState.Idle,
+                interactionMode = InteractionMode.HoldToTalk,
+            ),
+        )
+        var starts = 0
+        var stops = 0
+        compose.mainClock.autoAdvance = false
+
+        compose.setContent {
+            MaterialTheme {
+                content(
+                    uiState,
+                    {
+                        starts += 1
+                        uiState = uiState.copy(state = VoiceState.Listening)
+                    },
+                    {
+                        stops += 1
+                        uiState = uiState.copy(state = VoiceState.Idle)
+                    },
+                )
+            }
+        }
+
+        compose.onNodeWithTag(tag)
+            .assertHasClickAction()
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+            .performSemanticsAction(SemanticsActions.OnClick)
+        compose.mainClock.advanceTimeByFrame()
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(0, stops)
+            assertEquals(VoiceState.Listening, uiState.state)
+        }
+
+        compose.onNodeWithTag(tag)
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        compose.mainClock.advanceTimeByFrame()
+        compose.runOnIdle {
+            assertEquals(1, starts)
+            assertEquals(1, stops)
+            assertEquals(VoiceState.Idle, uiState.state)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
@@ -721,6 +721,32 @@ class VoiceViewModelBargeInTest {
         )
     }
 
+    @Test
+    fun `failed barge-in capture stays failed instead of resuming stale audio`() = runTest {
+        every { recorder.startRecording() } throws
+            IllegalStateException("Microphone is in use by another voice feature")
+        val vm = buildViewModel(
+            BargeInPreferences(
+                enabled = true,
+                sensitivity = BargeInSensitivity.Default,
+                resumeAfterInterruption = true,
+            ),
+        )
+        vm.seedSpeakingStateForTest(
+            chunks = listOf("current.", "stale tail."),
+            currentIdx = 0,
+        )
+        vm.drainTtsQueueForTest()
+
+        vm.onBargeInDetected()
+        runCurrent()
+        advanceTimeBy(650)
+        runCurrent()
+
+        assertEquals(VoiceState.Error, vm.uiState.value.state)
+        assertTrue(vm.drainTtsQueueForTest().isEmpty())
+    }
+
     // -------------------------------------------------------------------
     // Test 4 — resumeAfterInterruption=false → silence still no re-enqueue
     // -------------------------------------------------------------------

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
@@ -12,6 +12,7 @@ import com.hermesandroid.relay.data.BargeInPreferencesRepository
 import com.hermesandroid.relay.data.BargeInSensitivity
 import com.hermesandroid.relay.network.relay.RelayVoiceClient
 import com.hermesandroid.relay.viewmodel.ChatViewModel
+import com.hermesandroid.relay.viewmodel.InteractionMode
 import com.hermesandroid.relay.viewmodel.VoiceState
 import com.hermesandroid.relay.viewmodel.VoiceViewModel
 import io.mockk.every
@@ -271,6 +272,224 @@ class VoiceViewModelBargeInTest {
 
         verify(exactly = 0) { recorder.startRecording() }
         assertEquals(VoiceState.Idle, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `continuous completion waits for queue-drain barge-in release before capture`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returnsMany listOf(readerRelease, null, null)
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Finished."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        // The play worker tears down barge-in before the shared completion
+        // finalizer runs. Repeated teardown calls must retain that first
+        // asynchronous release instead of attempting VoiceCapture immediately.
+        vm.stopBargeInListenerForTest()
+        vm.finishAgentAudioOutputForTest()
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        verify(exactly = 1) { bargeInListener.start(any()) }
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        verify(exactly = 1) { bargeInListener.start(any()) }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `continuous completion repeats serialized handoff across turns`() = runTest {
+        val firstRelease = Job()
+        val secondRelease = Job()
+        var stopCalls = 0
+        every { bargeInListener.stop() } answers {
+            when (stopCalls++) {
+                0 -> firstRelease
+                1 -> secondRelease
+                else -> null
+            }
+        }
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("First."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        vm.stopBargeInListenerForTest()
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+        firstRelease.complete()
+        runCurrent()
+
+        vm.seedSpeakingStateForTest(chunks = listOf("Second."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.stopBargeInListenerForTest()
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+        verify(exactly = 1) { recorder.startRecording() }
+
+        secondRelease.complete()
+        runCurrent()
+        verify(exactly = 2) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `barge-in disabled keeps continuous completion immediate`() = runTest {
+        val vm = buildViewModel(
+            BargeInPreferences(
+                enabled = false,
+                sensitivity = BargeInSensitivity.Off,
+            ),
+        )
+        vm.seedSpeakingStateForTest(chunks = listOf("Finished."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `exit cancels continuous capture waiting for microphone release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returnsMany listOf(readerRelease, null, null)
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Finished."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.startBargeInListenerForTest()
+        vm.stopBargeInListenerForTest()
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+
+        vm.exitVoiceMode()
+        vm.startBargeInListenerForTest()
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        verify(exactly = 1) { bargeInListener.start(any()) }
+        assertTrue(!vm.uiState.value.voiceMode)
+    }
+
+    @Test
+    fun `pause cancels continuous capture waiting for microphone release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returnsMany listOf(readerRelease, null, null)
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Finished."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.startBargeInListenerForTest()
+        vm.stopBargeInListenerForTest()
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+
+        vm.pauseContinuousMode()
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        assertEquals(VoiceState.Idle, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `rapid mode change starts only the newly armed continuous capture`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returnsMany listOf(readerRelease, null, null, null)
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Finished."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.startBargeInListenerForTest()
+        vm.stopBargeInListenerForTest()
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+
+        vm.setInteractionMode(InteractionMode.TapToTalk)
+        vm.setInteractionMode(InteractionMode.Continuous)
+        runCurrent()
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `next barge-in generation waits for prior reader release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returnsMany listOf(readerRelease, null)
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("First."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        vm.stopBargeInListenerForTest()
+        vm.startBargeInListenerForTest()
+        vm.startBargeInListenerForTest()
+        runCurrent()
+        verify(exactly = 1) { bargeInListener.start(any()) }
+
+        readerRelease.complete()
+        runCurrent()
+        verify(exactly = 2) { bargeInListener.start(any()) }
+    }
+
+    @Test
+    fun `barge-in capture waits for reader release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        runCurrent()
+
+        vm.onBargeInDetected()
+        runCurrent()
+        verify(exactly = 0) { recorder.startRecording() }
+
+        readerRelease.complete()
+        runCurrent()
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `transient recorder ownership failures remain explicitly retryable`() = runTest {
+        var attempts = 0
+        every { recorder.startRecording() } answers {
+            attempts++
+            if (attempts <= 2) {
+                throw IllegalStateException("Microphone is in use by another voice feature")
+            }
+            java.io.File("voice-retry-test.wav")
+        }
+        val vm = buildViewModel(
+            BargeInPreferences(
+                enabled = false,
+                sensitivity = BargeInSensitivity.Off,
+            ),
+        )
+        vm.seedSpeakingStateForTest(chunks = listOf("Finished."), currentIdx = 0)
+        vm.setInteractionMode(InteractionMode.Continuous)
+
+        vm.finishAgentAudioOutputForTest()
+        runCurrent()
+        assertEquals(VoiceState.Error, vm.uiState.value.state)
+
+        vm.startListening()
+        runCurrent()
+        assertEquals(VoiceState.Error, vm.uiState.value.state)
+
+        vm.startListening()
+        runCurrent()
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+        verify(exactly = 3) { recorder.startRecording() }
     }
 
     // -------------------------------------------------------------------

--- a/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/voice/VoiceViewModelBargeInTest.kt
@@ -10,6 +10,7 @@ import com.hermesandroid.relay.audio.VoiceSfxPlayer
 import com.hermesandroid.relay.data.BargeInPreferences
 import com.hermesandroid.relay.data.BargeInPreferencesRepository
 import com.hermesandroid.relay.data.BargeInSensitivity
+import com.hermesandroid.relay.data.VoiceEngineMode
 import com.hermesandroid.relay.network.relay.RelayVoiceClient
 import com.hermesandroid.relay.viewmodel.ChatViewModel
 import com.hermesandroid.relay.viewmodel.InteractionMode
@@ -457,6 +458,142 @@ class VoiceViewModelBargeInTest {
         runCurrent()
         verify(exactly = 1) { recorder.startRecording() }
         assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `exit invalidates barge-in capture waiting for reader release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        vm.exitVoiceMode()
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        assertTrue(!vm.uiState.value.voiceMode)
+        assertEquals(VoiceState.Idle, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `continuous pause invalidates barge-in capture waiting for reader release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.setInteractionMode(InteractionMode.Continuous)
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        vm.pauseContinuousMode()
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        assertEquals(VoiceState.Idle, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `interaction mode switch invalidates barge-in capture waiting for reader release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        vm.setInteractionMode(InteractionMode.HoldToTalk)
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        assertEquals(InteractionMode.HoldToTalk, vm.uiState.value.interactionMode)
+        assertEquals(VoiceState.Idle, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `engine switch invalidates barge-in capture waiting for reader release`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        vm.setVoiceEngineModeForTest(VoiceEngineMode.RealtimeAgent)
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 0) { recorder.startRecording() }
+        assertEquals(VoiceState.Idle, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `newer manual capture supersedes barge-in release waiter`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        vm.startListening()
+        runCurrent()
+        verify(exactly = 0) { recorder.startRecording() }
+
+        readerRelease.complete()
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `reader release completion starts valid barge-in capture only once`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        assertTrue(readerRelease.complete())
+        runCurrent()
+        assertTrue(!readerRelease.complete())
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Listening, vm.uiState.value.state)
+    }
+
+    @Test
+    fun `failed barge-in recorder acquisition does not arm resume watchdog`() = runTest {
+        val readerRelease = Job()
+        every { bargeInListener.stop() } returns readerRelease
+        every { recorder.startRecording() } throws
+            IllegalStateException("Microphone is in use by another voice feature")
+        val vm = buildViewModel()
+        vm.seedSpeakingStateForTest(chunks = listOf("Speaking.", "Tail."), currentIdx = 0)
+        vm.startBargeInListenerForTest()
+        vm.onBargeInDetected()
+        runCurrent()
+
+        readerRelease.complete()
+        runCurrent()
+        advanceTimeBy(700)
+        runCurrent()
+
+        verify(exactly = 1) { recorder.startRecording() }
+        assertEquals(VoiceState.Error, vm.uiState.value.state)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Keep Voice Focus interruption honest across Tap-to-talk, Hold-to-talk, and Continuous, stop Google Play builds from offering a system overlay capability they do not declare, and keep Hold-to-talk operable without raw touch.

This refresh uses #477's corrected microphone handoff at exact head `3ae19758e421a6951208bf6f7ea753883a8d69cd`, so immediate Hold-to-talk steering waits for release, revalidates its capture epoch/mode/engine, and cannot race a stale barge-in listener.

## Changes

- hide the Voice system-overlay action on Google Play and defensively block its launch path outside sideload builds
- make Hold-to-talk interrupt Thinking, Transcribing, and Speaking before capturing the replacement direction
- keep the original pointer press/hold/release gesture while adding one semantic Start/Stop action for TalkBack and Switch Access
- make in-app, expanded-overlay, and minimized-overlay Hold controls keyboard focusable with Enter, Space, and DPAD activation
- keep pending microphone acquisition announced as Stop-capable so a second accessibility action cancels through the existing release seam
- keep barge-in steering captures silence-completable in every interaction mode
- leave failed or invalidated barge-in capture in a settled state without arming stale-audio resume
- preserve #477's retained release fence, capture epochs, and exit/pause/mode/engine invalidation
- add focused flavor, interaction, handoff, failure, semantics, and keyboard regressions

## Verification

- Sideload Hold-control surface matrix — 26 tests (18 state + 6 in-app interaction + 2 overlay host), zero failures, errors, or skips
- Google Play Hold-control surface matrix — identical 26 tests, zero failures, errors, or skips
- `.\gradlew.bat :app:assembleSideloadDebug --rerun-tasks --no-daemon --max-workers=1 "-Dkotlin.compiler.execution.strategy=in-process"` — passed; APK SHA-256 `16CF100C7D8A958507280AF48CEB9DA15CBEB6B5D2E1F59C13D2855F86C0739F`
- `.\gradlew.bat :app:assembleGooglePlayDebug --rerun-tasks --no-daemon --max-workers=1 "-Dkotlin.compiler.execution.strategy=in-process"` — passed; APK SHA-256 `2D6D2BFB5F293FC070ECF2166553533F9A427054EE655B3F37003B4850A8AD20`
- `.\gradlew.bat :app:lintSideloadDebug --rerun-tasks --no-daemon --max-workers=1 "-Dkotlin.compiler.execution.strategy=in-process"` — passed
- `.\gradlew.bat :app:lintGooglePlayDebug --rerun-tasks --no-daemon --max-workers=1 "-Dkotlin.compiler.execution.strategy=in-process"` — passed
- all Gradle runs used Android Studio JBR, an isolated `pr-478` Gradle home, and one worker; no Gradle/Kotlin process remained afterward
- merged-manifest inspection — Google Play omits `SYSTEM_ALERT_WINDOW`; sideload declares it
- `python scripts/check-android-collection-apis.py` — passed
- `python scripts/check-version-tracks.py` — passed
- `python scripts/check-android-release-notes.py` — passed
- `git diff --check` — passed
- independent exact-diff review — no actionable findings or release blockers
- Android 16 / API 36 Samsung was inspected read-only. Maintainer sideload and assistive-technology review remain; this task did not install or deploy the build.

## Lineage / contributor credit

- Source PR(s): #477
- Attribution preserved by: exact commits `10f62d798c7434cc585ac189e1f601dba20f37eb` and `3ae19758e421a6951208bf6f7ea753883a8d69cd`, merged with no-ff lineage commit `89f2f772e289f61c674b03f4003faff0a16799fe`

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: lint and focused unit tests ran, or rationale is listed above
- [x] Translation changes: locale status/review references are accurate, `python scripts/check-android-locales.py` ran, and device/emulator review is documented, or N/A — no string resources changed
- [x] Server changes: focused `python -m unittest ...` checks ran, or rationale is listed above — N/A
- [x] Desktop changes: `npm run build` or a narrower documented check ran, or rationale is listed above — N/A
- [x] Docs/site changes: docs build or link check ran, or rationale is listed above — N/A
- [x] UI changes were tested on emulator/device or desktop surface when applicable — Robolectric semantics/keyboard coverage passed; missing physical assistive-technology proof is stated above
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CHANGELOG.md updated (if user-facing)
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged work links the source PR and preserves contributor authorship, or N/A