### PR TITLE
fix(plugin): harden Git workspace path containment

### DIFF
--- a/plugin/git_state.py
+++ b/plugin/git_state.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 import logging
 import os
 import re
+import stat
 import subprocess
 import tempfile
+from functools import wraps
 from pathlib import Path
+from threading import Lock, RLock
 from typing import Any
 
 from .config import raw_config_value
@@ -47,6 +50,12 @@ _USERINFO_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@]+)@")
 _SSH_USERINFO_RE = re.compile(r"^([^/@:]+)@([^:]+):")
 _ERROR_USERINFO_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)([^\s/@]+)@")
 _ERROR_SSH_USERINFO_RE = re.compile(r"(?<![\w@])([^\s/@:]+)@([^\s:]+):")
+
+# FastAPI executes synchronous routes concurrently. These locks serialize Git
+# operations per repository without creating worker threads, so one API call
+# cannot replace a validated working-tree path underneath another.
+_REPO_LOCKS_GUARD = Lock()
+_REPO_LOCKS: dict[str, RLock] = {}
 
 
 class GitStateError(ValueError):
@@ -91,13 +100,18 @@ def _run_git_bounded(
     args: list[str],
     *,
     mutation: bool,
+    literal_pathspecs: bool = False,
 ) -> tuple[int, str, str]:
     """Run Git without materializing unbounded stdout or stderr in memory."""
     error_type = GitError if mutation else GitStateError
     with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
         try:
