### PR TITLE
fix(ci): route Android presets through registered workflow

### DIFF
--- a/.github/workflows/android-on-demand.yml
+++ b/.github/workflows/android-on-demand.yml
@@ -3,23 +3,14 @@ name: Android On-Demand
 run-name: Android ${{ inputs.preset }} · ${{ inputs.head_sha }}
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       head_sha:
-        description: Exact pushed commit SHA to verify
         required: true
         type: string
       preset:
-        description: Android verification lane
         required: true
-        default: focused
-        type: choice
-        options:
-          - focused
-          - lint
-          - assemble-debug
-          - release-smoke
-          - all-final
+        type: string
 
 permissions:
   contents: read
@@ -38,11 +29,19 @@ jobs:
         shell: bash
         env:
           REQUESTED_SHA: ${{ inputs.head_sha }}
+          REQUESTED_PRESET: ${{ inputs.preset }}
         run: |
           if [[ ! "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "head_sha must be a full lowercase 40-character commit SHA" >&2
             exit 2
           fi
+          case "$REQUESTED_PRESET" in
+            focused|lint|assemble-debug|release-smoke|all-final) ;;
+            *)
+              echo "unsupported Android preset: $REQUESTED_PRESET" >&2
+              exit 2
+              ;;
+          esac
 
       - name: Checkout exact commit
         uses: actions/checkout@v7

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -20,13 +20,25 @@ on:
         description: "Exact candidate commit to check"
         required: true
         type: string
+      android_preset:
+        description: "Optional Android-only compute lane"
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - focused
+          - lint
+          - assemble-debug
+          - release-smoke
+          - all-final
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: ci-required-${{ github.ref }}
+  group: ci-required-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', inputs.head_sha, inputs.android_preset) || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -113,33 +125,41 @@ jobs:
 
   android:
     needs: changes
-    if: needs.changes.outputs.android == 'true'
+    if: needs.changes.outputs.android == 'true' && (github.event_name != 'workflow_dispatch' || inputs.android_preset == 'auto')
     uses: ./.github/workflows/ci-android.yml
+
+  android_on_demand:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' && inputs.android_preset != 'auto'
+    uses: ./.github/workflows/android-on-demand.yml
+    with:
+      head_sha: ${{ inputs.head_sha }}
+      preset: ${{ inputs.android_preset }}
 
   desktop:
     needs: changes
-    if: needs.changes.outputs.desktop == 'true'
+    if: needs.changes.outputs.desktop == 'true' && (github.event_name != 'workflow_dispatch' || inputs.android_preset == 'auto')
     uses: ./.github/workflows/ci-desktop.yml
 
   plugin:
     needs: changes
-    if: needs.changes.outputs.plugin == 'true'
+    if: needs.changes.outputs.plugin == 'true' && (github.event_name != 'workflow_dispatch' || inputs.android_preset == 'auto')
     uses: ./.github/workflows/ci-plugin.yml
 
   dashboard:
     needs: changes
-    if: needs.changes.outputs.dashboard == 'true'
+    if: needs.changes.outputs.dashboard == 'true' && (github.event_name != 'workflow_dispatch' || inputs.android_preset == 'auto')
     uses: ./.github/workflows/ci-dashboard.yml
 
   contract:
     needs: changes
-    if: needs.changes.outputs.contract == 'true'
+    if: needs.changes.outputs.contract == 'true' && (github.event_name != 'workflow_dispatch' || inputs.android_preset == 'auto')
     uses: ./.github/workflows/ci-contract.yml
 
   docs:
     name: Build public docs
     needs: changes
-    if: needs.changes.outputs.docs == 'true'
+    if: needs.changes.outputs.docs == 'true' && (github.event_name != 'workflow_dispatch' || inputs.android_preset == 'auto')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -161,11 +181,12 @@ jobs:
   guard:
     name: Required checks
     if: always()
-    needs: [changes, android, desktop, plugin, dashboard, contract, docs]
+    needs: [changes, android, android_on_demand, desktop, plugin, dashboard, contract, docs]
     runs-on: ubuntu-latest
     env:
       CHANGES_RESULT: ${{ needs.changes.result }}
       ANDROID_RESULT: ${{ needs.android.result }}
+      ANDROID_ON_DEMAND_RESULT: ${{ needs.android_on_demand.result }}
       DESKTOP_RESULT: ${{ needs.desktop.result }}
       PLUGIN_RESULT: ${{ needs.plugin.result }}
       DASHBOARD_RESULT: ${{ needs.dashboard.result }}
@@ -176,7 +197,7 @@ jobs:
         shell: bash
         run: |
           failed=0
