### PR TITLE
chore(android): serialize Windows build lanes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,13 @@ configuration between invocations and do not add `--no-daemon` to normal dev
 commands; a different heap or Java home starts a separate daemon and discards
 the warm-process benefit.
 
+On Windows, all repository dev helpers serialize Android build and device work
+through one machine-wide lane shared by every Hermes-Relay worktree. Use
+`scripts/android-lane.ps1` for ad hoc Gradle, connected-test, and APK-install
+commands, and keep Android Studio idle while another owner holds the lane. See
+[Windows Android build lane](docs/android-build-lane.md) for the coordinator
+gate, status command, and exceptional recovery modes.
+
 Use the narrowest command that proves the change:
 
 1. `scripts/dev.bat compile` for a Kotlin compile check.

--- a/docs/android-build-lane.md
+++ b/docs/android-build-lane.md
@@ -1,0 +1,98 @@
+# Windows Android build lane
+
+Hermes-Relay uses one machine-wide Android build lane on Windows. Every local
+worktree shares the same named operating-system mutex through
+`scripts/android-lane.ps1`. When commands use the wrapper, Gradle, Kotlin
+compilation, lint, tests, assemblies, connected tests, and APK installation do
+not compete for the same host resources and shared caches.
+
+This is a local developer workflow. CI jobs run on separate hosts and are not
+affected.
+
+## Normal use
+
+The Windows `scripts/dev.bat` commands and `scripts/android-prepush.py` acquire
+the lane automatically. For an ad hoc Gradle command, use:
+
+```powershell
+.\scripts\android-lane.ps1 gradle `
+  :app:testSideloadDebugUnitTest `
+  --tests "*ChatViewModelTest*" `
+  --console=plain
+```
+
+The wrapper waits until the current owner exits and releases the mutex. Windows
+also releases the mutex if its owner crashes; the next waiter reports that it
+recovered an abandoned lane. Use Ctrl+C to cancel a waiter without stopping the
+owner. A bounded wait is available when a caller has its own deadline:
+
+```powershell
+.\scripts\android-lane.ps1 --timeout-seconds 900 gradle :app:lintSideloadDebug
+```
+
+Check the lane without starting work:
+
+```powershell
+.\scripts\android-lane.ps1 status
+```
+
+`status` exits 0 when idle and 1 when busy. It intentionally does not expose the
+owning process's arguments because Gradle properties can contain credentials.
+
+Use `exec` for a connected/device workflow that must exclude every
+wrapper-managed Gradle lane, including explicit APK installation:
+
+```powershell
+.\scripts\android-lane.ps1 exec python scripts/android-gateway-certify.py <arguments>
+.\scripts\android-lane.ps1 exec adb -t <transport-id> install -r <apk>
+```
+
+Raw `gradlew`, Android Studio sync/build/run, and raw `adb install` do not pass
+through the mutex. Before using one of those paths, check that the lane is idle
+and keep all queued wrappers idle until it finishes. During final integration,
+close or pause Android Studio's automatic Gradle activity and let one
+coordinator own the sequence.
+
+## Final coordinator gate
+
+Run the final gates serially on the exact candidate head. Keep each focused
+test invocation narrow so it releases the lane promptly for other queued work.
+The coordinator then runs, in order:
+
+1. Focused sideload unit tests.
+2. Focused Google Play unit and policy tests.
+3. Android lint.
+4. Sideload and Google Play assemblies (or the release-equivalent both-flavor gate).
+5. Connected/instrumentation and physical-device checks when the change needs them.
+6. The explicit APK install only after every preceding gate passes.
+
+Do not run lint, both-flavor builds, connected checks, or installation in
+parallel. A timeout from an outer agent or terminal is not evidence that Gradle
+failed; use the wrapper's process exit and Gradle output as the result.
+
+## Resource policy
+
+The normal serialized path retains the repository defaults:
+
+- the shared Gradle user home, wrapper distributions, dependency cache, build
+  cache, configuration cache, and compatible warm daemon;
+- `org.gradle.jvmargs=-Xmx4g`, `org.gradle.daemon=true`,
+  `org.gradle.caching=true`, `org.gradle.configuration-cache=true`, and
+  `org.gradle.parallel=true`;
+- Gradle's normal worker selection inside the one active invocation.
+
+`--max-workers` limits workers only inside one Gradle invocation. It does not
+prevent another worktree, Android Studio, or an APK-install lane from running.
+Likewise, `--no-daemon` can still start a single-use daemon to honor the required
+JVM settings; it is not a cross-process isolation mechanism.
+
+Use a worktree-specific `GRADLE_USER_HOME`, `--no-build-cache`,
+`--max-workers=1`, or `-Pkotlin.compiler.execution.strategy=in-process` only to
+recover from a confirmed daemon/cache failure or for an explicitly isolated
+exception. Those modes discard normal cache and warm-daemon benefits, can use
+more disk and memory, and must still acquire the Android lane.
+
+If recovery is required, first preserve the failing output and verify that no
+other owner is active. Do not kill unrelated Java, Gradle, Kotlin, Android
+Studio, or ADB processes merely to clear the lane; an OS-abandoned mutex is
+recoverable automatically.

--- a/docs/gateway-contract-testing.md
+++ b/docs/gateway-contract-testing.md
@@ -111,8 +111,8 @@ turn is live. The external lane consumes the shared Python fixture and reads
 its authoritative history over HTTP.
 
 ```powershell
-.\gradlew.bat :app:compileSideloadDebugAndroidTestKotlin
-.\gradlew.bat :app:assembleSideloadDebug :app:assembleSideloadDebugAndroidTest
+.\scripts\android-lane.ps1 gradle :app:compileSideloadDebugAndroidTestKotlin
+.\scripts\android-lane.ps1 gradle :app:assembleSideloadDebug :app:assembleSideloadDebugAndroidTest
 ```
 
 The external test is opt-in through the instrumentation argument
@@ -126,7 +126,7 @@ transport ID, targets only `com.axiomlabs.hermesrelay.sideload`, and performs no
 installation unless its corresponding install flag is supplied.
 
 ```powershell
-python scripts/android-gateway-certify.py `
+.\scripts\android-lane.ps1 exec python scripts/android-gateway-certify.py `
   --transport-id <adb-transport-id> `
   --apk app/build/outputs/apk/sideload/debug/<sideload-apk> `
   --test-apk app/build/outputs/apk/androidTest/sideload/debug/<test-apk> `

--- a/scripts/android-lane.ps1
+++ b/scripts/android-lane.ps1
@@ -1,0 +1,141 @@
+# Hermes-Relay's machine-wide Windows lane for Gradle and Android device work.
+# Every worktree uses the same named mutex. Keep this script dependency-free so
+# it can run under the Windows PowerShell bundled with Windows.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$mutexName = "Global\HermesRelay.AndroidBuildLane.v1"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+function Show-Usage {
+    Write-Host @"
+Usage:
+  .\scripts\android-lane.ps1 status
+  .\scripts\android-lane.ps1 [--timeout-seconds <seconds>] gradle <gradle-args...>
+  .\scripts\android-lane.ps1 [--timeout-seconds <seconds>] exec <command> <args...>
+
+Examples:
+  .\scripts\android-lane.ps1 gradle :app:testSideloadDebugUnitTest --tests "*ChatViewModelTest*"
+  .\scripts\android-lane.ps1 exec python scripts/android-gateway-certify.py --help
+
+The default wait is unbounded. Ctrl+C cancels a waiter without affecting the
+current owner. Use exec for connected-test or APK-install workflows that must
+serialize with wrapper-managed Gradle lanes. Keep Android Studio idle separately.
+"@
+}
+
+function New-AndroidLaneMutex {
+    try {
+        return [System.Threading.Mutex]::new($false, $mutexName)
+    }
+    catch [System.UnauthorizedAccessException] {
+        throw "The machine-wide Hermes-Relay Android lane exists but this Windows account cannot open it. Run all worktrees under the same account or correct the mutex permissions."
+    }
+}
+
+function Test-AcquireMutex {
+    param(
+        [System.Threading.Mutex] $Mutex,
+        [TimeSpan] $Wait
+    )
+
+    try {
+        return $Mutex.WaitOne($Wait)
+    }
+    catch [System.Threading.AbandonedMutexException] {
+        Write-Warning "The previous Android lane owner exited without releasing the mutex; ownership was recovered."
+        return $true
+    }
+}
+
+$tokens = @($args)
+if ($tokens.Count -eq 0 -or $tokens[0] -in @("help", "--help", "-h")) {
+    Show-Usage
+    exit 0
+}
+
+$timeoutSeconds = 0
+if ($tokens[0] -eq "--timeout-seconds") {
+    if ($tokens.Count -lt 3) {
+        throw "--timeout-seconds requires a non-negative integer and a mode."
+    }
+    $parsedTimeout = 0
+    if (-not [int]::TryParse($tokens[1], [ref] $parsedTimeout) -or $parsedTimeout -lt 0) {
+        throw "--timeout-seconds must be a non-negative integer."
+    }
+    $timeoutSeconds = $parsedTimeout
+    $tokens = @($tokens[2..($tokens.Count - 1)])
+}
+
+$mode = $tokens[0]
+$mutex = New-AndroidLaneMutex
+$acquired = $false
+
+try {
+    if ($mode -eq "status") {
+        $acquired = Test-AcquireMutex -Mutex $mutex -Wait ([TimeSpan]::Zero)
+        if ($acquired) {
+            Write-Host "Hermes-Relay Android lane: IDLE"
+            $mutex.ReleaseMutex()
+            $acquired = $false
+            exit 0
+        }
+        Write-Host "Hermes-Relay Android lane: BUSY"
+        exit 1
+    }
+
+    if ($mode -notin @("gradle", "exec")) {
+        throw "Unknown mode '$mode'. Use status, gradle, or exec."
+    }
+    if ($mode -eq "exec" -and $tokens.Count -lt 2) {
+        throw "exec requires a command."
+    }
+
+    $waitDescription = if ($timeoutSeconds -eq 0) { "without a timeout" } else { "for up to $timeoutSeconds seconds" }
+    Write-Host "Waiting for the machine-wide Hermes-Relay Android lane $waitDescription..."
+
+    $startedWaiting = [System.Diagnostics.Stopwatch]::StartNew()
+    while (-not $acquired) {
+        $sliceSeconds = 30
+        if ($timeoutSeconds -gt 0) {
+            $remaining = $timeoutSeconds - [int][Math]::Floor($startedWaiting.Elapsed.TotalSeconds)
+            if ($remaining -le 0) {
+                throw "Timed out waiting for the machine-wide Hermes-Relay Android lane after $timeoutSeconds seconds."
+            }
+            $sliceSeconds = [Math]::Min($sliceSeconds, $remaining)
+        }
+        $acquired = Test-AcquireMutex -Mutex $mutex -Wait ([TimeSpan]::FromSeconds($sliceSeconds))
+        if (-not $acquired) {
+            Write-Host "Still waiting for the Hermes-Relay Android lane ($([int]$startedWaiting.Elapsed.TotalSeconds)s elapsed)..."
+        }
+    }
+
+    Write-Host "Acquired the machine-wide Hermes-Relay Android lane."
+    Push-Location $repoRoot
+    try {
+        if ($mode -eq "gradle") {
+            $executable = Join-Path $repoRoot "gradlew.bat"
+            $commandArguments = if ($tokens.Count -gt 1) { @($tokens[1..($tokens.Count - 1)]) } else { @() }
+        }
+        else {
+            $executable = $tokens[1]
+            $commandArguments = if ($tokens.Count -gt 2) { @($tokens[2..($tokens.Count - 1)]) } else { @() }
+        }
+
+        & $executable @commandArguments
+        $commandExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+    }
+    finally {
+        Pop-Location
+    }
+
+    exit $commandExitCode
+}
+finally {
+    if ($acquired) {
+        $mutex.ReleaseMutex()
+        Write-Host "Released the machine-wide Hermes-Relay Android lane."
+    }
+    $mutex.Dispose()
+}

--- a/scripts/android-prepush.py
+++ b/scripts/android-prepush.py
@@ -86,13 +86,23 @@ def main() -> int:
         print("\nAndroid repository checks passed.")
         return 0
 
-    wrapper = REPO_ROOT / ("gradlew.bat" if sys.platform == "win32" else "gradlew")
-    gradle = [
-        str(wrapper),
+    if sys.platform == "win32":
+        gradle = [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPO_ROOT / "scripts" / "android-lane.ps1"),
+            "gradle",
+        ]
+    else:
+        gradle = [str(REPO_ROOT / "gradlew")]
+    gradle.extend([
         "--console=plain",
         "--configuration-cache",
         *tasks,
-    ]
+    ])
     if not args.skip_tests:
         for test_name in FOCUSED_TESTS:
             gradle.extend(("--tests", test_name))

--- a/scripts/dev.bat
+++ b/scripts/dev.bat
@@ -4,6 +4,11 @@ REM Usage: scripts\dev.bat <command>
 
 cd /d "%~dp0\.."
 
+REM Secondary worktrees normally do not carry local.properties. Reuse the
+REM standard per-user SDK location when the caller has not selected one.
+if not defined ANDROID_HOME if exist "%LOCALAPPDATA%\Android\Sdk" set "ANDROID_HOME=%LOCALAPPDATA%\Android\Sdk"
+if not defined ANDROID_SDK_ROOT if defined ANDROID_HOME set "ANDROID_SDK_ROOT=%ANDROID_HOME%"
+
 if "%1"=="" goto help
 if "%1"=="build" goto build
 if "%1"=="release" goto release
@@ -27,14 +32,15 @@ goto help
 
 :build
 echo Building sideload debug APK...
-call gradlew.bat :app:assembleSideloadDebug --console=plain
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:assembleSideloadDebug --console=plain
+if errorlevel 1 exit /b %errorlevel%
 echo APK: app\build\outputs\apk\sideload\debug\
 goto end
 
 :release
 echo Building release APK...
-call gradlew.bat assembleRelease
-if errorlevel 1 goto end
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle assembleRelease
+if errorlevel 1 exit /b %errorlevel%
 echo.
 echo Release APK:
 dir /b app\build\outputs\apk\release\*.apk 2>nul
@@ -43,8 +49,8 @@ goto end
 
 :bundle
 echo Building release AAB (for Google Play upload)...
-call gradlew.bat bundleRelease
-if errorlevel 1 goto end
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle bundleRelease
+if errorlevel 1 exit /b %errorlevel%
 echo.
 echo Release AAB:
 dir /b app\build\outputs\bundle\release\*.aab 2>nul
@@ -53,8 +59,8 @@ goto end
 
 :install
 echo Building and installing sideload debug to connected device...
-call gradlew.bat :app:installSideloadDebug --console=plain
-if errorlevel 1 goto end
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:installSideloadDebug --console=plain
+if errorlevel 1 exit /b %errorlevel%
 echo Launching app...
 REM Explicit FQCN: the sideload applicationId includes the flavor suffix but the
 REM namespace (and thus the real class FQCN) is still com.hermesandroid.relay,
@@ -64,8 +70,8 @@ goto end
 
 :run
 echo Building, installing, and launching sideload debug...
-call gradlew.bat :app:installSideloadDebug --console=plain
-if errorlevel 1 goto end
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:installSideloadDebug --console=plain
+if errorlevel 1 exit /b %errorlevel%
 REM Explicit FQCN: the sideload applicationId includes the flavor suffix but the
 REM namespace (and thus the real class FQCN) is still com.hermesandroid.relay,
 REM so the `.MainActivity` shorthand no longer resolves correctly.
@@ -75,7 +81,8 @@ goto end
 
 :compile
 echo Compiling sideload debug Kotlin...
-call gradlew.bat :app:compileSideloadDebugKotlin --console=plain
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:compileSideloadDebugKotlin --console=plain
+if errorlevel 1 exit /b %errorlevel%
 goto end
 
 :testone
@@ -84,35 +91,40 @@ if "%~2"=="" (
     exit /b 2
 )
 echo Running focused sideload test: %~2
-call gradlew.bat :app:testSideloadDebugUnitTest --tests "%~2" --console=plain
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:testSideloadDebugUnitTest --tests "%~2" --console=plain
+if errorlevel 1 exit /b %errorlevel%
 goto end
 
 :installfast
 echo Building arm64 sideload debug and installing to connected phone...
-call gradlew.bat :app:installSideloadDebug -Phermes.devAbi=arm64-v8a --console=plain
-if errorlevel 1 goto end
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:installSideloadDebug -Phermes.devAbi=arm64-v8a --console=plain
+if errorlevel 1 exit /b %errorlevel%
 echo Launching app...
 adb shell am start -n com.axiomlabs.hermesrelay.sideload/com.hermesandroid.relay.MainActivity
 goto end
 
 :test
 echo Running sideload debug unit tests...
-call gradlew.bat :app:testSideloadDebugUnitTest --console=plain
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:testSideloadDebugUnitTest --console=plain
+if errorlevel 1 exit /b %errorlevel%
 goto end
 
 :lint
 echo Running sideload debug lint...
-call gradlew.bat :app:lintSideloadDebug --console=plain
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle :app:lintSideloadDebug --console=plain
+if errorlevel 1 exit /b %errorlevel%
 goto end
 
 :prepush
 echo Running Android pre-push checks...
 python scripts\android-prepush.py
+if errorlevel 1 exit /b %errorlevel%
 goto end
 
 :clean
 echo Cleaning build...
-call gradlew.bat clean
+call powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 gradle clean
+if errorlevel 1 exit /b %errorlevel%
 goto end
 
 :devices


### PR DESCRIPTION
## Summary

Serialize Windows Gradle and Android device workflows across Hermes-Relay worktrees with one machine-wide mutex. The normal path keeps the shared daemon, dependency cache, build cache, and configuration cache.

## Changes

- Add `scripts/android-lane.ps1` with queue status, bounded waits, abandoned-owner recovery, Gradle execution, and connected-device command support.
- Route Windows dev helpers, pre-push Gradle checks, and Gateway certification examples through the shared lane.
- Preserve Gradle exit codes and discover the standard Android SDK location in secondary worktrees.
- Document the final serial test, lint, both-flavor build, connected-test, and APK-install sequence plus exceptional recovery modes.

## Verification

- `cmd /c scripts\dev.bat test-one "com.hermesandroid.relay.network.ArchitectureBoundaryTest"` — passed.
- Real cross-process contention probe — second caller reported busy, waited, acquired the lane, and returned it to idle.
- Wrapped command exit-code probe — exit code `7` propagated unchanged.
- Negative Gradle test selection — `dev.bat` propagated exit code `1`.
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\android-lane.ps1 --timeout-seconds 60 gradle help --console=plain` — passed.
- `python -m py_compile scripts/android-prepush.py` — passed.
- Full Android lint, assemblies, and device installation were not run because this changes developer tooling and documentation, not application source or runtime behavior.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Android changes: focused unit tests ran; full lint is not applicable to the tooling-only change
- [x] Translation changes: N/A
- [x] Server changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: link targets and command examples were checked; no rendered site behavior changed
- [x] UI changes: N/A
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md: N/A for an internal developer workflow
- [x] Public writing hygiene checked
- [x] Lineage/contributor credit: N/A