+            command = ["git", "-C", str(repo)]
+            if literal_pathspecs:
+                command.append("--literal-pathspecs")
+            command.extend(args)
             result = subprocess.run(
-                ["git", "-C", str(repo), *args],
+                command,
                 stdout=stdout_file,
                 stderr=stderr_file,
                 timeout=GIT_TIMEOUT_SECONDS,
@@ -139,9 +153,14 @@ def _safe_git_error(text: str) -> str:
     return scrubbed[:MAX_GIT_ERROR_BYTES].strip()
 
 
-def _git(repo: Path, *args: str) -> str:
+def _git(repo: Path, *args: str, literal_pathspecs: bool = False) -> str:
     """Run ``git -C <repo> <args>`` and return bounded stdout."""
-    returncode, stdout, stderr = _run_git_bounded(repo, list(args), mutation=False)
+    returncode, stdout, stderr = _run_git_bounded(
+        repo,
+        list(args),
+        mutation=False,
+        literal_pathspecs=literal_pathspecs,
+    )
     if returncode != 0:
         raise GitStateError(
             f"git {args[0] if args else 'command'} failed for {repo.name}: "
@@ -157,11 +176,77 @@ def _is_git_repo(path: Path) -> bool:
 
 def _is_link_or_junction(path: Path) -> bool:
     is_junction = getattr(path, "is_junction", None)
-    return path.is_symlink() or bool(is_junction and is_junction())
+    if path.is_symlink() or bool(is_junction and is_junction()):
+        return True
+    if os.name != "nt":
+        return False
+    try:
+        attributes = os.lstat(path).st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    reparse_point = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(attributes & reparse_point)
 
 
 def _is_within(root: Path, candidate: Path) -> bool:
     return candidate == root or root in candidate.parents
+
+
+def _canonical_repo_root(repo: Path) -> Path:
+    """Return an unlinked absolute repository root or fail closed."""
+    lexical = Path(os.path.abspath(repo))
+    try:
+        if _is_link_or_junction(lexical):
+            raise GitStateError("repository root changed during operation")
+        canonical = lexical.resolve(strict=True)
+    except GitStateError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise GitStateError("repository root changed during operation") from exc
+    if os.path.normcase(str(canonical)) != os.path.normcase(str(lexical)):
+        raise GitStateError("repository root changed during operation")
+    return canonical
+
+
+def _serialized_repo_operation(function: Any) -> Any:
+    """Serialize a Git operation against other operations on the same repo."""
+
+    @wraps(function)
+    def wrapped(repo: Path, *args: Any, **kwargs: Any) -> Any:
+        key = os.path.normcase(os.path.abspath(repo))
+        with _REPO_LOCKS_GUARD:
+            lock = _REPO_LOCKS.setdefault(key, RLock())
+        with lock:
+            return function(repo, *args, **kwargs)
+
+    return wrapped
+
+
+def _resolve_repo_disk_path(
+    repo: Path,
+    path: str,
+    *,
+    strict: bool,
+) -> Path:
+    """Resolve a validated relative path and prove canonical repo containment.
+
+    ``Path.resolve`` follows symlinks and junctions before ``commonpath``
+    compares the canonical filesystem paths. Different-drive paths fail
+    closed on Windows. Callers that open the result must revalidate the opened
+    handle before using it as defense in depth against an unexpected path
+    replacement. Concurrent external same-user filesystem mutation is outside
+    the plugin trust boundary.
+    """
+    safe_path = resolve_repo_path(repo, path)
+    root = _canonical_repo_root(repo)
+    candidate = (root / safe_path).resolve(strict=strict)
+    try:
+        common = Path(os.path.commonpath((str(root), str(candidate))))
+    except ValueError as exc:
+        raise GitStateError(f"path escapes repository: {safe_path}") from exc
+    if os.path.normcase(str(common)) != os.path.normcase(str(root)):
+        raise GitStateError(f"path escapes repository: {safe_path}")
+    return candidate
 
 
 def _has_link_component(base: Path, path: Path) -> bool:
@@ -175,6 +260,19 @@ def _has_link_component(base: Path, path: Path) -> bool:
         if _is_link_or_junction(current):
             return True
     return False
+
+
+def _validate_untracked_delete_path(repo: Path, path: str) -> str:
+    """Validate one exact untracked file before delegating deletion to Git."""
+    safe_path = resolve_repo_path(repo, path)
+    root = _canonical_repo_root(repo)
+    lexical = root / safe_path
+    if _has_link_component(root, lexical):
+        raise GitStateError(f"path contains a link or junction: {safe_path}")
+    candidate = _resolve_repo_disk_path(repo, safe_path, strict=False)
+    if candidate.exists() and candidate.is_dir():
+        raise GitStateError(f"path is not a file: {safe_path}")
+    return safe_path
 
 
 def repo_id(repo: Path, base: Path | None = None) -> str:
@@ -433,19 +531,27 @@ def repo_diff(repo: Path, path: str, kind: str) -> dict[str, Any]:
     args = ["diff", "--no-color", "--"]
     if kind == "staged":
         args = ["diff", "--cached", "--no-color", "--"]
-    output = _git(repo, *args, safe_path)
+    output = _git(repo, *args, safe_path, literal_pathspecs=True)
     truncated = len(output) > MAX_DIFF_BYTES
     if truncated:
         output = output[:MAX_DIFF_BYTES]
     return {"path": safe_path, "kind": kind, "diff": output, "truncated": truncated}
 
 
+@_serialized_repo_operation
 def read_file(repo: Path, path: str) -> dict[str, Any]:
     """Read a tracked file's working-tree content. Untracked/binary/missing → error."""
     safe_path = resolve_repo_path(repo, path)
     # Confirm the file is tracked before reading.
     try:
-        _git(repo, "ls-files", "--error-unmatch", "--", safe_path)
+        _git(
+            repo,
+            "ls-files",
+            "--error-unmatch",
+            "--",
+            safe_path,
+            literal_pathspecs=True,
+        )
     except GitStateError as exc:
         raise GitStateError(f"file is not tracked: {safe_path}") from exc
 
@@ -453,12 +559,16 @@ def read_file(repo: Path, path: str) -> dict[str, Any]:
     # modified-but-uncommitted file returns what is on disk. Read bytes first:
     # binary content dies on the NUL check (before any decode), and non-UTF-8
     # text raises a clear GitStateError instead of an unhandled 500.
-    root = repo.resolve()
     try:
-        disk_path = (repo / safe_path).resolve(strict=True)
-        if not _is_within(root, disk_path):
-            raise GitStateError(f"path escapes repository: {safe_path}")
+        disk_path = _resolve_repo_disk_path(repo, safe_path, strict=True)
         with disk_path.open("rb") as handle:
+            # Re-resolve after opening, then prove the open handle still names
+            # that in-repo file. This fails closed if a parent, junction, repo
+            # root, or leaf is replaced between validation and open; reads use
+            # the already-verified handle after this point.
+            revalidated = _resolve_repo_disk_path(repo, safe_path, strict=True)
+            if not os.path.samestat(os.fstat(handle.fileno()), revalidated.stat()):
+                raise GitStateError(f"path changed during read: {safe_path}")
             raw = handle.read(MAX_FILE_BYTES + 1)
     except OSError as exc:
         raise GitStateError(f"could not read file: {safe_path}") from exc
@@ -573,12 +683,22 @@ def _is_git_repo(path: Path) -> bool:
     return (path / ".git").exists()
 
 
-def _run_mutation(repo: Path, args: list[str]) -> str:
+def _run_mutation(
+    repo: Path,
+    args: list[str],
+    *,
+    literal_pathspecs: bool = False,
+) -> str:
     """Run a mutating ``git -C <repo> <args>``; raise a classified GitError.
 
     Arg lists only (never shell interpolation); bounded by a timeout.
     """
-    returncode, stdout, stderr_output = _run_git_bounded(repo, args, mutation=True)
+    returncode, stdout, stderr_output = _run_git_bounded(
+        repo,
+        args,
+        mutation=True,
+        literal_pathspecs=literal_pathspecs,
+    )
     if returncode != 0:
         stderr = _safe_git_error(stderr_output or stdout)
         raise GitError(
@@ -588,11 +708,33 @@ def _run_mutation(repo: Path, args: list[str]) -> str:
     return stdout
 
 
-def _mutate(repo: Path, args: list[str]) -> str:
+def _mutate(
+    repo: Path,
+    args: list[str],
+    *,
+    literal_pathspecs: bool = False,
+) -> str:
     """Validate ``repo`` is a real git work tree, then run the mutation."""
     if not _is_git_repo(repo):
         raise GitError(f"not a git repository: {repo.name}", code="non-repo")
-    return _run_mutation(repo, args)
+    return _run_mutation(repo, args, literal_pathspecs=literal_pathspecs)
+
+
+def _is_tracked_path(repo: Path, path: str) -> bool:
+    """Classify one literal path without treating Git failures as untracked."""
+    returncode, stdout, stderr = _run_git_bounded(
+        repo,
+        ["ls-files", "--error-unmatch", "--", path],
+        mutation=False,
+        literal_pathspecs=True,
+    )
+    if returncode == 0:
+        return True
+    if returncode == 1:
+        return False
+    raise GitStateError(
+        f"git ls-files failed for {repo.name}: {_safe_git_error(stderr or stdout)}"
+    )
 
 
 def _is_dirty(repo: Path) -> bool:
@@ -712,20 +854,23 @@ def _fresh_mutation_result(
     return result
 
 
+@_serialized_repo_operation
 def stage(repo: Path, paths: list[str]) -> dict[str, Any]:
     """Stage ``paths`` (repo-relative) and return fresh status."""
     safe = _validate_paths(paths)
-    _mutate(repo, ["add", "--"] + safe)
+    _mutate(repo, ["add", "--"] + safe, literal_pathspecs=True)
     return _fresh_mutation_result(repo)
 
 
+@_serialized_repo_operation
 def unstage(repo: Path, paths: list[str]) -> dict[str, Any]:
     """Unstage ``paths`` and return fresh status."""
     safe = _validate_paths(paths)
-    _mutate(repo, ["restore", "--staged", "--"] + safe)
+    _mutate(repo, ["restore", "--staged", "--"] + safe, literal_pathspecs=True)
     return _fresh_mutation_result(repo)
 
 
+@_serialized_repo_operation
 def discard(
     repo: Path,
     paths: list[str],
@@ -740,26 +885,25 @@ def discard(
     _require_confirmation(confirmation, CONFIRM_DISCARD)
     safe = _validate_paths(paths)
     tracked: list[str] = []
+    untracked: list[str] = []
     for path in safe:
-        try:
-            _git(repo, "ls-files", "--error-unmatch", "--", path)
+        if _is_tracked_path(repo, path):
             tracked.append(path)
-        except GitStateError:
-            # Untracked path — only touched when delete_untracked is set.
-            if not delete_untracked:
-                continue
-            root = repo.resolve()
-            candidate = (repo / path).resolve()
-            if candidate != root and root not in candidate.parents:
-                raise GitStateError(f"path escapes repository: {path}")
-            if candidate.is_file():
-                candidate.unlink()
+        elif delete_untracked:
+            untracked.append(path)
+    # Reject links and directories before asking Git to remove only the exact
+    # literal file names. Concurrent same-user filesystem mutation is outside
+    # the plugin trust boundary; stationary redirections fail closed here.
+    deletable = [_validate_untracked_delete_path(repo, path) for path in untracked]
+    if deletable:
+        _mutate(repo, ["clean", "-f", "--"] + deletable, literal_pathspecs=True)
     # Revert tracked modifications for the given paths.
     if tracked:
-        _mutate(repo, ["checkout", "--"] + tracked)
+        _mutate(repo, ["checkout", "--"] + tracked, literal_pathspecs=True)
     return _fresh_mutation_result(repo)
 
 
+@_serialized_repo_operation
 def commit(repo: Path, message: str) -> dict[str, Any]:
     """Create a commit from the staged index. Empty message is rejected."""
     message = _validate_commit_message(message)
@@ -767,14 +911,16 @@ def commit(repo: Path, message: str) -> dict[str, Any]:
     return _fresh_mutation_result(repo)
 
 
+@_serialized_repo_operation
 def commit_selected(repo: Path, message: str, paths: list[str]) -> dict[str, Any]:
     """Commit only the given ``paths`` (staged + modified) under ``message``."""
     message = _validate_commit_message(message)
     safe = _validate_paths(paths)
-    _mutate(repo, ["commit", "-m", message, "--"] + safe)
+    _mutate(repo, ["commit", "-m", message, "--"] + safe, literal_pathspecs=True)
     return _fresh_mutation_result(repo)
 
 
+@_serialized_repo_operation
 def fetch(repo: Path, remote: str = "origin") -> dict[str, Any]:
     """Fetch from ``remote`` (default origin) and return fresh status/branches."""
     remote = _validate_remote(repo, remote)
@@ -782,6 +928,7 @@ def fetch(repo: Path, remote: str = "origin") -> dict[str, Any]:
     return _fresh_mutation_result(repo, {"branches": repo_branches(repo)})
 
 
+@_serialized_repo_operation
 def pull(repo: Path, remote: str = "origin", branch: str = "") -> dict[str, Any]:
     """Pull from ``remote``/``branch`` (defaults: origin + current branch).
 
@@ -805,6 +952,7 @@ def pull(repo: Path, remote: str = "origin", branch: str = "") -> dict[str, Any]
     return _fresh_mutation_result(repo)
 
 
+@_serialized_repo_operation
 def push(
     repo: Path,
     remote: str = "origin",
@@ -826,6 +974,7 @@ def push(
     return _fresh_mutation_result(repo, {"branches": repo_branches(repo)})
 
 
+@_serialized_repo_operation
 def checkout(
     repo: Path,
     ref: str,
@@ -857,7 +1006,7 @@ def _staged_diff(repo: Path, paths: list[str] | None) -> tuple[str, bool]:
     if paths:
         args.append("--")
         args.extend(paths)
-    output = _git(repo, *args)
+    output = _git(repo, *args, literal_pathspecs=bool(paths))
     truncated = len(output) > MAX_DIFF_BYTES
     if truncated:
         output = output[:MAX_DIFF_BYTES]
@@ -945,6 +1094,7 @@ async def commit_message_selected(
     return await _generate_message(diff)
 
 
+@_serialized_repo_operation
 def stash_checkout(
     repo: Path,
     ref: str,

--- a/plugin/tests/test_git_state.py
+++ b/plugin/tests/test_git_state.py
@@ -313,6 +313,15 @@ class GitStateFileTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             git_state.read_file(self.repo, "untracked.txt")
 
+    def test_read_tracking_check_treats_pathspec_magic_as_literal(self) -> None:
+        (self.repo / "name1.txt").write_text("tracked", encoding="utf-8")
+        _git(self.repo, "add", "name1.txt")
+        _git(self.repo, "commit", "-q", "-m", "add tracked pathspec sibling")
+        (self.repo / "name[1].txt").write_text("untracked", encoding="utf-8")
+
+        with self.assertRaisesRegex(git_state.GitStateError, "file is not tracked"):
+            git_state.read_file(self.repo, "name[1].txt")
+
     def test_read_missing_file_raises(self) -> None:
         with self.assertRaises(ValueError):
             git_state.read_file(self.repo, "nope.txt")
@@ -357,6 +366,57 @@ class GitStateFileTests(unittest.TestCase):
 
         with self.assertRaisesRegex(git_state.GitStateError, "escapes repository"):
             git_state.read_file(self.repo, tracked_path)
+
+    def test_read_rejects_parent_swapped_after_validation(self) -> None:
+        nested = self.repo / "nested"
+        nested.mkdir()
+        tracked = nested / "tracked.txt"
+        tracked.write_text("safe", encoding="utf-8")
+        _git(self.repo, "add", "nested/tracked.txt")
+        _git(self.repo, "commit", "-q", "-m", "add nested file")
+
+        parked = self.repo / "nested-original"
+        outside = self.base / "outside"
+        outside.mkdir()
+        (outside / "tracked.txt").write_text("secret", encoding="utf-8")
+        original_open = Path.open
+        swapped = False
+
+        def swap_before_open(path: Path, *args: object, **kwargs: object):
+            nonlocal swapped
+            if not swapped and path == tracked:
+                swapped = True
+                nested.rename(parked)
+                _link_directory(nested, outside)
+            return original_open(path, *args, **kwargs)
+
+        with patch.object(Path, "open", new=swap_before_open):
+            with self.assertRaisesRegex(git_state.GitStateError, "escapes repository"):
+                git_state.read_file(self.repo, "nested/tracked.txt")
+
+        self.assertTrue((parked / "tracked.txt").exists())
+        self.assertEqual("secret", (outside / "tracked.txt").read_text(encoding="utf-8"))
+
+    def test_read_rejects_repo_root_swapped_after_validation(self) -> None:
+        parked = self.base / "file-repo-original"
+        outside = _init_repo(self.base, "outside-repo")
+        (outside / "README.md").write_text("# Secret\n", encoding="utf-8")
+        original_open = Path.open
+        swapped = False
+
+        def swap_before_open(path: Path, *args: object, **kwargs: object):
+            nonlocal swapped
+            if not swapped and path == self.repo / "README.md":
+                swapped = True
+                self.repo.rename(parked)
+                _link_directory(self.repo, outside)
+            return original_open(path, *args, **kwargs)
+
+        with patch.object(Path, "open", new=swap_before_open):
+            with self.assertRaisesRegex(git_state.GitStateError, "repository root changed"):
+                git_state.read_file(self.repo, "README.md")
+
+        self.assertEqual("# Secret\n", (outside / "README.md").read_text(encoding="utf-8"))
 
     def test_read_tracked_file_is_bounded_during_read(self) -> None:
         (self.repo / "large.txt").write_text("x" * (git_state.MAX_FILE_BYTES + 100), encoding="utf-8")

--- a/plugin/tests/test_git_state_write.py
+++ b/plugin/tests/test_git_state_write.py
@@ -12,6 +12,8 @@ import os
 import subprocess
 import unittest
 from pathlib import Path
+from threading import Event, Thread
+from unittest.mock import patch
 
 from plugin import git_state
 
@@ -48,6 +50,15 @@ def _init_bare_remote(root: Path, name: str) -> Path:
     remote.mkdir(parents=True, exist_ok=True)
     _run(["git", "init", "-q", "--bare", "-b", "main"], remote)
     return remote
+
+
+def _link_directory(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        if os.name != "nt":
+            raise
+        _run(["cmd", "/c", "mklink", "/J", str(link), str(target)], link.parent)
 
 
 class _MutationBase(unittest.TestCase):
@@ -99,6 +110,46 @@ class StageUnstageTests(_MutationBase):
         with self.assertRaises(git_state.GitStateError):
             git_state.stage(self.repo, ["../outside"])
 
+    def test_stage_treats_wildcard_as_literal_path(self) -> None:
+        (self.repo / "first.txt").write_text("first", encoding="utf-8")
+        (self.repo / "second.txt").write_text("second", encoding="utf-8")
+
+        with self.assertRaises(git_state.GitError):
+            git_state.stage(self.repo, ["*.txt"])
+
+        status = git_state.repo_status(self.repo)
+        self.assertEqual([], status["staged"])
+        self.assertEqual(
+            {"first.txt", "second.txt"},
+            {entry["path"] for entry in status["untracked"]},
+        )
+
+    def test_stage_treats_pathspec_magic_as_literal_path(self) -> None:
+        literal = "name[1].txt"
+        expanded = "name1.txt"
+        (self.repo / literal).write_text("literal", encoding="utf-8")
+        (self.repo / expanded).write_text("expanded", encoding="utf-8")
+
+        git_state.stage(self.repo, [literal])
+
+        status = git_state.repo_status(self.repo)
+        self.assertEqual({literal}, {entry["path"] for entry in status["staged"]})
+        self.assertEqual({expanded}, {entry["path"] for entry in status["untracked"]})
+
+    def test_unstage_treats_wildcard_as_literal_path(self) -> None:
+        for name in ("first.txt", "second.txt"):
+            (self.repo / name).write_text(name, encoding="utf-8")
+            _git(self.repo, "add", name)
+
+        with self.assertRaises(git_state.GitError):
+            git_state.unstage(self.repo, ["*.txt"])
+
+        status = git_state.repo_status(self.repo)
+        self.assertEqual(
+            {"first.txt", "second.txt"},
+            {entry["path"] for entry in status["staged"]},
+        )
+
 
 class CommitTests(_MutationBase):
     def test_commit_creates_a_real_commit(self) -> None:
@@ -147,6 +198,17 @@ class CommitTests(_MutationBase):
         with self.assertRaises(git_state.GitError):
             git_state.commit_selected(self.repo, "", ["a.txt"])
 
+    def test_commit_selected_treats_wildcard_as_literal_path(self) -> None:
+        for name in ("first.txt", "second.txt"):
+            (self.repo / name).write_text(name, encoding="utf-8")
+            _git(self.repo, "add", name)
+
+        with self.assertRaises(git_state.GitError):
+            git_state.commit_selected(self.repo, "must stay scoped", ["*.txt"])
+
+        self.assertNotIn("first.txt", _git(self.repo, "ls-tree", "-r", "--name-only", "HEAD"))
+        self.assertNotIn("second.txt", _git(self.repo, "ls-tree", "-r", "--name-only", "HEAD"))
+
 
 class DiscardConfirmationTests(_MutationBase):
     def test_discard_requires_confirmation_string(self) -> None:
@@ -178,6 +240,222 @@ class DiscardConfirmationTests(_MutationBase):
             delete_untracked=True,
         )
         self.assertFalse((self.repo / "untracked.txt").exists())
+
+    def test_discard_delete_untracked_rejects_link_outside_repo(self) -> None:
+        outside = self.base / "outside.txt"
+        outside.write_text("keep", encoding="utf-8")
+        link = self.repo / "untracked-link.txt"
+        try:
+            link.symlink_to(outside)
+        except OSError as exc:
+            self.skipTest(f"symlink creation unavailable: {exc}")
+
+        with self.assertRaisesRegex(git_state.GitStateError, "link or junction"):
+            git_state.discard(
+                self.repo,
+                ["untracked-link.txt"],
+                confirmation=git_state.CONFIRM_DISCARD,
+                delete_untracked=True,
+            )
+
+        self.assertEqual("keep", outside.read_text(encoding="utf-8"))
+        self.assertTrue(link.is_symlink())
+
+    @unittest.skipUnless(os.name == "nt", "Windows junction fallback")
+    def test_discard_rejects_junction_on_python_311_fallback(self) -> None:
+        target = self.repo / "target"
+        target.mkdir()
+        (target / "keep.txt").write_text("keep", encoding="utf-8")
+        junction = self.repo / "junction"
+        _run(["cmd", "/c", "mklink", "/J", str(junction), str(target)], self.repo)
+
+        with patch.object(Path, "is_junction", return_value=False, create=True):
+            with self.assertRaisesRegex(git_state.GitStateError, "link or junction"):
+                git_state.discard(
+                    self.repo,
+                    ["junction/keep.txt"],
+                    confirmation=git_state.CONFIRM_DISCARD,
+                    delete_untracked=True,
+                )
+
+        self.assertEqual("keep", (target / "keep.txt").read_text(encoding="utf-8"))
+
+    def test_discard_delete_untracked_treats_wildcard_as_literal_path(self) -> None:
+        for name in ("first.txt", "second.txt"):
+            (self.repo / name).write_text(name, encoding="utf-8")
+
+        git_state.discard(
+            self.repo,
+            ["*.txt"],
+            confirmation=git_state.CONFIRM_DISCARD,
+            delete_untracked=True,
+        )
+
+        self.assertTrue((self.repo / "first.txt").exists())
+        self.assertTrue((self.repo / "second.txt").exists())
+
+    def test_discard_does_not_delete_when_tracking_check_fails(self) -> None:
+        target = self.repo / "keep.txt"
+        target.write_text("keep", encoding="utf-8")
+
+        with patch.object(
+            git_state,
+            "_run_git_bounded",
+            return_value=(128, "", "fatal: repository unavailable"),
+        ):
+            with self.assertRaisesRegex(git_state.GitStateError, "ls-files failed"):
+                git_state.discard(
+                    self.repo,
+                    ["keep.txt"],
+                    confirmation=git_state.CONFIRM_DISCARD,
+                    delete_untracked=True,
+                )
+
+        self.assertEqual("keep", target.read_text(encoding="utf-8"))
+
+    def test_discard_delete_untracked_does_not_follow_swapped_parent(self) -> None:
+        nested = self.repo / "nested"
+        nested.mkdir()
+        (nested / "delete.txt").write_text("repo", encoding="utf-8")
+        parked = self.repo / "nested-original"
+        outside = self.base / "outside"
+        outside.mkdir()
+        outside_file = outside / "delete.txt"
+        outside_file.write_text("keep", encoding="utf-8")
+        original_validate = git_state._validate_untracked_delete_path
+
+        def swap_before_delete(repo: Path, path: str) -> str:
+            if nested.exists() and not nested.is_symlink():
+                nested.rename(parked)
+                _link_directory(nested, outside)
+            return original_validate(repo, path)
+
+        with patch.object(
+            git_state,
+            "_validate_untracked_delete_path",
+            side_effect=swap_before_delete,
+        ):
+            with self.assertRaisesRegex(git_state.GitStateError, "link or junction"):
+                git_state.discard(
+                    self.repo,
+                    ["nested/delete.txt"],
+                    confirmation=git_state.CONFIRM_DISCARD,
+                    delete_untracked=True,
+                )
+
+        self.assertEqual("keep", outside_file.read_text(encoding="utf-8"))
+        self.assertTrue((parked / "delete.txt").exists())
+
+    def test_discard_delete_untracked_rejects_swapped_repo_root(self) -> None:
+        (self.repo / "delete.txt").write_text("repo", encoding="utf-8")
+        parked = self.base / "write-repo-original"
+        outside = self.base / "outside-repo"
+        outside.mkdir()
+        outside_file = outside / "delete.txt"
+        outside_file.write_text("keep", encoding="utf-8")
+        original_validate = git_state._validate_untracked_delete_path
+
+        def swap_before_delete(repo: Path, path: str) -> str:
+            self.repo.rename(parked)
+            _link_directory(self.repo, outside)
+            return original_validate(repo, path)
+
+        with patch.object(
+            git_state,
+            "_validate_untracked_delete_path",
+            side_effect=swap_before_delete,
+        ):
+            with self.assertRaisesRegex(git_state.GitStateError, "repository root changed"):
+                git_state.discard(
+                    self.repo,
+                    ["delete.txt"],
+                    confirmation=git_state.CONFIRM_DISCARD,
+                    delete_untracked=True,
+                )
+
+        self.assertEqual("keep", outside_file.read_text(encoding="utf-8"))
+        self.assertTrue((parked / "delete.txt").exists())
+
+    def test_discard_tracked_treats_wildcard_as_literal_path(self) -> None:
+        for name in ("first.txt", "second.txt"):
+            (self.repo / name).write_text("v1", encoding="utf-8")
+            _git(self.repo, "add", name)
+        _git(self.repo, "commit", "-q", "-m", "add tracked files")
+        for name in ("first.txt", "second.txt"):
+            (self.repo / name).write_text("v2", encoding="utf-8")
+
+        git_state.discard(
+            self.repo,
+            ["*.txt"],
+            confirmation=git_state.CONFIRM_DISCARD,
+        )
+
+        self.assertEqual("v2", (self.repo / "first.txt").read_text(encoding="utf-8"))
+        self.assertEqual("v2", (self.repo / "second.txt").read_text(encoding="utf-8"))
+
+    def test_discard_serializes_against_checkout_on_same_repo(self) -> None:
+        target = self.repo / "delete.txt"
+        target.write_text("delete", encoding="utf-8")
+        _git(self.repo, "branch", "other")
+        validation_reached = Event()
+        allow_discard = Event()
+        checkout_started = Event()
+        checkout_completed = Event()
+        errors: list[BaseException] = []
+        original_validate = git_state._validate_untracked_delete_path
+
+        def blocked_validate(repo: Path, path: str) -> str:
+            result = original_validate(repo, path)
+            validation_reached.set()
+            if not allow_discard.wait(5):
+                raise AssertionError("test timed out waiting to continue discard")
+            return result
+
+        def run_discard() -> None:
+            try:
+                git_state.discard(
+                    self.repo,
+                    ["delete.txt"],
+                    confirmation=git_state.CONFIRM_DISCARD,
+                    delete_untracked=True,
+                )
+            except BaseException as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+
+        def run_checkout() -> None:
+            checkout_started.set()
+            try:
+                git_state.checkout(
+                    self.repo,
+                    "other",
+                    confirmation=git_state.CONFIRM_DIRTY_CHECKOUT,
+                )
+            except BaseException as exc:  # pragma: no cover - reported below
+                errors.append(exc)
+            finally:
+                checkout_completed.set()
+
+        with patch.object(
+            git_state,
+            "_validate_untracked_delete_path",
+            side_effect=blocked_validate,
+        ):
+            discard_thread = Thread(target=run_discard)
+            checkout_thread = Thread(target=run_checkout)
+            discard_thread.start()
+            self.assertTrue(validation_reached.wait(5))
+            checkout_thread.start()
+            self.assertTrue(checkout_started.wait(5))
+            self.assertFalse(checkout_completed.wait(0.2))
+            allow_discard.set()
+            discard_thread.join(5)
+            checkout_thread.join(5)
+
+        self.assertFalse(discard_thread.is_alive())
+        self.assertFalse(checkout_thread.is_alive())
+        self.assertEqual([], errors)
+        self.assertFalse(target.exists())
+        self.assertEqual("other", _git(self.repo, "branch", "--show-current"))
 
     def test_discard_returns_fresh_status(self) -> None:
         (self.repo / "tracked.txt").write_text("v1", encoding="utf-8")


### PR DESCRIPTION
## Summary

Harden the optional Plugin Git workspace before the Android 1.14.0 / Plugin 1.11.0 release. This closes the path-scope gaps identified by CodeQL on release PR #490 without changing the Git workspace UI or grant model.

## Changes

- Treat every user-supplied Git file path as a literal pathspec while preserving native branch, ref, remote, stash, and checkout parsing.
- Keep tracked reads and confirmed untracked deletion inside the selected canonical repository, including Python 3.11-compatible Windows junction/reparse detection.
- Serialize Git reads and mutations per repository so concurrent authenticated API calls cannot replace a validated path.
- Fail closed when Git cannot classify a path as tracked or untracked.
- Add wildcard/pathspec, symlink/junction, root/parent swap, concurrent checkout, and stash-compatibility regressions.

## Verification

- `python -m pytest plugin/tests/test_relay_security.py plugin/tests/test_voice_routes.py plugin/tests/test_session_grants.py plugin/tests/test_native_layout_imports.py plugin/tests/test_profile_discovery.py plugin/tests/test_profiles_updated_broadcast.py plugin/tests/test_git_state.py plugin/tests/test_git_state_write.py plugin/tests/test_git_state_extras.py plugin/tests/test_mobile_plugin_store.py plugin/dashboard/test_git_api.py -q` — 246 passed, 5 skipped, 15 subtests passed.
- `python -m compileall -q plugin/git_state.py plugin/tests/test_git_state.py plugin/tests/test_git_state_write.py` — passed.
- `git diff --check` — passed.
- Codex Security diff scan `dcd09514-9074-4033-b354-8b0f4dad433a` — complete, zero findings.
- Independent final security/compatibility review — PASS.

## Screenshots

No visual change.

## Compatibility / risk

- No API, persistence, migration, route, grant, or upstream Hermes contract change.
- User-controlled file paths are literal only; branch/ref/remote/stash behavior remains unchanged.
- Concurrent authenticated Plugin Git operations are serialized per repository. Malicious external mutation by a process already running as the same service user remains outside the Plugin trust boundary.
- Rollback is the single commit in this PR.

## Lineage / contributor credit

- Source PR(s): #490 security review alerts 81-85
- Attribution preserved by: focused follow-up commit on current `origin/dev`; no contributor commits replaced

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A — no Android files changed
- [x] Translation changes: N/A — no catalogs changed
- [x] Server/plugin changes: focused tests ran
- [x] Desktop changes: N/A — no Desktop files changed
- [x] Docs/site changes: N/A — no docs/site files changed
- [x] UI changes: N/A — no visual change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md` is updated for user-visible changes, or N/A is listed above — N/A, defense-in-depth only
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above