### PR TITLE
chore(website): refresh desktop UI source fingerprint

### DIFF
--- a/docs/media/desktop-ui-screenshots.json
+++ b/docs/media/desktop-ui-screenshots.json
@@ -51,7 +51,7 @@
   "sourceFingerprint": {
     "algorithm": "sha256",
     "normalization": "text-lf-v1",
-    "digest": "8cf00c04da9e80621b439563145be49ede9539ac95ab903b1903763004e370bc",
+    "digest": "38253cb9fb1124a629625ea0bc5be09a4f61af91e3fca0103cbb12a5279aae54",
     "files": [
       "desktop/tray/ui/App.tsx",
       "desktop/tray/ui/main.tsx",


### PR DESCRIPTION
## Summary

Refresh the deterministic Desktop UI screenshot source fingerprint after the coordinated CLI+UI pairing/version changes, unblocking Website CI for release PR #490.

The canonical screenshot pixels are unchanged: the fingerprint delta comes from an optional endpoint-shape/display-label addition and the tray lockfile version bump. The screenshot fixture still renders the existing Tailscale example route, and all five canonical PNG/WebP pairs remain byte-current.

## Changes

- Update `docs/media/desktop-ui-screenshots.json` from the recorded source digest to the exact current digest.
- Leave canonical screenshots and website derivatives unchanged after asset comparison verified every scene.

## Verification

- `npm run assets:check` in `website/` — product, responsive, and all five Desktop UI scenes passed.
- `npm run build` in `website/` — locale validation, Astro diagnostics/build, and seven-file built-site validation passed with zero errors or warnings.
- `git diff --check` — passed.

## Lineage / contributor credit

- Source PR(s): #490
- Attribution preserved by: N/A; generated release-hygiene metadata only

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: N/A
- [x] Translation changes: N/A; website locale validation passed
- [x] Server changes: N/A
- [x] Desktop changes: fingerprint-only; canonical scene comparison passed
- [x] Docs/site changes: complete website asset and build checks passed
- [x] UI changes were tested on emulator/device or desktop surface when applicable — no pixel change; canonical asset comparison passed
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md updated — N/A; no user-facing behavior change
- [x] Public writing hygiene checked
- [x] Salvaged work links the source PR and preserves contributor authorship, or N/A
