### PR TITLE
test(android): refresh v1.14 What's New assertions

### DIFF
--- a/app/src/test/kotlin/com/hermesandroid/relay/screenshots/ChangelogHistoryScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/screenshots/ChangelogHistoryScreenshotTest.kt
@@ -25,7 +25,7 @@ class ChangelogHistoryScreenshotTest {
                 ChangelogScreen(onClose = {})
             }
         }
-        compose.onNodeWithText("Supervised Mode").assertExists()
+        compose.onNodeWithText("Reliable routes").assertExists()
         compose.onNodeWithText("Installed").assertExists()
         compose.onRoot().captureRoboImage("build/ui-regression/changelog-history.png")
     }

--- a/app/src/test/kotlin/com/hermesandroid/relay/screenshots/WhatsNewToastScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/screenshots/WhatsNewToastScreenshotTest.kt
@@ -61,9 +61,9 @@ class WhatsNewToastScreenshotTest {
                 }
             }
         }
-        compose.onNodeWithText("Supervised Mode").assertExists()
-        compose.onNodeWithText("Also: 2 fixes").assertExists()
-        compose.onNodeWithText("Accurate activity, safer return…").assertExists()
+        compose.onNodeWithText("Reliable routes").assertExists()
+        compose.onNodeWithText("Also: 2 features · 10 fixes").assertExists()
+        compose.onNodeWithText("delegated-agent previews, safer voice and sessions…").assertExists()
         compose.onNodeWithText("View all").assertExists()
         compose.onNodeWithContentDescription("Close").assertExists()
         compose.onRoot().captureRoboImage("build/ui-regression/whats-new-toast-large-text.png")
@@ -84,7 +84,7 @@ class WhatsNewToastScreenshotTest {
             }
         }
 
-        compose.onNodeWithText("Supervised Mode").performClick()
+        compose.onNodeWithText("Reliable routes").performClick()
         expanded = false
         compose.onNodeWithText("View all").performClick()
         compose.onNodeWithContentDescription("Close").performClick()
@@ -106,7 +106,7 @@ class WhatsNewToastScreenshotTest {
             }
         }
         compose.mainClock.advanceTimeBy(300L)
-        compose.onNodeWithText("Supervised Mode").performTouchInput { swipeLeft(durationMillis = 300L) }
+        compose.onNodeWithText("Reliable routes").performTouchInput { swipeLeft(durationMillis = 300L) }
         compose.mainClock.advanceTimeBy(300L)
 
         assertTrue(dismissed)


### PR DESCRIPTION
## Summary

Refresh the Android What's New and changelog UI tests to assert the bundled v1.14.0 release content instead of stale v1.13.2 copy.

## Changes

- Assert the v1.14.0 `Reliable routes` highlight in changelog history and toast interactions.
- Assert the current `2 features · 10 fixes` digest and preview copy.
- Keep production behavior and release assets unchanged; Roborazzi outputs remain generated build artifacts.

## Verification

- `./gradlew :app:testSideloadDebugUnitTest --tests com.hermesandroid.relay.screenshots.ChangelogHistoryScreenshotTest --tests com.hermesandroid.relay.screenshots.WhatsNewToastScreenshotTest --console=plain`
- `./gradlew :app:testSideloadDebugUnitTest --max-workers=1 --no-parallel --console=plain`
- `./gradlew lint --max-workers=1 --no-parallel --console=plain`
- `python scripts/check-android-release-notes.py`
- `python scripts/check-android-locales.py`
- Generated Roborazzi history and large-text toast frames inspected; no production visual change.
- Translation, server, desktop, and docs changes: N/A.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: lint and focused unit tests ran, or rationale is listed above
- [x] Translation changes: locale status/review references are accurate, `python scripts/check-android-locales.py` ran, and device/emulator review is documented, or N/A
- [x] Server changes: focused `python -m unittest ...` checks ran, or rationale is listed above
- [x] Desktop changes: `npm run build` or a narrower documented check ran, or rationale is listed above
- [x] Docs/site changes: docs build or link check ran, or rationale is listed above
- [x] UI changes were tested on emulator/device or desktop surface when applicable
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CHANGELOG.md updated (if user-facing)
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged work links the source PR and preserves contributor authorship, or N/A