### PR TITLE
watchdog: arm longer leash on compacting status instead of killing silent compaction

### DIFF
--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/GatewayChatClient.kt
@@ -153,6 +153,19 @@ class GatewayChatClient(
         private const val ASK_SUDO_TIMEOUT_MS = 150_000L
         private const val ASK_UNBOUNDED_TIMEOUT_MS = 600_000L
 
+        /**
+         * Server-side context compaction summarizes the transcript through a
+         * (possibly slow) model with NO deltas or tool events flowing until it
+         * finishes — near the context ceiling that silence routinely exceeds
+         * [TURN_TIMEOUT_MS], so the idle watchdog would `session.interrupt` a
+         * healthy compression, roll back its work, and retrigger on the next
+         * prompt forever. A `status.update` event with kind `compacting`
+         * (emitted at compaction start, and periodically by newer gateways)
+         * arms this longer leash instead; any regular event rearms
+         * [TURN_TIMEOUT_MS].
+         */
+        private const val COMPACTING_TIMEOUT_MS = 600_000L
+
         private const val RPC_TIMEOUT_MS = 15_000L
         const val PROFILE_AVATAR_MAX_BYTES = 2_000_000
 
@@ -3675,10 +3688,12 @@ class GatewayChatClient(
     // ------------------------------------------------------------------
 
     /** Per-event idle-watchdog duration — asks block server-side with no events, so they arm longer. */
-    private fun watchdogTimeoutFor(eventType: String): Long = when (eventType) {
-        "clarify.request", "secret.request" -> ASK_CLARIFY_SECRET_TIMEOUT_MS
-        "sudo.request" -> ASK_SUDO_TIMEOUT_MS
-        "approval.request" -> ASK_UNBOUNDED_TIMEOUT_MS
+    private fun watchdogTimeoutFor(eventType: String, payload: JsonObject? = null): Long = when {
+        eventType == "clarify.request" || eventType == "secret.request" -> ASK_CLARIFY_SECRET_TIMEOUT_MS
+        eventType == "sudo.request" -> ASK_SUDO_TIMEOUT_MS
+        eventType == "approval.request" -> ASK_UNBOUNDED_TIMEOUT_MS
+        eventType == "status.update" &&
+            payload?.stringField("kind") == "compacting" -> COMPACTING_TIMEOUT_MS
         else -> turnIdleTimeoutMs
     }
 
@@ -3797,7 +3812,7 @@ class GatewayChatClient(
             // Reset on every event — long tool runs keep the turn alive.
             // Ask requests block with no further events, so they arm with
             // their own (longer) duration via watchdogTimeoutFor.
-            armWatchdog(watchdogTimeoutFor(type))
+            armWatchdog(watchdogTimeoutFor(type, payload))
             // Queue this immediately before the terminal callbacks. Both are
             // marshalled through the same dispatcher, preserving callback order
             // even when the WebSocket reader and reconnect coroutine differ.


### PR DESCRIPTION
## Problem

Server-side context compaction summarizes the transcript with **no deltas or tool events flowing** until it finishes. Near the context ceiling that silence routinely exceeds `TURN_TIMEOUT_MS` (180s), so the idle-progress watchdog fires `session.interrupt` on a **healthy** compression, rolls back its work, and the next prompt retriggers it — an infinite "Operation interrupted." loop that makes near-full sessions permanently unresponsive from the app.

Observed live tonight (gateway on gpt-5.6-sol via openai-codex, whose Codex window recently dropped to 272k — making preflight compaction far more common): four consecutive turns killed at exactly prompt+~251s (= visible tool work + 180.0s of silent compaction). Gateway compression telemetry for the same window:

```
{"commit_status":"aborted","failure_class":"explicit_interrupt","total_duration_ms":180469}
{"commit_status":"aborted","failure_class":"explicit_interrupt","total_duration_ms":180233}
{"commit_status":"aborted","failure_class":"explicit_interrupt","total_duration_ms":180219}
```

The user never touched stop — the watchdog fired each time.

## Fix

Treat a `status.update` event with kind `compacting` exactly like the ask events that already arm longer leashes, via the same `watchdogTimeoutFor` seam: arm `COMPACTING_TIMEOUT_MS` (600s, matching `ASK_UNBOUNDED_TIMEOUT_MS`) instead of the 180s default. Any regular event rearms `TURN_TIMEOUT_MS` as before.

The gateway already re-tags compaction lifecycle notices to kind `compacting` (`tui_gateway/server.py` `_status_update`), so a single event at compaction start engages the longer leash on current gateways. Pairs with NousResearch/hermes-agent#98371, which makes the gateway emit that status periodically during compression so each heartbeat re-arms the watchdog on any client.

## Testing

- `:app:compileSideloadDebugKotlin` — BUILD SUCCESSFUL
- `:app:testSideloadDebugUnitTest --tests "com.hermesandroid.relay.network.upstream.*"` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)