### PR TITLE
fix(android): harden supervised Gateway setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **Android Bot Chats render loaded history immediately.** Route-owned chat screens observe their own handler state from first composition, including fast history loads that settle before another frame. (Supersedes #453.)
+- **Supervised Gateway setup stays parent-owned.** Add Gateway is single-flight and checks live parent authority before allocating a draft, relock/back cancels the exact pending setup, and the locked Chat footer no longer attempts protected navigation.
 
 ## [Android 1.14.0] - 2026-08-30
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/RelayApp.kt
@@ -144,6 +144,7 @@ import com.hermesandroid.relay.data.VoicePresentationMode
 import com.hermesandroid.relay.data.capabilities
 import com.hermesandroid.relay.data.displayLabel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -738,6 +739,10 @@ fun RelayApp() {
     val pendingAddConnectionJobs = remember {
         mutableMapOf<String, kotlinx.coroutines.Job>()
     }
+    var pendingAddConnectionTargetId by rememberSaveable { mutableStateOf<String?>(null) }
+    val pendingAddConnectionAbortJobs = remember {
+        mutableMapOf<String, kotlinx.coroutines.Job>()
+    }
     val prepareAddConnection: (String, Boolean) -> Unit = { id, retryRequested ->
         val existingJob = pendingAddConnectionJobs[id]
         if (shouldStartPairPreparation(existingJob?.isActive == true, retryRequested)) {
@@ -756,6 +761,25 @@ fun RelayApp() {
             }
             pendingAddConnectionJobs[id] = job
             job.start()
+        }
+    }
+    val abortAddConnection: (String) -> kotlinx.coroutines.Job = { id ->
+        pendingAddConnectionAbortJobs[id] ?: connectionSwitchScope.launch {
+            try {
+                pendingAddConnectionJobs.remove(id)?.cancelAndJoin()
+                connectionViewModel.discardPlaceholderConnection(id)
+            } finally {
+                if (pendingAddConnectionTargetId == id) {
+                    pendingAddConnectionTargetId = null
+                }
+            }
+        }.also { job ->
+            pendingAddConnectionAbortJobs[id] = job
+            job.invokeOnCompletion {
+                if (pendingAddConnectionAbortJobs[id] === job) {
+                    pendingAddConnectionAbortJobs.remove(id)
+                }
+            }
         }
     }
 
@@ -1351,6 +1375,9 @@ fun RelayApp() {
                 currentRoute = currentRoute,
             )
             if (redirect) {
+                pendingAddConnectionTargetId?.let { targetId ->
+                    abortAddConnection(targetId).join()
+                }
                 navController.navigate(Screen.Chat.route(openAgentSheet = false)) {
                     popUpTo(navController.graph.findStartDestination().id) { inclusive = false }
                     launchSingleTop = true
@@ -2113,10 +2140,20 @@ fun RelayApp() {
                         ?: AgentDisplay.displayModelName(serverModelName)
                         ?: stringResource(R.string.status_model_pending)
                     val footerModelLabel = compactFooterModelLabel(modelLabel)
-                    val openConnections = {
-                        navController.navigate(Screen.ConnectionsSettings.route) {
-                            launchSingleTop = true
+                    val openConnections: (() -> Unit)? = if (
+                        isSupervisedRouteContentAllowed(
+                            supervisedEnabled = supervisedPolicy.enabled,
+                            parentAccessUnlocked = parentAccessForCurrentRoute,
+                            currentRoute = Screen.ConnectionsSettings.route,
+                        )
+                    ) {
+                        {
+                            navController.navigate(Screen.ConnectionsSettings.route) {
+                                launchSingleTop = true
+                            }
                         }
+                    } else {
+                        null
                     }
                     RelayStatusStrip(
                         leadingBadge = {
@@ -3203,16 +3240,34 @@ fun RelayApp() {
                         addConnectionEnabled = mayStartAddConnection(
                             supervisedEnabled = supervisedPolicy.enabled,
                             parentAccessUnlocked = parentAccessForCurrentRoute,
+                            activeTargetId = pendingAddConnectionTargetId,
                         ),
-                        onAddConnection = {
-                            val id = java.util.UUID.randomUUID().toString()
+                        onAddConnection = addConnection@{
+                            val liveConnectionId = connectionViewModel.activeConnectionId.value
+                            val livePolicyState = supervisedPolicyState.value
+                                ?.takeIf { (ownerId, _) -> ownerId == liveConnectionId }
+                            val livePolicy = when {
+                                liveConnectionId == null -> SupervisedModePolicy()
+                                livePolicyState != null -> livePolicyState.second
+                                else -> return@addConnection
+                            }
+                            val liveRoute = navController.currentDestination?.route
+                            val liveParentAccess = parentAccessUnlocked &&
+                                !shouldRelockParentAccess(
+                                    supervisedEnabled = livePolicy.enabled,
+                                    parentAccessUnlocked = parentAccessUnlocked,
+                                    route = liveRoute,
+                                )
                             runAddConnectionAction(
-                                supervisedEnabled = supervisedPolicy.enabled,
-                                parentAccessUnlocked = parentAccessForCurrentRoute,
-                                navigateToPair = {
+                                supervisedEnabled = livePolicy.enabled,
+                                parentAccessUnlocked = liveParentAccess,
+                                activeTargetId = pendingAddConnectionTargetId,
+                                allocateTarget = { java.util.UUID.randomUUID().toString() },
+                                recordTarget = { id -> pendingAddConnectionTargetId = id },
+                                navigateToPair = { id ->
                                     navController.navigate(Screen.Pair.route(connectionId = id))
                                 },
-                                prepareConnection = { prepareAddConnection(id, false) },
+                                prepareConnection = { id -> prepareAddConnection(id, false) },
                             )
                         },
                         onBack = { navController.popBackStack() },
@@ -3356,9 +3411,15 @@ fun RelayApp() {
                             if (connectionIdArg != null && pairDraftId == connectionIdArg) {
                                 connectionSwitchScope.launch {
                                     connectionViewModel.commitConnectionDraft(connectionIdArg)
+                                    if (pendingAddConnectionTargetId == connectionIdArg) {
+                                        pendingAddConnectionTargetId = null
+                                    }
                                     navController.popBackStack()
                                 }
                             } else {
+                                if (pendingAddConnectionTargetId == connectionIdArg) {
+                                    pendingAddConnectionTargetId = null
+                                }
                                 navController.popBackStack()
                             }
                         },
@@ -3378,6 +3439,9 @@ fun RelayApp() {
                                     runCatching {
                                         connectionViewModel.commitConnectionDraft(targetId)
                                     }.onSuccess {
+                                        if (pendingAddConnectionTargetId == targetId) {
+                                            pendingAddConnectionTargetId = null
+                                        }
                                         android.util.Log.i(
                                             "GatewayPairFlow",
                                             "Opening Dashboard sign-in for staged gateway",
@@ -3414,14 +3478,12 @@ fun RelayApp() {
                             // never got a pairedAt stamp.
                             if (connectionIdArg != null) {
                                 connectionSwitchScope.launch {
-                                    // If Back wins the race with background
-                                    // preparation, wait until the placeholder
-                                    // exists before attempting to discard it.
-                                    pendingAddConnectionJobs.remove(connectionIdArg)?.join()
-                                    connectionViewModel.discardPlaceholderConnection(connectionIdArg)
+                                    abortAddConnection(connectionIdArg).join()
+                                    navController.popBackStack()
                                 }
+                            } else {
+                                navController.popBackStack()
                             }
-                            navController.popBackStack()
                         },
                     )
                 }

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicy.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicy.kt
@@ -15,18 +15,24 @@ internal fun isSupervisedRouteAllowed(route: String?, parentAccessUnlocked: Bool
 internal fun mayStartAddConnection(
     supervisedEnabled: Boolean,
     parentAccessUnlocked: Boolean,
-): Boolean = !supervisedEnabled || parentAccessUnlocked
+    activeTargetId: String? = null,
+): Boolean = activeTargetId == null && (!supervisedEnabled || parentAccessUnlocked)
 
 internal inline fun runAddConnectionAction(
     supervisedEnabled: Boolean,
     parentAccessUnlocked: Boolean,
-    navigateToPair: () -> Unit,
-    prepareConnection: () -> Unit,
-): Boolean {
-    if (!mayStartAddConnection(supervisedEnabled, parentAccessUnlocked)) return false
-    navigateToPair()
-    prepareConnection()
-    return true
+    activeTargetId: String?,
+    allocateTarget: () -> String,
+    recordTarget: (String) -> Unit,
+    navigateToPair: (String) -> Unit,
+    prepareConnection: (String) -> Unit,
+): String? {
+    if (!mayStartAddConnection(supervisedEnabled, parentAccessUnlocked, activeTargetId)) return null
+    val targetId = allocateTarget()
+    recordTarget(targetId)
+    navigateToPair(targetId)
+    prepareConnection(targetId)
+    return targetId
 }
 
 /** Do not inspect or mutate a NavController until its first destination exists. */

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/SupervisedNavigationPolicyTest.kt
@@ -40,32 +40,50 @@ class SupervisedNavigationPolicyTest {
     @Test fun `parent access or ordinary mode permits add gateway`() {
         assertTrue(mayStartAddConnection(supervisedEnabled = true, parentAccessUnlocked = true))
         assertTrue(mayStartAddConnection(supervisedEnabled = false, parentAccessUnlocked = false))
+        assertFalse(
+            mayStartAddConnection(
+                supervisedEnabled = false,
+                parentAccessUnlocked = true,
+                activeTargetId = "already-started",
+            ),
+        )
     }
 
-    @Test fun `locked add gateway action has no side effects`() {
-        var navigated = false
-        var prepared = false
-        val started = runAddConnectionAction(
+    @Test fun `locked add gateway action performs no allocation or side effects`() {
+        val actions = mutableListOf<String>()
+        val target = runAddConnectionAction(
             supervisedEnabled = true,
             parentAccessUnlocked = false,
-            navigateToPair = { navigated = true },
-            prepareConnection = { prepared = true },
-        )
-        assertFalse(started)
-        assertFalse(navigated)
-        assertFalse(prepared)
-    }
-
-    @Test fun `allowed add gateway action navigates before preparation`() {
-        val actions = mutableListOf<String>()
-        val started = runAddConnectionAction(
-            supervisedEnabled = true,
-            parentAccessUnlocked = true,
+            activeTargetId = null,
+            allocateTarget = { actions += "allocate"; "target" },
+            recordTarget = { actions += "record" },
             navigateToPair = { actions += "navigate" },
             prepareConnection = { actions += "prepare" },
         )
-        assertTrue(started)
-        assertTrue(actions == listOf("navigate", "prepare"))
+        assertTrue(target == null)
+        assertTrue(actions.isEmpty())
+    }
+
+    @Test fun `allowed add gateway action records target before navigation and preparation`() {
+        val actions = mutableListOf<String>()
+        val target = runAddConnectionAction(
+            supervisedEnabled = true,
+            parentAccessUnlocked = true,
+            activeTargetId = null,
+            allocateTarget = { actions += "allocate"; "target" },
+            recordTarget = { actions += "record:$it" },
+            navigateToPair = { actions += "navigate:$it" },
+            prepareConnection = { actions += "prepare:$it" },
+        )
+        assertTrue(target == "target")
+        assertTrue(
+            actions == listOf(
+                "allocate",
+                "record:target",
+                "navigate:target",
+                "prepare:target",
+            ),
+        )
     }
 
     @Test fun `supervised redirect waits until the navigation graph has a route`() {
@@ -75,6 +93,7 @@ class SupervisedNavigationPolicyTest {
         assertTrue(isSupervisedRouteContentAllowed(true, false, Screen.Chat.route))
         assertTrue(shouldRedirectSupervisedRoute(true, false, Screen.AdvancedSettings.route))
         assertFalse(isSupervisedRouteContentAllowed(true, false, Screen.AdvancedSettings.route))
+        assertFalse(isSupervisedRouteContentAllowed(true, false, Screen.ConnectionsSettings.route))
         assertFalse(shouldRedirectSupervisedRoute(true, true, Screen.AdvancedSettings.route))
         assertTrue(isSupervisedRouteContentAllowed(true, true, Screen.AdvancedSettings.route))
     }


### PR DESCRIPTION
## Summary

- Salvages and supersedes #467 while preserving contributor credit.
- Rechecks live, connection-owned parent authority before allocating an Add Gateway draft.
- Keeps setup single-flight and cleans the exact pending draft before a supervised relock redirect.
- Removes the locked footer's protected-navigation attempt, avoiding the loading-cover flash.

Closes #466.

## Changes

- Allocate and record one setup target only after the current supervised policy permits it.
- Disable repeated Add Gateway taps while that target is active.
- Cancel and discard the exact draft before returning to supervised Chat on relock or Back.
- Make the locked Chat footer non-clickable instead of relying on a later route redirect.
- Extend focused policy/order coverage for locked, unlocked, and active-target cases.

## Verification

- `./gradlew :app:testSideloadDebugUnitTest --rerun-tasks -Pkotlin.compiler.execution.strategy=in-process --max-workers=1 --no-daemon --no-build-cache --console=plain` — passed: 2,889 tests, 0 failures/errors, 12 skipped.
- Physical sideload device (SM-S938U, Android build 1.14.0-sideload) — confirmed locked Add blocking, rapid-tap single-flight behavior, automatic relock while Gateways remained mounted, clean Back/cancel behavior, and no footer loading flash.
- GitHub Required checks on exact head `7b390fa99`: Android build, lint, test, and sentinel all passed.

## Screenshots

No static screenshot. The change removes a transient forbidden-route/loading flash; physical-device behavior is documented above.

## Compatibility / risk

- Android-local navigation and transient draft ownership only.
- No server, Relay plugin, protocol, persistent-schema, permission, or upstream Hermes dependency change.
- Existing ordinary and parent-unlocked navigation-before-preparation behavior remains intact.

## Lineage / contributor credit

- Source PR(s): #467
- Attribution preserved by: `Co-authored-by` trailer on the salvage commit.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: full sideload unit suite and exact-head GitHub lint/build/test passed
- [x] Translation changes: N/A — existing localized guidance is unchanged
- [x] Server/plugin changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: N/A
- [x] UI changes were tested on a relevant physical device
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated
- [x] Public writing hygiene checked
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship
