### PR TITLE
fix(android): retain generated image results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Android Bot Chats render loaded history immediately.** Route-owned chat screens observe their own handler state from first composition, including fast history loads that settle before another frame. (Supersedes #453.)
 - **Supervised Gateway setup stays parent-owned.** Add Gateway is single-flight and checks live parent authority before allocating a draft, relock/back cancels the exact pending setup, and the locked Chat footer no longer attempts protected navigation.
+- **Generated images stay visible and use their intended Chat animation.** Completed image media survives a marker-lagging history refresh, and both the built-in `image_generate` tool and profile tools ending in `_create_image` use the image-generation presentation.
 
 ## [Android 1.14.0] - 2026-08-30
 

--- a/app/src/main/kotlin/com/hermesandroid/relay/data/ChatMessage.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/data/ChatMessage.kt
@@ -11,6 +11,16 @@ package com.hermesandroid.relay.data
 enum class AttachmentState { LOADING, LOADED, FAILED }
 
 /**
+ * Gateway tool events do not yet expose an output kind before completion.
+ * Recognize the upstream built-in plus the profile-tool naming convention used
+ * for image generators without guessing from generic prompt arguments.
+ */
+internal fun isImageGenerationToolName(name: String): Boolean {
+    val normalized = name.trim().lowercase()
+    return normalized == "image_generate" || normalized.endsWith("_create_image")
+}
+
+/**
  * How the UI should render a loaded attachment. Derived from the MIME type.
  * - [IMAGE]  inline image (decode bytes / load URI).
  * - [VIDEO]  file card with play icon, tap opens ACTION_VIEW.

--- a/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/network/upstream/ChatHandler.kt
@@ -13,6 +13,7 @@ import com.hermesandroid.relay.data.MessageRole
 import com.hermesandroid.relay.data.MoaReference
 import com.hermesandroid.relay.data.RealtimeTurnTrace
 import com.hermesandroid.relay.data.ToolCall
+import com.hermesandroid.relay.data.isImageGenerationToolName
 import com.hermesandroid.relay.data.VoiceIntentTrace
 import com.hermesandroid.relay.network.shared.LocalDispatchResult
 import com.hermesandroid.relay.network.upstream.models.MessageItem
@@ -1499,11 +1500,13 @@ class ChatHandler {
 
             // Run the media marker parser on assistant content; strip matched
             // lines and queue hits for post-assignment dispatch.
+            val messageMediaHits = mutableListOf<Pair<String, MediaMarkerHit>>()
             val afterMedia = if (role == MessageRole.ASSISTANT && persistedImages.cleanedText.isNotEmpty()) {
-                extractMediaMarkersFromContent(messageId, persistedImages.cleanedText, pendingMediaHits)
+                extractMediaMarkersFromContent(messageId, persistedImages.cleanedText, messageMediaHits)
             } else {
                 persistedImages.cleanedText
             }
+            pendingMediaHits += messageMediaHits
 
             // Cards are synchronous (no async fetch) so we attach them
             // straight onto the reconstructed ChatMessage and strip their
@@ -1537,15 +1540,25 @@ class ChatHandler {
             val prior = priorById[messageId]
             // Outbound attachments: prefer an id-match (covers any future
             // user-message id reconciliation), else fall back to the
-            // content-keyed queue. Inbound attachments are intentionally
-            // excluded — they come back via the marker re-dispatch.
+            // content-keyed queue. Inbound attachments normally come back via
+            // marker re-dispatch. One narrow exception retains a completed
+            // image_generate result when the immediate post-turn history read
+            // still lacks its MEDIA marker; otherwise the rendered image
+            // disappears during the persistence-lag window.
             val carriedAttachments = run {
                 val persistedImagePaths = persistedImages.paths.toHashSet()
+                val priorGeneratedImage = prior?.toolCalls.orEmpty().any { tool ->
+                    isImageGenerationToolName(tool.name) &&
+                        tool.isComplete && tool.success != false
+                }
                 val byId = prior?.attachments.orEmpty().filter { attachment ->
                     attachment.relayToken == null ||
+                        (role == MessageRole.USER && attachment.relayToken in persistedImagePaths) ||
                         (
-                            role == MessageRole.USER &&
-                                attachment.relayToken in persistedImagePaths
+                            role == MessageRole.ASSISTANT &&
+                                priorGeneratedImage &&
+                                attachment.isImage &&
+                                messageMediaHits.isEmpty()
                             )
                 }
                 when {

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholder.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholder.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.annotation.RequiresApi
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.data.ToolCall
+import com.hermesandroid.relay.data.isImageGenerationToolName
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import java.util.Locale
@@ -65,7 +66,6 @@ import kotlin.math.cos
 import kotlin.math.floor
 import kotlin.math.sin
 
-private const val IMAGE_GENERATION_TOOL = "image_generate"
 private const val GRID_COLUMNS = 42
 private const val GRID_ROWS = 24
 private const val DEFAULT_ANIMATION_DURATION_MS = 4_800
@@ -134,11 +134,11 @@ internal fun resolveImageGenerationVisualStyle(
 }
 
 internal fun ToolCall.showsImageGenerationPlaceholder(): Boolean =
-    !isComplete && name.trim().lowercase() == IMAGE_GENERATION_TOOL
+    !isComplete && isImageGenerationToolName(name)
 
 internal fun imageGenerationStartedAt(toolCalls: List<ToolCall>): Long? =
     toolCalls.lastOrNull {
-        it.name.trim().lowercase() == IMAGE_GENERATION_TOOL
+        isImageGenerationToolName(it.name)
     }?.startedAt
 
 internal fun formatGenerationDuration(elapsedMillis: Long): String =
@@ -155,7 +155,7 @@ internal fun shouldShowImageGenerationPlaceholder(
     hasMediaResult: Boolean,
 ): Boolean {
     val imageCalls = toolCalls.filter {
-        it.name.trim().lowercase() == IMAGE_GENERATION_TOOL
+        isImageGenerationToolName(it.name)
     }
     if (imageCalls.any { !it.isComplete }) return true
     return !hasMediaResult &&

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MessageBubble.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/MessageBubble.kt
@@ -83,6 +83,7 @@ import com.hermesandroid.relay.data.HermesCardAction
 import com.hermesandroid.relay.data.MediaSettingsRepository
 import com.hermesandroid.relay.data.MessageDeliveryStatus
 import com.hermesandroid.relay.data.MessageRole
+import com.hermesandroid.relay.data.isImageGenerationToolName
 import com.hermesandroid.relay.data.parseChatQuotedPrompt
 import com.hermesandroid.relay.ui.components.pet.petObstacleSurface
 import com.hermesandroid.relay.ui.components.pet.petPerchSurface
@@ -292,9 +293,7 @@ fun MessageBubble(
         append(streamingStatusLabel ?: visibleMessageContent.take(100))
     }
     val hasImageGenerationCall = remember(message.toolCalls) {
-        message.toolCalls.any {
-            it.name.trim().lowercase() == "image_generate"
-        }
+        message.toolCalls.any { isImageGenerationToolName(it.name) }
     }
     val imageGenerationStartMillis = remember(message.toolCalls) {
         imageGenerationStartedAt(message.toolCalls)

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ToolActivityRun.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/components/ToolActivityRun.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hermesandroid.relay.R
 import com.hermesandroid.relay.data.ToolCall
+import com.hermesandroid.relay.data.isImageGenerationToolName
 import com.hermesandroid.relay.ui.components.pet.petObstacleSurface
 
 private val TOOL_ACTIVITY_PET_ROUTES = setOf("chat")
@@ -101,7 +102,8 @@ internal fun ToolCall.requiresStandaloneToolSurface(): Boolean {
         !error.isNullOrBlank() ||
         outputRisk != null ||
         normalized in FILE_EDIT_TOOLS ||
-        normalized in ATTENTION_TOOLS
+        normalized in ATTENTION_TOOLS ||
+        isImageGenerationToolName(name)
 }
 
 internal data class ToolActivityCounts(

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/ChatScreen.kt
@@ -265,6 +265,7 @@ import com.hermesandroid.relay.ui.components.ToolTranscriptItem
 import com.hermesandroid.relay.ui.components.groupTranscriptTools
 import com.hermesandroid.relay.ui.components.isVisibleForToolDisplay
 import com.hermesandroid.relay.ui.components.showsImageGenerationPlaceholder
+import com.hermesandroid.relay.data.isImageGenerationToolName
 import com.hermesandroid.relay.ui.components.VoiceModeOverlay
 import com.hermesandroid.relay.ui.LocalSnackbarHost
 import com.hermesandroid.relay.ui.showHumanError
@@ -1228,7 +1229,7 @@ fun ChatScreen(
         buildMap {
             messages.forEach { message ->
                 val generationCount = message.toolCalls.count {
-                    it.name.trim().equals("image_generate", ignoreCase = true)
+                    isImageGenerationToolName(it.name)
                 }
                 if (generationCount > 0) {
                     put(message.uiKey, nextOrdinal + generationCount - 1)

--- a/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/viewmodel/ChatViewModel.kt
@@ -126,6 +126,7 @@ import com.hermesandroid.relay.notifications.InteractionRequestNotifier
 import com.hermesandroid.relay.reliability.ReliabilityCenter
 import com.hermesandroid.relay.reliability.SessionResetEvidence
 import com.hermesandroid.relay.ui.components.ServerImageResult
+import com.hermesandroid.relay.data.isImageGenerationToolName
 import com.hermesandroid.relay.ui.components.SlashCommand
 import com.hermesandroid.relay.voice.RealtimeTurnSyncBuilder
 import com.hermesandroid.relay.voice.VoiceIntentSyncBuilder
@@ -9566,7 +9567,7 @@ class ChatViewModel : ViewModel() {
             ensurePostInterimMessage()
             streamDeltas.flushNow()
             val alreadyObserved =
-                toolName == "image_generate" &&
+                isImageGenerationToolName(toolName) &&
                     observedImageToolStates.putIfAbsent(toolCallId, "running") != null
             if (!alreadyObserved) {
                 handler.onToolCallStart(currentMessageId, toolCallId, toolName, argsPreview)

--- a/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ChatHandlerTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/network/upstream/ChatHandlerTest.kt
@@ -1531,6 +1531,86 @@ class ChatHandlerTest {
     }
 
     @Test
+    fun loadMessageHistory_preservesCompletedGeneratedImageUntilMarkerPersists() {
+        handler.addPlaceholderMessage(
+            ChatMessage(
+                id = "assistant-live-image",
+                role = MessageRole.ASSISTANT,
+                content = "Here is the generated image.",
+                timestamp = 1L,
+                attachments = listOf(
+                    Attachment(
+                        contentType = "image/png",
+                        content = "",
+                        fileName = "generated.png",
+                        relayToken = "/tmp/generated.png",
+                        state = AttachmentState.LOADED,
+                    ),
+                ),
+                toolCalls = listOf(
+                    ToolCall(
+                        id = "image-call",
+                        name = "willow_create_image",
+                        args = null,
+                        result = "success",
+                        success = true,
+                        isComplete = true,
+                    ),
+                ),
+            ),
+        )
+
+        handler.loadMessageHistory(
+            listOf(
+                MessageItem(
+                    id = "assistant-server-image",
+                    role = "assistant",
+                    content = JsonPrimitive("Here is the generated image."),
+                ),
+            ),
+        )
+
+        val message = handler.messages.value.single()
+        assertEquals("assistant-server-image", message.id)
+        assertEquals("assistant-live-image", message.uiKey)
+        assertEquals(1, message.attachments.size)
+        assertEquals("generated.png", message.attachments.single().fileName)
+    }
+
+    @Test
+    fun loadMessageHistory_doesNotCarryUnownedAssistantInboundImage() {
+        handler.addPlaceholderMessage(
+            ChatMessage(
+                id = "assistant-live-generic",
+                role = MessageRole.ASSISTANT,
+                content = "A generic fetched image.",
+                timestamp = 1L,
+                attachments = listOf(
+                    Attachment(
+                        contentType = "image/png",
+                        content = "",
+                        fileName = "generic.png",
+                        relayToken = "generic-token",
+                        state = AttachmentState.LOADED,
+                    ),
+                ),
+            ),
+        )
+
+        handler.loadMessageHistory(
+            listOf(
+                MessageItem(
+                    id = "assistant-server-generic",
+                    role = "assistant",
+                    content = JsonPrimitive("A generic fetched image."),
+                ),
+            ),
+        )
+
+        assertTrue(handler.messages.value.single().attachments.isEmpty())
+    }
+
+    @Test
     fun loadMessageHistory_consumesOutboundAttachmentOncePerDuplicateContent() {
         // Two identical-text sends, only the first with an attachment: the
         // attachment must land on exactly one reloaded row, not both.

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholderTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ImageGenerationPlaceholderTest.kt
@@ -26,6 +26,7 @@ class ImageGenerationPlaceholderTest {
         )
 
         assertTrue(active.showsImageGenerationPlaceholder())
+        assertTrue(active.copy(name = "willow_create_image").showsImageGenerationPlaceholder())
         assertFalse(active.copy(isComplete = true, success = true).showsImageGenerationPlaceholder())
         assertFalse(active.copy(name = "video_generate").showsImageGenerationPlaceholder())
     }

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ToolActivityRunTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/components/ToolActivityRunTest.kt
@@ -28,6 +28,7 @@ class ToolActivityRunTest {
         val standalone = listOf(
             call("risk", "read_file").copy(outputRisk = "high"),
             call("image", "image_generate"),
+            call("profile-image", "willow_create_image"),
             call("approval", "request_user_input"),
             call("delegate", "delegate_task"),
         )


### PR DESCRIPTION
## Summary

- Keep completed generated-image media visible when post-turn history arrives before its `MEDIA:` marker is persisted.
- Preserve ordinary marker re-dispatch behavior for unrelated inbound assistant images, avoiding duplicate attachments.
- Recognize the built-in `image_generate` tool and profile tools ending in `_create_image` as the same image-generation presentation.

## Changes

- Carry forward only successful, completed image-generation attachments when the refreshed server row has no media marker yet.
- Add a negative control proving generic inbound assistant images are not retained by this exception.
- Centralize the narrow image-tool name classifier and use it for progress animation, result transition, tool grouping, rotation order, activity deduplication, and reconciliation.
- Add `willow_create_image` coverage for the profile-tool convention.

## Verification

- Forced focused sideload tests for `ChatHandlerTest`, `ImageGenerationPlaceholderTest`, `ToolActivityRunTest`, and the adjacent supervised policy slice — passed.
- Physical sideload device (SM-S938U, Android 1.14.0-sideload) — generated images display and remain visible after completion/history refresh; the observed profile tool was `willow_create_image`.
- `./gradlew :app:testSideloadDebugUnitTest --rerun-tasks -Pkotlin.compiler.execution.strategy=in-process --max-workers=1 --no-daemon --no-build-cache --console=plain` — passed: 2,892 tests, 0 failures/errors, 12 skipped.`r`n- GitHub exact-head checks passed: Android build, lint, test, vanilla-upstream contract, and Required checks.

## Screenshots

No static screenshot. Physical-device behavior is documented above.

## Compatibility / risk

- Android-local presentation and history reconciliation only.
- No image provider, server, Relay plugin, protocol, permission, or persistent-schema change.
- The name classifier is intentionally narrow: exact `image_generate` or suffix `_create_image`; it does not infer from generic arguments.

## Lineage / contributor credit

- Source PR(s): N/A — this is the independent generated-image follow-up separated from the #467 salvage.
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Scope is focused
- [x] Android changes: full suite and exact-head CI passed
- [x] Translation changes: N/A
- [x] Server/plugin changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: N/A
- [x] UI behavior was tested on a physical device
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated
- [x] Public writing hygiene checked
- [x] Salvaged/replacement lineage: N/A
