### PR TITLE
release: prepare Android 1.14.0, Plugin 1.11.0, and CLI+UI beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,36 +6,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [Android 1.14.0] - 2026-08-30
+
 ### Added
 
-- **Android can preview delegated agent work without leaving the parent chat.** The current-chat activity sheet shows bounded lifecycle, progress, and tool previews for concurrent children, opens vanilla Hermes child history read-only when the Gateway exposes it, and stays explicit when reconnect gaps or older routes leave details unavailable.
-- **Android presents Relay Git as a first-class native workspace.** A compact optional Chat rail opens repository status, line totals, filters, diffs, branches, staging, commits, and remotes; the full workspace remains available from Settings when Chat controls are hidden.
-- **Hermes-Relay Plugin provides a bounded Git workspace API for authenticated Dashboard clients.** Configured repository roots, path validation, tracked line totals, scoped write grants, and explicit confirmation protect repository reads and mutations.
+- **Android can preview delegated agent work without leaving the parent chat.** The current-chat activity sheet shows bounded lifecycle, progress, and tool previews for concurrent children, opens vanilla Hermes child history read-only when the Gateway exposes it, and stays explicit when reconnect gaps or older routes leave details unavailable. (#447)
+- **Android presents Relay Git as a first-class native workspace.** A compact optional Chat rail opens repository status, line totals, filters, diffs, branches, staging, commits, and remotes; the full workspace remains available from Settings when Chat controls are hidden. An updated optional Hermes-Relay Plugin is required for Git operations.
 
 ### Changed
 
-- **Hermes-Relay Dashboard management is organized around operator tasks.** Overview, Devices, Activity, Remote Access, Git, and Settings now have separate native Dashboard surfaces; pairing is QR-first, paired clients use responsive cards, and token-backed media is labeled as a bounded diagnostic instead of a health counter.
-- **New Relay pairing uses each Dashboard origin as the network ingress.** Dashboard, CLI, and TUI QR flows advertise the same-origin Relay transport for LAN, Tailscale, and public HTTPS routes. Recommended Tailscale uses dedicated HTTPS `:10443` for local Dashboard `:9119`, avoiding conflicts with an existing Traefik, Caddy, or nginx listener on `:443`; old `:443`/`:9119` routes and direct `:8767` remain explicit migration compatibility while `:8642` stays an optional API fallback.
-- **Dashboard pairing now explains and verifies route security before exposing an invite.** Endpoint receipts show Dashboard, Relay, and API URLs with priority and per-surface probe status, distinguish tailnet encryption from application TLS, and block malformed or plaintext public candidates.
+- **Connections now explain and recover each Dashboard, Relay, and optional API route independently.** LAN, Tailscale, and public HTTPS can fail over without allowing an unauthenticated or different-origin Relay route to borrow Dashboard credentials. Protected same-origin Relay health challenges are recognized as authentication boundaries instead of outages. An updated optional Hermes-Relay Plugin is required for same-origin Relay ingress. (Related: #399)
 - **Android What's New leads with one curated release highlight without interrupting startup.** A timed post-update toast can be swiped or closed, previews additional feature/fix counts when a release has meaningful secondary items, expands into the centered highlight view on request, and keeps the full technical history available. Each release can present one plain-language summary, up to three primary benefits, and up to two quieter improvements, while release checks keep the structured entry, fallback, Play copy, and public release records aligned.
 
 ### Fixed
 
-- **Android wake-word detection now loads a compatible native ONNX Runtime.** Packaged sherpa and Java JNI consumers are checked against the shared runtime for every supported ABI before release.
+- **Android wake-word detection now loads a compatible native ONNX Runtime.** Packaged sherpa and Java JNI consumers are checked against the shared runtime for every supported ABI before release. (#444)
 - **Android Continuous voice waits for barge-in microphone teardown before listening again.** Multi-turn hands-free conversations no longer lose the microphone after a response finishes with barge-in enabled. (#464)
-- **Opening Android no longer claims or interrupts a turn already running in Hermes Desktop/TUI.** Passive foreground and session browsing now use read-only Gateway status plus profile-scoped history; live-session resume remains reserved for explicit Android actions and exact Android-owned recovery.
-- **Android provisional Threads can be removed without touching server history.** The drawer now offers a local-only removal action, reconciles promoted phone sessions without duplicate rows, and keeps Thread routing isolated to the active saved connection.
-- **Android Clarify cards make custom answers explicit and keyboard-friendly.** Choice prompts label their Other answer field, submit trimmed text from the keyboard, and do not restore an authoritatively expired prompt after session navigation.
+- **Opening Android no longer claims or interrupts a turn already running in Hermes Desktop/TUI.** Passive foreground and session browsing now use read-only Gateway status plus profile-scoped history; live-session resume remains reserved for explicit Android actions and exact Android-owned recovery. (Related: #365)
+- **Android provisional Threads can be removed without touching server history.** The drawer now offers a local-only removal action, reconciles promoted phone sessions without duplicate rows, and keeps Thread routing isolated to the active saved connection. (#461)
+- **Android Clarify cards make custom answers explicit and keyboard-friendly.** Choice prompts label their Other answer field, submit trimmed text from the keyboard, and do not restore an authoritatively expired prompt after session navigation. (#446)
 - **The visible Android Sphere keeps its smooth procedural motion across startup and chat.** Backgrounded and motion-disabled surfaces remain still without reducing foreground animation to a stepped ambient pulse.
 - **Android Voice Focus keeps Stop and immediate spoken steering available across every interaction mode.** Hold-to-talk now interrupts Thinking and Transcribing turns before capturing the replacement direction, remains operable through TalkBack, Switch Access, and keyboard controls, preserves pointer press-and-release behavior across floating controls, and Google Play no longer offers the sideload-only system overlay action.
-- **Android Assistant sessions explain when no speech was captured instead of appearing stuck at Ready.** Retry feedback survives the separate system overlay process, recreated session UI requests the current turn state, and locked sessions keep transcript, response, and technical error text private.
-- **Android New Chat keeps the current profile and stays fresh across profile switches.** Starting from All Profiles no longer forces the literal default profile, choosing another profile from an empty draft no longer reopens that profile's previous session after route settlement or restart, and leaving a provisional phone Thread cannot route the next turn to its old chat under the new profile.
-- **Android self-hosted OIDC keeps sign-in on one trusted Dashboard origin.** Android follows upstream `native_pkce` capability for every interactive provider and falls back to exact-host cookies only when needed. Private and Tailscale routes can discover a provider-declared callback, verify the same installation, and ask before retaining a different authenticated Dashboard/Gateway origin; public origins require HTTPS while reviewed local or overlay HTTP remains compatible. Routes presents that origin separately from optional network paths and no longer exposes internal roles as a VPN. (#399)
+- **Android Assistant sessions explain when no speech was captured instead of appearing stuck at Ready.** Retry feedback survives the separate system overlay process, recreated session UI requests the current turn state, and locked sessions keep transcript, response, and technical error text private. (Related: #424)
+- **Android New Chat keeps the current profile and stays fresh across profile switches.** Starting from All Profiles no longer forces the literal default profile, choosing another profile from an empty draft no longer reopens that profile's previous session after route settlement or restart, and leaving a provisional phone Thread cannot route the next turn to its old chat under the new profile. (#436)
 - **Android Dashboard connections and profile drawers no longer wait on unavailable optional routes.** Dashboard, API fallback, and Relay probes run independently; API/Relay never gate a normal Dashboard connection, Gateway auth/ticket failures are not blindly retried, and authenticated session history remains available without a live Gateway socket. Concurrent route probes are shared and generation-safe, healthy same-priority routes win immediately, superseded session reads cancel their HTTP calls, and optional PR decoration stays outside the session-list critical path.
 
 ### Removed
 
 - **Android Chat no longer includes the hidden clean-focus presentation.** The long-press gesture, overlapping instructional pill, reduced composer, and alternate fading transcript were removed so Chat keeps one complete interaction model. Voice Focus remains available.
+
+## [Plugin 1.11.0] - 2026-08-30
+
+### Added
+
+- **Hermes-Relay Plugin provides a bounded Git workspace API for authenticated Dashboard clients.** Configured repository roots, path validation, tracked line totals, scoped write grants, and explicit confirmation protect repository reads and mutations.
+- **Relay extensions can use the authenticated Dashboard origin as one network ingress.** Fixed allowlisted HTTP and WebSocket paths proxy to the local Relay while Dashboard admission and Relay session authentication remain separate. (Related: #399)
+
+### Changed
+
+- **Hermes-Relay Dashboard management is organized around operator tasks.** Overview, Devices, Activity, Remote Access, Git, and Settings now have separate native Dashboard surfaces; pairing is QR-first, paired clients use responsive cards, and token-backed media is labeled as a bounded diagnostic instead of a health counter. (#486)
+- **Dashboard, CLI, and TUI pairing advertise the same explicit route set.** Recommended Tailscale uses dedicated HTTPS `:10443` for local Dashboard `:9119`, public HTTPS and LAN stay visible fallbacks, and old `:443`/`:9119` plus direct `:8767` remain migration compatibility.
+- **Pairing receipts explain transport protection before exposing an invite.** Per-surface probes distinguish application TLS, tailnet encryption, optional API fallback, and authenticated Relay ingress.
+
+### Fixed
+
+- **Public and roaming pairing no longer invent closed direct Relay or Dashboard ports.** Exact Dashboard origins own their same-origin Relay paths, ambiguous or plaintext public candidates fail closed, and inactive optional API routes are omitted.
+- **Dense pairing QRs scan reliably.** Dashboard, CLI, and TUI render integer-sized modules with a full quiet zone.
+- **Remote-access migration keeps existing listeners safe.** Recommended setup avoids taking over `:443`, explicit legacy cleanup remains available, and default disable actions remove only the listeners they own.
+
+## [0.4.0-beta.6] - 2026-08-30
+
+### Changed
+
+- **Hermes-Relay CLI+UI preserves the complete multi-route pairing topology.** Dashboard, Relay, optional API, priorities, and transport protection remain attached to one saved host across LAN, Tailscale, and public routes. (Related: #399)
+
+### Fixed
+
+- **Desktop rejects Dashboard-ingress Relay dials until it can mint Dashboard WebSocket tickets.** The daemon and host selector choose a compatible direct Relay fallback instead of attempting an unauthenticated same-origin ingress.
+- **API-less pairing remains valid.** Dashboard and direct Relay routes can pair without inventing an optional API server, while secure-first ranking keeps plain LAN as the final fallback.
 
 ## [Android 1.13.2] - 2026-08-25
 

--- a/CLI_RELEASE_NOTES.md
+++ b/CLI_RELEASE_NOTES.md
@@ -1,33 +1,22 @@
 # Hermes-Relay CLI+UI v__VERSION__
 
-**Release Date:** 2026-08-25
+**Release Date:** 2026-08-30
 
-This beta makes the Desktop connector resilient through Relay interruptions,
-aligns Windows computer control with current CUA Driver releases, adds a native
-Linux ARM64 build, and hardens installation and update discovery.
+This beta preserves complete multi-route pairing while preventing Desktop from dialing Dashboard-ingress Relay routes before Dashboard WebSocket ticket support is available. (Related: #399)
 
 **Beta phase.** Assets remain unsigned, so Windows SmartScreen and macOS Gatekeeper may warn on first launch. Standalone CLI binaries ship for Windows x64, Linux x64/arm64, and macOS x64/arm64; the management UI is Windows-only.
 
 ## What's changed
 
-### Added
-
-- **Linux ARM64 is a first-class release target.** The one-line installer,
-  updater, checksums, and release artifacts now cover both Linux x64 and arm64.
-- **The public site shows the real Windows CLI UI.** Deterministic screenshots
-  cover connections, host access, activity, computer control, and updates.
-
 ### Changed
 
-- **Public naming is aligned.** Releases use `Hermes-Relay CLI+UI` while the
-  beta keeps its existing `desktop-v*` tag and updater contract.
+- **Saved hosts retain the full route topology.** Dashboard, Relay, optional API, route priority, transport protection, certificate pins, and the selected host survive LAN, Tailscale, and public-route changes without creating duplicate hosts.
+- **API-less pairing is first-class.** Dashboard plus direct Relay can pair without inventing an optional API server, while secure-first ranking retains plain LAN as the final fallback.
 
 ### Fixed
 
-- **The daemon reconnects instead of exiting after an interrupted Relay socket.** Relay restarts and repeated transient replacement failures stay on bounded automatic backoff, and terminal failures persist an accurate stopped reason for the UI.
-- **Oversized desktop-tool output no longer closes the shared connection.** PowerShell output and every serialized desktop response stay inside the Relay WebSocket budget.
-- **Current CUA Driver releases remain compatible by contract.** Driver 0.20 and newer are accepted when their manifest and required tools match Hermes, and Windows uses the manifest-declared direct standard-mode runtime instead of a stale machine-wide daemon.
-- **Install and update discovery paginates the multi-surface release history.** Desktop releases remain discoverable after more Android and Server releases, Windows cooperative updates clean their released backup, and unsigned installers retain the normal SmartScreen warning.
+- **Dashboard-ingress Relay routes fail closed on Desktop.** The daemon, host selector, and Relay transport reject ingress that requires a Dashboard WebSocket ticket and choose a compatible direct Relay fallback instead of attempting an unauthenticated dial.
+- **Pairing accepts the current v3 candidate shape.** Optional API records, same-origin Dashboard/Relay routes, and legacy top-level payloads remain compatible without collapsing route ownership.
 
 ## Install
 
@@ -58,9 +47,4 @@ hermes-relay --version
 hermes-relay hosts list --json
 hermes-relay daemon start
 hermes-relay daemon status --json
-hermes-relay computer-use status --json
 ```
-
-On Windows, click the Hermes-Relay CLI UI notification-area icon to open the management popup directly above it.
-
-See the [CLI and tray guide](https://hermes-relay.dev/docs/desktop/) for installation, access modes, grants, and troubleshooting.

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,26 +1,29 @@
 # Hermes-Relay Plugin v__VERSION__
 
-**Release Date:** August 25, 2026
+**Release Date:** August 30, 2026
 
 ## Summary
 
-This release adds a provider-neutral account-usage surface for Android and Dashboard clients. Relay resolves Codex credential pools, structured Nous balances, and OpenCode Go windows on the Hermes host without returning provider credentials.
-
-Standard chat, session history, and Vanilla Hermes voice remain upstream-owned and do not require this plugin.
+This release lets one authenticated Hermes Dashboard origin carry Gateway plus optional Relay extensions, adds a bounded Git workspace, and reorganizes the Dashboard plugin around operator tasks. Standard chat, session history, profiles, Manage, and standard voice remain upstream-owned and do not require this plugin.
 
 ## Added
 
-- **Provider-neutral usage snapshots.** Authenticated Dashboard clients can resolve the exact active Codex pool entry, Nous balances, and OpenCode Go account windows through one normalized schema.
-- **Bounded paired-client fallback.** Operators may explicitly enable the Relay usage route for paired standalone clients while credentials remain host-side.
+- **Dashboard same-origin Relay ingress.** Fixed allowlisted HTTP and WebSocket routes proxy to the local Relay while Dashboard admission and Relay session authentication remain independent. (Related: #399)
+- **Bounded Git workspace.** Configured roots, path containment, line totals, diffs, branches, staging, commits, remotes, grants, and explicit confirmations protect repository operations.
 
 ## Changed
 
-- **Usage capabilities are explicit.** Responses identify Relay-enhanced credential pools, structured balances, and provider adapters instead of implying unsupported upstream data.
-- **Public product naming is aligned.** Releases use `Hermes-Relay Plugin` while retaining the `server-v*` tag and installation contract.
+- **Task-oriented Dashboard UI.** Overview, Devices, Activity, Remote Access, Git, and Settings now have dedicated surfaces with QR-first pairing, responsive device cards, and honest media diagnostics. (#486)
+- **One explicit route topology.** Dashboard, CLI, and TUI pairing advertise Dashboard, Relay, and optional API surfaces with stable priorities across Tailscale, public HTTPS, and LAN.
+- **Dedicated Tailscale listener.** Recommended setup uses tailnet HTTPS `:10443` to local Dashboard `:9119`, avoiding ownership of a reverse proxy's `:443`. Existing `:443`, `:9119`, and direct `:8767` routes remain migration compatibility.
 
 ## Fixed
 
-- **Custom Hermes homes resolve correctly.** Relay profile discovery and session persistence follow `HERMES_HOME` by default while preserving the explicit `RELAY_HERMES_CONFIG` override.
+- Public and roaming invites no longer synthesize closed direct Relay `:8767` or wrong Dashboard `:9119` routes.
+- Ambiguous, credential-bearing, or plaintext public candidates fail closed before an invite is exposed.
+- Dense pairing QRs use integer-sized modules and a full quiet zone.
+- Inactive optional API routes are omitted; protected Dashboard-ingress `401/403` responses display as authentication-required while direct Relay and API failures remain failures.
+- Default Tailscale disable actions remove only owned listeners, and explicit migration cleanup accepts only the bounded supported ports.
 
 ## Install / update
 
@@ -31,6 +34,8 @@ Standard chat, session history, and Vanilla Hermes voice remain upstream-owned a
     curl -fsSL https://raw.githubusercontent.com/Codename-11/hermes-relay/server-v__VERSION__/install.sh | bash
     # or, if already installed:
     hermes-relay-update
+
+Restart or reload the Hermes Dashboard and Relay after updating so the new manifest, routes, and committed Dashboard bundle are active.
 
 ## Verify
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Hermes-Relay Android v1.13.2
+# Hermes-Relay Android v1.14.0
 
-**Release Date:** August 25, 2026
+**Release Date:** August 30, 2026
 
 ## Download
 
-> Installing on your phone? Download `hermes-relay-1.13.2-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
+> Installing on your phone? Download `hermes-relay-1.14.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
 
 The `.aab` file is a Play Console upload bundle and cannot be installed by tapping it on a phone.
 
@@ -12,20 +12,33 @@ Verify the download against `SHA256SUMS.txt`. See the [sideload guide](https://h
 
 ## Summary
 
-This release adds a parent-configured Supervised Mode and improves its return from full settings. It also keeps session rows neutral until live activity is confirmed.
+This release makes saved Hermes connections reliable across LAN, Tailscale, and public HTTPS while keeping Dashboard authentication bound to its exact trusted origin. It also adds delegated-agent previews and an optional native Git workspace, and improves Voice, Assistant, Threads, profile drafts, and Clarify interactions.
 
 ## Added
 
-- Use a profile-pinned Supervised Mode with parent-controlled attachments, Standard voice, generated media, history, actions, and technical details. Device authentication protects full settings; this remains a client-side restricted view rather than a server-enforced account boundary.
+- **Delegated-agent previews.** Follow bounded lifecycle, progress, tool previews, and available read-only child history without leaving the parent chat. Partial history and reconnect gaps remain explicit. (#447)
+- **Native Git workspace.** Review repository state, diffs, branches, staging, commits, and remotes from Chat or Settings. Git operations require Hermes-Relay Plugin v1.11.0 and retain confirmation and grant boundaries.
+
+## Changed
+
+- **Route-aware connections.** Dashboard, Relay, and optional API health are evaluated independently across LAN, Tailscale, and public HTTPS. Same-origin Relay ingress stays on the Dashboard origin that owns authentication, while direct compatibility routes keep separate credentials. (Related: #399)
+- **Voice Focus controls.** Stop and immediate spoken steering remain accessible while Hermes is Thinking, Transcribing, or Speaking, including TalkBack, Switch Access, keyboard, and sideload overlay surfaces.
 
 ## Fixed
 
-- Keep session rows neutral while optional live activity is unavailable or still loading, and reserve full-row activity borders for actual Starting or Working turns.
-- Keep Supervised Chat rendered when parent access relocks after visiting full settings.
+- Wake-word detection packages one compatible ONNX Runtime for sherpa and Java JNI on every supported ABI. (#444)
+- Continuous voice waits for barge-in microphone teardown before listening again. (#464)
+- Fresh chats retain their selected profile without reopening a previous session or carrying a proactive Thread route across profiles. (#436)
+- Provisional Threads can be removed locally and reconcile with promoted sessions without deleting server history. (#461)
+- Clarify cards expose a reachable Other answer, keyboard Send, and authoritative expiry behavior. (#446)
+- Passive Android browsing no longer claims or interrupts a turn owned by another client. (Related: #365)
+- Assistant sessions show retryable no-speech feedback, recover their active state after recreation, and redact conversation details behind the keyguard. (Related: #424)
+- Protected Relay ingress `401/403` responses are recognized as authentication boundaries rather than outages; malformed, different-origin, and direct unauthorized routes still fail closed.
 
 ## Install / Verify
 
-- App version: **1.13.2** (versionCode **51**).
-- Standard Chat, sessions, Manage, sharing, profile switching, and Vanilla Hermes voice continue to work against unmodified upstream Hermes.
-- Granular Device Control remains sideload-only; the Google Play build continues to ship Hermes Bridge Core without AccessibilityService Device Control.
-- The optional Relay plugin remains unnecessary for standard Android chat, sessions, Manage, and Vanilla Hermes voice.
+- App version: **1.14.0** (versionCode **52**).
+- Standard Chat, sessions, profiles, Manage, and standard voice continue to work against unmodified upstream Hermes without the optional Relay plugin.
+- Install Hermes-Relay Plugin v1.11.0 for same-origin Relay extensions, Git workspace actions, Bridge, media, proactive features, and enhanced voice.
+- Granular Device Control and the system Voice Focus overlay remain sideload-only; the Google Play build does not declare their restricted permissions.
+- Existing connections, drafts, sessions, profile ownership, and legacy direct Relay routes remain data-preserving compatibility paths.

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
-v1.13.2 - Supervised Mode and clearer activity
+v1.14.0 - Connections that follow you
 
-Supervised Mode creates a simpler, profile-focused chat with device-protected parent settings and control over attachments, Standard voice, generated media, history, actions, and technical details. Activity indicators now appear only while Hermes is genuinely working, and returning from parent settings keeps Supervised Chat open.
+Connections now recover independently across LAN, Tailscale, and public HTTPS without mixing Dashboard and Relay authentication. Preview delegated agents, use the optional native Git workspace, and get safer Continuous voice, Voice Focus, Assistant, Threads, profile drafts, and Clarify controls. Wake-word detection also packages a compatible native runtime.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -2,6 +2,56 @@
  "schema": 2,
  "versions": [
   {
+   "version": "1.14.0",
+   "title": "Connections that follow you",
+   "date": "2026-08-30",
+   "highlight": {
+    "title": "Reliable routes",
+    "summary": "Move between LAN, Tailscale, and public HTTPS without mixing Dashboard or Relay authentication.",
+    "bullets": [
+     "Keep Chat and sessions on the trusted Dashboard while optional Relay routes recover independently.",
+     "Preview delegated agent work and use the optional native Git workspace.",
+     "Use more reliable Continuous voice, Voice Focus, Assistant, Threads, profiles, and Clarify controls."
+    ]
+   },
+   "improvements": [
+    "Wake-word detection now packages a compatible native runtime for every supported ABI.",
+    "Protected Relay health checks no longer appear as broken routes."
+   ],
+   "toastDigest": {
+    "additionalFeatureCount": 2,
+    "fixCount": 10,
+    "preview": [
+     "delegated-agent previews",
+     "safer voice and sessions"
+    ]
+   },
+   "playNotes": "Connections now recover independently across LAN, Tailscale, and public HTTPS without mixing Dashboard and Relay authentication. Preview delegated agents, use the optional native Git workspace, and get safer Continuous voice, Voice Focus, Assistant, Threads, profile drafts, and Clarify controls. Wake-word detection also packages a compatible native runtime.",
+   "sections": [
+    {
+     "header": "Use the best available route",
+     "bullets": [
+      "Resolve Dashboard, Relay, and optional API health independently across LAN, Tailscale, and public HTTPS.",
+      "Keep same-origin Relay ingress on the exact Dashboard origin that owns authentication."
+     ]
+    },
+    {
+     "header": "Follow active work",
+     "bullets": [
+      "Preview delegated-agent lifecycle, progress, tools, and available read-only child history from the parent chat.",
+      "Review Git status, diffs, branches, staging, commits, and remotes through the optional Relay plugin."
+     ]
+    },
+    {
+     "header": "Keep voice and conversations owned correctly",
+     "bullets": [
+      "Serialize microphone handoff and keep Voice Focus Stop and steering accessible across active phases.",
+      "Preserve fresh profile drafts, provisional Thread ownership, Clarify answers, passive observation, and Assistant privacy through reconnects."
+     ]
+    }
+   ]
+  },
+  {
    "version": "1.13.2",
    "title": "Supervised Mode and clearer activity",
    "date": "2026-08-25",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,9 +1,10 @@
-v1.13.2 - Supervised Mode and clearer activity
+v1.14.0 - Connections that follow you
 
-Supervised Mode
-* Protect parent settings with your phone's device authentication.
-* Choose access to attachments, Standard voice, generated media, history, actions, and technical details.
-* Keep Supervised Chat open when returning from parent settings.
+Reliable routes
+* Keep Chat and sessions on the trusted Dashboard while optional Relay routes recover independently.
+* Preview delegated agent work and use the optional native Git workspace.
+* Use more reliable Continuous voice, Voice Focus, Assistant, Threads, profiles, and Clarify controls.
 
 Also improved
-* Activity indicators now appear only while Hermes is genuinely working.
+* Wake-word detection now packages a compatible native runtime for every supported ABI.
+* Protected Relay health checks no longer appear as broken routes.

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-beta.5",
+      "version": "0.4.0-beta.6",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-beta.5" as const
+export const VERSION = "0.4.0-beta.6" as const

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-beta.5"
+version = "0.4.0-beta.6"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-beta.5"
+version = "0.4.0-beta.6"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-beta.5",
+      "version": "0.4.0-beta.6",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.6",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -91,9 +91,9 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.13.2 - Supervised Mode and clearer activity
+v1.14.0 - Connections that follow you
 
-Supervised Mode creates a simpler, profile-focused chat with device-protected parent settings and control over attachments, Standard voice, generated media, history, actions, and technical details. Activity indicators now appear only while Hermes is genuinely working, and returning from parent settings keeps Supervised Chat open.
+Connections now recover independently across LAN, Tailscale, and public HTTPS without mixing Dashboard and Relay authentication. Preview delegated agents, use the optional native Git workspace, and get safer Continuous voice, Voice Focus, Assistant, Threads, profile drafts, and Clarify controls. Wake-word detection also packages a compatible native runtime.
 ```
 ## Category
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.13.2"
-appVersionCode = "51"
+appVersionName = "1.14.0"
+appVersionCode = "52"
 agp = "9.3.2"
 kotlin = "2.4.10"
 compose-bom = "2026.08.00"

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Hermes-Relay",
   "description": "Paired devices, Bridge activity, media tokens, and remote access for Hermes-Relay",
   "icon": "Activity",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,7 +1,7 @@
 name: hermes-relay
 manifest_version: 2
 api_version: 1
-version: 1.10.0
+version: 1.11.0
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 license: MIT

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # CLI+UI releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.10.0"
+version = "1.11.0"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ wheels = [
 
 [[package]]
 name = "hermes-relay"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare the three release surfaces changed by the merged integration batch:

- Hermes-Relay Android `1.14.0` (`versionCode 52`)
- Hermes-Relay Plugin `1.11.0`
- Hermes-Relay CLI+UI `0.4.0-beta.6`

The notes keep each surface's scope separate, preserve the upstream-only Android path, and link every addressed issue without closing reporter/device-dependent bugs before immutable artifacts exist.

Addresses #436, #444, #446, #447, #461, and #464.

Related: #365, #399, and #424.

## Changes

- Bump Android release metadata to `1.14.0` / code `52` and add the structured in-app release entry.
- Regenerate Android What's New, Google Play notes, and Play listing copy from the structured source.
- Bump Plugin/Python/Dashboard metadata and `uv.lock` to `1.11.0`.
- Bump standalone CLI and Windows tray metadata to `0.4.0-beta.6` across npm, Rust, Tauri, and generated version sources.
- Promote the merged Unreleased work into separate Android, Plugin, and CLI+UI CHANGELOG sections.
- Rewrite all three release-note files with surface-owned behavior, compatibility boundaries, install guidance, and accurate issue references.
- Keep #365, #399, and #424 explicitly related rather than fixed; the reported environment/device-specific paths remain open for confirmation.
- Link Dashboard redesign PR #486 as provenance without treating it as an issue.

## Verification

- `python scripts/check-android-release-notes.py` — Android structured source, fallback, Play notes, and listing are aligned for `1.14.0`.
- `python scripts/check-android-locales.py` — 12 catalogs passed.
- `python scripts/check-android-collection-apis.py` — passed.
- `python scripts/check-plugin-version-sync.py --expect 1.11.0` — all Plugin/Dashboard metadata passed.
- `python scripts/check-version-tracks.py` — Android `1.14.0`, Plugin `1.11.0`, and CLI+UI `0.4.0-beta.6` are internally consistent.
- `uv build` — built `hermes_relay-1.11.0` wheel and source archive.
- `cd plugin/dashboard && npm ci && npm test && npm run build` — 46/46 tests passed; bundle rebuilt.
- `cd desktop && npm ci && npm test && npm run build && npm run check:version-sync` — 182/182 tests passed; build and synchronized version checks passed.
- `cd user-docs && npm ci && npm run build` — 91 route contracts, five localized core-page sets, and VitePress build passed.
- `git diff --check` — passed.
- Independent release-copy review found the issue matrix, SemVer, public hygiene, and workflow placeholders correct.

## Lineage / contributor credit

- Source PR(s): #488, which preserves #469, #471, #472, #475, #476, #477, #478, #480, #481, and #486 lineage
- Attribution preserved by: release prep is additive metadata/copy on exact merged `dev` commit `1800bee7`; source authorship remains in the integration history

## Non-goals

- This PR does not create tags, publish packages, deploy the Plugin, or roll out Android.
- Android Play preflight and the strict `dev` → `main` release PR occur only after this exact release-prep head reaches `dev` and remains green.
- Issue closure waits for successful immutable publication and the evidence policy described above.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: lint and focused unit tests ran, or rationale is listed above
- [x] Translation changes: locale status/review references are accurate, `python scripts/check-android-locales.py` ran, and device/emulator review is documented, or N/A
- [x] Server changes: focused `python -m unittest ...` checks ran, or rationale is listed above
- [x] Desktop changes: `npm run build` or a narrower documented check ran, or rationale is listed above
- [x] Docs/site changes: docs build or link check ran, or rationale is listed above
- [x] UI changes were tested on emulator/device or desktop surface when applicable
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CHANGELOG.md updated (if user-facing)
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged work links the source PR and preserves contributor authorship, or N/A