-          for check in CHANGES ANDROID DESKTOP PLUGIN DASHBOARD CONTRACT DOCS; do
+          for check in CHANGES ANDROID ANDROID_ON_DEMAND DESKTOP PLUGIN DASHBOARD CONTRACT DOCS; do
             result_var="${check}_RESULT"
             result="${!result_var}"
             echo "$check: $result"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,9 +270,10 @@ Release notes (`RELEASE_NOTES.md`, `app/src/main/assets/whats_new.txt`, `docs/pl
 
 ## Testing
 
-- **Android cloud verification (preferred for pushed work):** dispatch
-  `.github/workflows/android-on-demand.yml` against the exact pushed SHA with
-  `focused`, `lint`, `assemble-debug`, `release-smoke`, or `all-final`. Check for
+- **Android cloud verification (preferred for pushed work):** dispatch the
+  registered `Required checks` workflow with an exact base/head SHA pair and
+  `android_preset` set to `focused`, `lint`, `assemble-debug`, `release-smoke`,
+  or `all-final`. It calls the reusable Android workflow from `dev`. Check for
   an existing run before dispatching the same SHA/preset again. The four
   `all-final` compute jobs use isolated runners and may execute concurrently.
 - **Full local Android gate (optional):** `scripts\dev.bat prepush` on Windows
@@ -287,7 +288,7 @@ Release notes (`RELEASE_NOTES.md`, `app/src/main/assets/whats_new.txt`, `docs/pl
   device lane is scheduled automatically.
 - **Python tests:** `python -m unittest plugin.tests.test_<name>` from the repo root with the hermes-agent venv active. `pytest` works too but the pre-existing `conftest.py` imports a module that isn't always installed — `unittest` avoids that entirely.
 
-CI is split into path-filtered workflows: `.github/workflows/ci-android.yml` (lint + build + test on app/Gradle changes), `.github/workflows/ci-server.yml` (syntax check + focused server tests on plugin/Python changes), and `.github/workflows/ci-desktop.yml` (desktop type/build/smoke checks). They run on pushes to `main` and `dev` and on PRs targeting either when their paths are touched. `android-on-demand.yml` is the trusted manual compute lane for an exact pushed commit; it does not replace required PR checks.
+CI is split into path-filtered workflows: `.github/workflows/ci-android.yml` (lint + build + test on app/Gradle changes), `.github/workflows/ci-server.yml` (syntax check + focused server tests on plugin/Python changes), and `.github/workflows/ci-desktop.yml` (desktop type/build/smoke checks). They run on pushes to `main` and `dev` and on PRs targeting either when their paths are touched. The registered `ci-required.yml` dispatcher calls `android-on-demand.yml` as the trusted manual compute lane for an exact pushed commit; it does not replace required PR checks.
 Superseded Android runs on `dev` and PR refs are canceled automatically; `main`
 runs are never canceled because each release-branch commit must complete its
 independent validation.

--- a/docs/android-build-lane.md
+++ b/docs/android-build-lane.md
@@ -26,17 +26,23 @@ Check recent runs before dispatching so another task does not duplicate the
 same SHA and preset:
 
 ```powershell
-gh run list --workflow android-on-demand.yml --event workflow_dispatch --limit 20
+$base = git merge-base origin/dev HEAD
 $sha = git rev-parse HEAD
-gh workflow run android-on-demand.yml --ref dev -f head_sha=$sha -f preset=focused
-gh run list --workflow android-on-demand.yml --event workflow_dispatch --limit 5
+gh run list --workflow ci-required.yml --event workflow_dispatch --limit 20
+gh workflow run ci-required.yml --ref dev `
+  -f base_sha=$base `
+  -f head_sha=$sha `
+  -f android_preset=focused
+gh run list --workflow ci-required.yml --event workflow_dispatch --limit 5
 ```
 
 The SHA must already exist on GitHub. Do not push solely to obtain cloud compute
 without push authorization. On-demand jobs read shared Gradle cache state but
 do not write it, so task commits cannot replace the cache populated by trusted
 `dev`/`main` CI. The on-demand result supplements rather than replaces required
-PR checks.
+PR checks. `Required checks` is the registered dispatcher because GitHub only
+registers manual workflow entry points from the default branch; it calls the
+Android workflow from the selected `dev` ref.
 
 ## Local use
 


### PR DESCRIPTION
## Summary

Make Android On-Demand usable immediately from `dev` by routing it through the already-registered `Required checks` workflow.

## Changes

- Convert `android-on-demand.yml` into a reusable workflow.
- Add an `android_preset` choice to the registered exact-SHA dispatcher.
- Keep ordinary PR and release-backmerge dispatch behavior unchanged with the default `auto` preset.
- Key dispatched concurrency by exact SHA and preset so separate worktrees can run concurrently while duplicate requests are deduplicated.
- Update developer commands to dispatch through `ci-required.yml`.

## Verification

- Live direct dispatch reproduced the blocker: GitHub returned `404 workflow android-on-demand.yml not found on the default branch`.
- Registered-dispatch and reusable-workflow structure validation passed.
- Embedded Bash syntax validation passed.
- `python -m unittest scripts.tests.android_prepush_test -v` — 2 passed.
- `node .github/scripts/classify-ci-paths.test.cjs` — passed.
- `git diff --check` — passed.

## Screenshots

No visual change.

## Compatibility / risk

Existing PR checks and exact release-backmerge dispatches retain `android_preset: auto`. The reusable workflow has read-only repository permissions and read-only Gradle caches.

## Lineage / contributor credit

- Source PR(s): #511
- Attribution preserved by: original commit history

## Checklist

- [x] Target branch is `dev`
- [x] Scope is focused and related PRs are linked
- [x] Android changes: workflow/helper tests passed; required CI will run
- [x] Translation changes: N/A
- [x] Server/plugin changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: command examples were updated
- [x] UI changes: N/A
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md`: N/A for CI plumbing
- [x] Public writing hygiene checked
- [x] Lineage/contributor credit recorded