### PR TITLE
release: Android 1.15.0, Plugin 1.11.1, CLI+UI 0.4.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [Android 1.15.0] - 2026-08-31
+
 ### Changed
 
 - **Android prefers current upstream Hermes for standard media, Git, usage, and notices.** Authenticated Dashboard file delivery, current-session `/api/git/*`, Gateway `usage.bars`, and keyed agent notices work without the optional Hermes-Relay Plugin; Relay remains additive for older-host media compatibility, sensitivity metadata, repository discovery and guarded mutations, multi-provider usage, and true Relay tools.
@@ -17,9 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Standard Hermes attachments no longer demand Relay pairing.** Host-local images, audio, video, and files download through the authenticated Dashboard, stay loaded across history reconciliation, and fall back to one neutral compatibility card on older hosts instead of flashing `Relay URL not configured` or retrying indefinitely.
 - **Removing optional Relay does not strand Standard voice or leak preferences across connections.** Runtime fallback keeps Dashboard voice usable, preserves configured choices through temporary outages, and normalizes only connection-scoped named-profile settings after explicit Relay removal.
-- **Relay prompt context advertises only real callable phone tools.** Phone-control and cross-platform delivery guidance now follows the exact selected session/profile tool catalog instead of implying unavailable `android_*` or `send_message` capabilities.
 - **Passively observed Desktop/TUI turns now show live activity in the Android session drawer.** A uniquely matched selected session projects Working or Waiting without Android resuming, activating, or interrupting the external runtime; ambiguous cross-profile matches remain neutral. (Related: #365)
-- **Hermes-Relay Plugin installs through the native Hermes command again.** The manifest remains fully described for current hosts while avoiding the installer/runtime schema mismatch in affected Hermes releases.
 - **Android Chat keeps one transport owner through sign-out and outages.** Dashboard/Gateway conversations now preserve their transcript, draft, profile, and session for sign-in or retry instead of silently sending the next turn to a reachable Direct API database. Legacy API-only connections and explicitly selected Direct API chats remain supported.
 - **Android keeps completed chat text visible when Dashboard sign-in expires.** Generic and reason-coded history `401` responses settle the local turn, preserve its transcript, and surface the existing sign-in recovery without reading another profile's API history.
 - **Android keeps long-running context compaction alive.** A client-visible compaction status extends and refreshes the Gateway turn watchdog instead of interrupting healthy compression after the ordinary idle window. (Supersedes #484.)
@@ -27,6 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Android Chat settles an owned Gateway turn when its terminal frame is lost.** An exact idle `session.active_list` snapshot now completes the matching local stream, reconciles durable history, and drains its queued follow-up without interrupting or claiming Desktop/TUI work.
 - **Supervised Gateway setup stays parent-owned.** Add Gateway is single-flight and checks live parent authority before allocating a draft, relock/back cancels the exact pending setup, and the locked Chat footer no longer attempts protected navigation.
 - **Generated images stay visible and use their intended Chat animation.** Completed image media survives a marker-lagging history refresh, and both the built-in `image_generate` tool and profile tools ending in `_create_image` use the image-generation presentation.
+
+## [Plugin 1.11.1] - 2026-08-31
+
+### Fixed
+
+- **Hermes-Relay Plugin installs through the native Hermes command again.** The manifest remains fully described for current hosts while avoiding the installer/runtime schema mismatch in affected Hermes releases.
+- **Relay prompt context advertises only real callable phone tools.** Phone-control and cross-platform delivery guidance now follows the exact selected session/profile tool catalog instead of implying unavailable `android_*` or `send_message` capabilities.
 
 ## [Android 1.14.0] - 2026-08-30
 
@@ -76,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Dense pairing QRs scan reliably.** Dashboard, CLI, and TUI render integer-sized modules with a full quiet zone.
 - **Remote-access migration keeps existing listeners safe.** Recommended setup avoids taking over `:443`, explicit legacy cleanup remains available, and default disable actions remove only the listeners they own.
 
-## [0.4.0-beta.6] - 2026-08-30
+## [0.4.0-beta.6] - 2026-08-31
 
 ### Changed
 

--- a/CLI_RELEASE_NOTES.md
+++ b/CLI_RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Hermes-Relay CLI+UI v__VERSION__
 
-**Release Date:** 2026-08-30
+**Release Date:** 2026-08-31
 
 This beta preserves complete multi-route pairing while preventing Desktop from dialing Dashboard-ingress Relay routes before Dashboard WebSocket ticket support is available. (Related: #399)
 

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,29 +1,15 @@
 # Hermes-Relay Plugin v__VERSION__
 
-**Release Date:** August 30, 2026
+**Release Date:** August 31, 2026
 
 ## Summary
 
-This release lets one authenticated Hermes Dashboard origin carry Gateway plus optional Relay extensions, adds a bounded Git workspace, and reorganizes the Dashboard plugin around operator tasks. Standard chat, session history, profiles, Manage, and standard voice remain upstream-owned and do not require this plugin.
-
-## Added
-
-- **Dashboard same-origin Relay ingress.** Fixed allowlisted HTTP and WebSocket routes proxy to the local Relay while Dashboard admission and Relay session authentication remain independent. (Related: #399)
-- **Bounded Git workspace.** Configured roots, path containment, line totals, diffs, branches, staging, commits, remotes, grants, and explicit confirmations protect repository operations.
-
-## Changed
-
-- **Task-oriented Dashboard UI.** Overview, Devices, Activity, Remote Access, Git, and Settings now have dedicated surfaces with QR-first pairing, responsive device cards, and honest media diagnostics. (#486)
-- **One explicit route topology.** Dashboard, CLI, and TUI pairing advertise Dashboard, Relay, and optional API surfaces with stable priorities across Tailscale, public HTTPS, and LAN.
-- **Dedicated Tailscale listener.** Recommended setup uses tailnet HTTPS `:10443` to local Dashboard `:9119`, avoiding ownership of a reverse proxy's `:443`. Existing `:443`, `:9119`, and direct `:8767` routes remain migration compatibility.
+This patch restores native installation compatibility on affected Hermes versions and makes Relay prompt context advertise only capabilities the selected session can actually call. Standard Chat, Manage, standard voice, and ordinary inbound files remain upstream-owned.
 
 ## Fixed
 
-- Public and roaming invites no longer synthesize closed direct Relay `:8767` or wrong Dashboard `:9119` routes.
-- Ambiguous, credential-bearing, or plaintext public candidates fail closed before an invite is exposed.
-- Dense pairing QRs use integer-sized modules and a full quiet zone.
-- Inactive optional API routes are omitted; protected Dashboard-ingress `401/403` responses display as authentication-required while direct Relay and API failures remain failures.
-- Default Tailscale disable actions remove only owned listeners, and explicit migration cleanup accepts only the bounded supported ports.
+- **Native installer compatibility.** The plugin keeps its complete current manifest while avoiding the installer/runtime schema mismatch that caused `manifest_version 2` installs to fail after an apparent Hermes update.
+- **Capability-gated phone context.** Phone-control and cross-platform delivery guidance now follows the selected session/profile tool catalog instead of implying unavailable `android_*` or `send_message` callables.
 
 ## Install / update
 
@@ -35,7 +21,7 @@ This release lets one authenticated Hermes Dashboard origin carry Gateway plus o
     # or, if already installed:
     hermes-relay-update
 
-Restart or reload the Hermes Dashboard and Relay after updating so the new manifest, routes, and committed Dashboard bundle are active.
+Restart or reload the Hermes Dashboard and Relay after updating so the new manifest and prompt context are active.
 
 ## Verify
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Hermes-Relay Android v1.14.0
+# Hermes-Relay Android v1.15.0
 
-**Release Date:** August 30, 2026
+**Release Date:** August 31, 2026
 
 ## Download
 
-> Installing on your phone? Download `hermes-relay-1.14.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
+> Installing on your phone? Download `hermes-relay-1.15.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
 
 The `.aab` file is a Play Console upload bundle and cannot be installed by tapping it on a phone.
 
@@ -12,33 +12,32 @@ Verify the download against `SHA256SUMS.txt`. See the [sideload guide](https://h
 
 ## Summary
 
-This release makes saved Hermes connections reliable across LAN, Tailscale, and public HTTPS while keeping Dashboard authentication bound to its exact trusted origin. It also adds delegated-agent previews and an optional native Git workspace, and improves Voice, Assistant, Threads, profile drafts, and Clarify interactions.
-
-## Added
-
-- **Delegated-agent previews.** Follow bounded lifecycle, progress, tool previews, and available read-only child history without leaving the parent chat. Partial history and reconnect gaps remain explicit. (#447)
-- **Native Git workspace.** Review repository state, diffs, branches, staging, commits, and remotes from Chat or Settings. Git operations require Hermes-Relay Plugin v1.11.0 and retain confirmation and grant boundaries.
+This release makes the everyday Android experience work through current upstream Hermes without treating the optional Hermes-Relay Plugin as a prerequisite. It also strengthens parent access, cross-client activity, transport ownership, recovery, and release visibility.
 
 ## Changed
 
-- **Route-aware connections.** Dashboard, Relay, and optional API health are evaluated independently across LAN, Tailscale, and public HTTPS. Same-origin Relay ingress stays on the Dashboard origin that owns authentication, while direct compatibility routes keep separate credentials. (Related: #399)
-- **Voice Focus controls.** Stop and immediate spoken steering remain accessible while Hermes is Thinking, Transcribing, or Speaking, including TalkBack, Switch Access, keyboard, and sideload overlay surfaces.
+- **Upstream-first standard surfaces.** Chat attachments, inbound host files, current-session Git reads, Nous usage bars, and keyed Hermes notices use authenticated Dashboard/Gateway contracts first. Relay remains an additive compatibility and enhancement layer.
+- **Clear Settings ownership.** Media sits with Chat and Voice under Hermes. Proactive Threads, Terminal, Notification Companion, Relay sessions, enhanced voice, and Device Control stay grouped under Relay tools.
+- **App-specific supervised parent access.** Parents choose a PIN or password and receive a six-word recovery phrase; Android device credentials and biometrics no longer grant parent authority.
+- **Complete What's New history.** Release highlights, the remaining improvements and fixes, compatibility notes, toast counts, and history now come from one structured inventory.
 
 ## Fixed
 
-- Wake-word detection packages one compatible ONNX Runtime for sherpa and Java JNI on every supported ABI. (#444)
-- Continuous voice waits for barge-in microphone teardown before listening again. (#464)
-- Fresh chats retain their selected profile without reopening a previous session or carrying a proactive Thread route across profiles. (#436)
-- Provisional Threads can be removed locally and reconcile with promoted sessions without deleting server history. (#461)
-- Clarify cards expose a reachable Other answer, keyboard Send, and authoritative expiry behavior. (#446)
-- Passive Android browsing no longer claims or interrupts a turn owned by another client. (Related: #365)
-- Assistant sessions show retryable no-speech feedback, recover their active state after recreation, and redact conversation details behind the keyguard. (Related: #424)
-- Protected Relay ingress `401/403` responses are recognized as authentication boundaries rather than outages; malformed, different-origin, and direct unauthorized routes still fail closed.
+- Host-local images, audio, video, and files download through the authenticated Dashboard and remain loaded across history reconciliation instead of flashing `Relay URL not configured` or returning to Loading.
+- Standard voice remains usable after explicit Relay removal, while temporary Relay outages preserve configured choices and default-profile preferences stay isolated across connections.
+- Android can display uniquely matched Desktop/TUI Working and Waiting activity without resuming, activating, or interrupting the external turn.
+- Dashboard/Gateway chats preserve their transcript, draft, profile, and session through sign-out or outages instead of silently changing to Direct API.
+- Completed text survives Dashboard-history authentication expiry and returns the existing sign-in recovery path.
+- Long-running context compaction refreshes the turn watchdog instead of being interrupted as idle.
+- Bot Chat history renders immediately after its route-owned handler binds.
+- An exact idle live-session snapshot settles an Android-owned turn whose terminal frame was lost, reconciles history, and drains its queued follow-up.
+- Supervised Add Gateway remains parent-owned across relock, back navigation, and pending setup cancellation.
+- Completed generated images stay visible during marker persistence lag and retain the intended image-generation presentation.
 
 ## Install / Verify
 
-- App version: **1.14.0** (versionCode **52**).
-- Standard Chat, sessions, profiles, Manage, and standard voice continue to work against unmodified upstream Hermes without the optional Relay plugin.
-- Install Hermes-Relay Plugin v1.11.0 for same-origin Relay extensions, Git workspace actions, Bridge, media, proactive features, and enhanced voice.
+- App version: **1.15.0** (versionCode **53**).
+- Standard Chat, sessions, profiles, Manage, standard voice, outbound attachments, and ordinary inbound files work against current unmodified upstream Hermes without the optional Hermes-Relay Plugin.
+- Install Hermes-Relay Plugin v1.11.1 for Terminal, proactive Threads/offline delivery, Notification Companion, Relay sessions, provider-native/realtime voice, compatibility media metadata, Secure Link, and phone/device control.
+- Explicit Direct API/API-only connections remain supported and are never used as a silent failover for a Dashboard-owned chat.
 - Granular Device Control and the system Voice Focus overlay remain sideload-only; the Google Play build does not declare their restricted permissions.
-- Existing connections, drafts, sessions, profile ownership, and legacy direct Relay routes remain data-preserving compatibility paths.

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
-v1.14.0 - Connections, delegated work, Git, and voice
+v1.15.0 - Standard Hermes first, with clearer Relay boundaries
 
-Connections now recover independently across LAN, Tailscale, and public HTTPS without mixing Dashboard and Relay authentication. Preview delegated agents, use the optional native Git workspace, and get safer Continuous voice, Voice Focus, Assistant, Threads, profile drafts, and Clarify controls. Wake-word detection also packages a compatible native runtime.
+Standard Chat, Voice, attachments, returned files, current-session Git, usage, and Hermes notices now prefer upstream Dashboard and Gateway support without requiring Relay. Returned media stays loaded, voice survives Relay removal, and Settings clearly separates standard Hermes from Relay tools. Supervised Mode also gains app-specific parent access and recovery.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -2,6 +2,108 @@
  "schema": 3,
  "versions": [
   {
+   "version": "1.15.0",
+   "title": "Standard Hermes first, with clearer Relay boundaries",
+   "date": "2026-08-31",
+   "summary": "Chat, voice, attachments, inbound files, current-session Git, usage, and Hermes notices now prefer current upstream Dashboard and Gateway support. Relay stays optional for compatibility and the tools it uniquely provides.",
+   "changes": [
+    {
+     "id": "upstream-standard-surfaces",
+     "kind": "improved",
+     "title": "Use standard Hermes without Relay prompts",
+     "summary": "Chat attachments, inbound files, current-session Git, Nous usage, and Hermes notices use upstream routes first.",
+     "highlight": true
+    },
+    {
+     "id": "stable-inbound-media",
+     "kind": "fixed",
+     "title": "Keep returned files loaded",
+     "summary": "Images, audio, video, and documents download through the Dashboard and no longer flash Relay errors or return to Loading.",
+     "highlight": true
+    },
+    {
+     "id": "supervised-parent-access",
+     "kind": "improved",
+     "title": "Use app-specific parent access",
+     "summary": "A parent PIN or password plus recovery phrase protects Supervised Mode without trusting the phone unlock credential.",
+     "highlight": true
+    },
+    {
+     "id": "settings-relay-boundaries",
+     "kind": "improved",
+     "title": "See which features need Relay",
+     "summary": "Media sits with standard Hermes settings while Threads, Terminal, notifications, enhanced voice, and device tools stay under Relay tools."
+    },
+    {
+     "id": "complete-release-history",
+     "kind": "improved",
+     "title": "Read the complete release record",
+     "summary": "What's New shows one release summary, selected highlights, every remaining change, and relevant compatibility notes."
+    },
+    {
+     "id": "relay-removal-voice",
+     "kind": "fixed",
+     "title": "Keep Standard voice after removing Relay",
+     "summary": "Dashboard voice remains ready, temporary outages preserve choices, and shared default-profile settings stay isolated."
+    },
+    {
+     "id": "passive-external-activity",
+     "kind": "fixed",
+     "title": "Observe another client's activity safely",
+     "summary": "A uniquely matched Desktop or TUI turn can show Working or Waiting without Android taking control."
+    },
+    {
+     "id": "chat-transport-ownership",
+     "kind": "fixed",
+     "title": "Keep each chat on its chosen transport",
+     "summary": "Dashboard chats preserve their transcript, draft, profile, and session through sign-out or outages instead of silently changing databases."
+    },
+    {
+     "id": "history-auth-recovery",
+     "kind": "fixed",
+     "title": "Preserve completed replies at sign-in expiry",
+     "summary": "A Dashboard history authentication failure keeps completed text visible and opens the existing sign-in recovery path."
+    },
+    {
+     "id": "compaction-watchdog",
+     "kind": "fixed",
+     "title": "Let long context compaction finish",
+     "summary": "Visible compaction activity refreshes the turn watchdog instead of being interrupted as idle."
+    },
+    {
+     "id": "bot-chat-binding",
+     "kind": "fixed",
+     "title": "Render Bot Chat history immediately",
+     "summary": "Route-owned Bot Chats observe their bound history from first composition."
+    },
+    {
+     "id": "missing-terminal-recovery",
+     "kind": "fixed",
+     "title": "Settle turns after a lost terminal frame",
+     "summary": "An exact idle live-session snapshot reconciles the Android-owned turn and drains its queued follow-up."
+    },
+    {
+     "id": "supervised-gateway-setup",
+     "kind": "fixed",
+     "title": "Keep Gateway setup parent-owned",
+     "summary": "Relock and back navigation cancel the exact pending setup without bypassing parent authority."
+    },
+    {
+     "id": "generated-image-retention",
+     "kind": "fixed",
+     "title": "Keep completed generated images visible",
+     "summary": "Generated media survives marker persistence lag and retains its intended Chat animation."
+    }
+   ],
+   "compatibility": [
+    "Current upstream Hermes provides standard Chat, sessions, Manage, voice, attachments, inbound files, current-session Git reads, usage, and notices without the optional Hermes-Relay Plugin.",
+    "Hermes-Relay Plugin 1.11.1 remains required for Terminal, proactive Threads and offline delivery, Notification Companion, Relay sessions, enhanced voice, Secure Link, and phone or device control.",
+    "Granular Device Control and the system Voice Focus overlay remain sideload-only."
+   ],
+   "playNotes": "Standard Chat, Voice, attachments, returned files, current-session Git, usage, and Hermes notices now prefer upstream Dashboard and Gateway support without requiring Relay. Returned media stays loaded, voice survives Relay removal, and Settings clearly separates standard Hermes from Relay tools. Supervised Mode also gains app-specific parent access and recovery.",
+   "sections": []
+  },
+  {
    "version": "1.14.0",
    "title": "Connections, delegated work, Git, and voice",
    "date": "2026-08-30",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,31 +1,29 @@
-v1.14.0 - Connections, delegated work, Git, and voice
+v1.15.0 - Standard Hermes first, with clearer Relay boundaries
 
 Summary
-* Connections now recover cleanly across networks. You can also follow delegated agents, work with Git repositories, and rely on steadier voice, sessions, Threads, profiles, Assistant, and Clarify controls.
+* Chat, voice, attachments, inbound files, current-session Git, usage, and Hermes notices now prefer current upstream Dashboard and Gateway support. Relay stays optional for compatibility and the tools it uniquely provides.
 
 Highlights
-* Connections recover independently — Move between LAN, Tailscale, and public HTTPS without mixing Dashboard and Relay authentication.
-* Follow delegated-agent activity — See lifecycle, progress, tool previews, and available read-only child history from the parent chat.
-* Work with repositories from Android — Review status, diffs, branches, staging, commits, and remotes from Chat or Settings.
-* Steer voice at any time — Stop or redirect Hermes while it is Thinking, Transcribing, or Speaking, including with accessibility controls.
+* Use standard Hermes without Relay prompts — Chat attachments, inbound files, current-session Git, Nous usage, and Hermes notices use upstream routes first.
+* Keep returned files loaded — Images, audio, video, and documents download through the Dashboard and no longer flash Relay errors or return to Loading.
+* Use app-specific parent access — A parent PIN or password plus recovery phrase protects Supervised Mode without trusting the phone unlock credential.
 
 Improved
-* Release notes stay out of your way — A dismissible post-update notice keeps startup usable and leaves the complete history available from Settings.
-* Chat uses one consistent presentation — The overlapping clean-focus mode was removed while the separate Voice Focus experience remains available.
+* See which features need Relay — Media sits with standard Hermes settings while Threads, Terminal, notifications, enhanced voice, and device tools stay under Relay tools.
+* Read the complete release record — What's New shows one release summary, selected highlights, every remaining change, and relevant compatibility notes.
 
 Fixed
-* Wake-word detection starts reliably — Compatible native voice components are now packaged for every supported phone architecture.
-* The visible Sphere keeps moving smoothly — Foreground animation no longer falls back to a stepped ambient pulse.
-* Continuous voice keeps the microphone — The next listening turn waits for barge-in recording to release cleanly.
-* New chats keep the selected profile — Fresh drafts no longer reopen an older session or carry a Thread route into another profile.
-* Provisional Threads can be removed safely — Local removal and later session promotion no longer risk duplicate rows or server history.
-* Clarify keeps custom answers reachable — Other answers, keyboard Send, and expired prompts now behave consistently.
-* Browsing no longer interrupts another client — Passive Android observation does not claim a turn owned by Desktop, TUI, or another client.
-* Assistant sessions recover more clearly — No-speech feedback, recreated session state, and keyguard privacy now remain intact.
-* Protected Relay routes report the right problem — Authentication challenges are no longer presented as outages, while unsafe routes still fail closed.
-* Connections and sessions become ready sooner — Unavailable optional API and Relay routes no longer delay a healthy Dashboard or authenticated session history.
+* Keep Standard voice after removing Relay — Dashboard voice remains ready, temporary outages preserve choices, and shared default-profile settings stay isolated.
+* Observe another client's activity safely — A uniquely matched Desktop or TUI turn can show Working or Waiting without Android taking control.
+* Keep each chat on its chosen transport — Dashboard chats preserve their transcript, draft, profile, and session through sign-out or outages instead of silently changing databases.
+* Preserve completed replies at sign-in expiry — A Dashboard history authentication failure keeps completed text visible and opens the existing sign-in recovery path.
+* Let long context compaction finish — Visible compaction activity refreshes the turn watchdog instead of being interrupted as idle.
+* Render Bot Chat history immediately — Route-owned Bot Chats observe their bound history from first composition.
+* Settle turns after a lost terminal frame — An exact idle live-session snapshot reconciles the Android-owned turn and drains its queued follow-up.
+* Keep Gateway setup parent-owned — Relock and back navigation cancel the exact pending setup without bypassing parent authority.
+* Keep completed generated images visible — Generated media survives marker persistence lag and retains its intended Chat animation.
 
 Compatibility
-* Standard Chat, sessions, profiles, Manage, and standard voice continue to work without the optional Hermes-Relay Plugin.
-* The Git workspace and same-origin Relay extensions require Hermes-Relay Plugin 1.11.0.
-* Granular Device Control and the system Voice Focus overlay remain available only in the sideload build.
+* Current upstream Hermes provides standard Chat, sessions, Manage, voice, attachments, inbound files, current-session Git reads, usage, and notices without the optional Hermes-Relay Plugin.
+* Hermes-Relay Plugin 1.11.1 remains required for Terminal, proactive Threads and offline delivery, Notification Companion, Relay sessions, enhanced voice, Secure Link, and phone or device control.
+* Granular Device Control and the system Voice Focus overlay remain sideload-only.

--- a/app/src/test/kotlin/com/hermesandroid/relay/screenshots/ChangelogHistoryScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/screenshots/ChangelogHistoryScreenshotTest.kt
@@ -25,10 +25,10 @@ class ChangelogHistoryScreenshotTest {
                 ChangelogScreen(onClose = {})
             }
         }
-        compose.onNodeWithText("v1.14.0 — Connections, delegated work, Git, and voice").assertExists()
+        compose.onNodeWithText("v1.15.0 — Standard Hermes first, with clearer Relay boundaries").assertExists()
         compose.onNodeWithText("Highlights").assertExists()
         compose.onNodeWithText("Fixed").assertExists()
-        compose.onNodeWithText("Wake-word detection starts reliably").assertExists()
+        compose.onNodeWithText("Keep Standard voice after removing Relay").assertExists()
         compose.onNodeWithText("Compatibility").assertExists()
         compose.onNodeWithText("Installed").assertExists()
         compose.onRoot().captureRoboImage("build/ui-regression/changelog-history.png")

--- a/app/src/test/kotlin/com/hermesandroid/relay/screenshots/WhatsNewToastScreenshotTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/screenshots/WhatsNewToastScreenshotTest.kt
@@ -61,10 +61,10 @@ class WhatsNewToastScreenshotTest {
                 }
             }
         }
-        compose.onNodeWithText("Connections, delegated work, Git, and voice").assertExists()
-        compose.onNodeWithText("Also: 2 improvements · 10 fixes").assertExists()
+        compose.onNodeWithText("Standard Hermes first, with clearer Relay boundaries").assertExists()
+        compose.onNodeWithText("Also: 2 improvements · 9 fixes").assertExists()
         compose.onNodeWithText(
-            "Release notes stay out of your way, Chat uses one consistent presentation…",
+            "See which features need Relay, Read the complete release record…",
         ).assertExists()
         compose.onNodeWithText("View all").assertExists()
         compose.onNodeWithContentDescription("Close").assertExists()
@@ -86,7 +86,7 @@ class WhatsNewToastScreenshotTest {
             }
         }
 
-        compose.onNodeWithText("Connections, delegated work, Git, and voice").performClick()
+        compose.onNodeWithText("Standard Hermes first, with clearer Relay boundaries").performClick()
         expanded = false
         compose.onNodeWithText("View all").performClick()
         compose.onNodeWithContentDescription("Close").performClick()
@@ -108,7 +108,7 @@ class WhatsNewToastScreenshotTest {
             }
         }
         compose.mainClock.advanceTimeBy(300L)
-        compose.onNodeWithText("Connections, delegated work, Git, and voice")
+        compose.onNodeWithText("Standard Hermes first, with clearer Relay boundaries")
             .performTouchInput { swipeLeft(durationMillis = 300L) }
         compose.mainClock.advanceTimeBy(300L)
 

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -91,9 +91,9 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.14.0 - Connections, delegated work, Git, and voice
+v1.15.0 - Standard Hermes first, with clearer Relay boundaries
 
-Connections now recover independently across LAN, Tailscale, and public HTTPS without mixing Dashboard and Relay authentication. Preview delegated agents, use the optional native Git workspace, and get safer Continuous voice, Voice Focus, Assistant, Threads, profile drafts, and Clarify controls. Wake-word detection also packages a compatible native runtime.
+Standard Chat, Voice, attachments, returned files, current-session Git, usage, and Hermes notices now prefer upstream Dashboard and Gateway support without requiring Relay. Returned media stays loaded, voice survives Relay removal, and Settings clearly separates standard Hermes from Relay tools. Supervised Mode also gains app-specific parent access and recovery.
 ```
 ## Category
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.14.0"
-appVersionCode = "52"
+appVersionName = "1.15.0"
+appVersionCode = "53"
 agp = "9.3.2"
 kotlin = "2.4.10"
 compose-bom = "2026.08.00"

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Hermes-Relay",
   "description": "Paired devices, Bridge activity, media tokens, and remote access for Hermes-Relay",
   "icon": "Activity",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -2,7 +2,7 @@ name: hermes-relay
 # Temporary v1 shim for Hermes installers that reject manifests the runtime supports; see TODO.md.
 manifest_version: 1
 api_version: 1
-version: 1.11.0
+version: 1.11.1
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 license: MIT

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # CLI+UI releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.11.0"
+version = "1.11.1"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Prepare the current `dev` integration tree for a coordinated Hermes-Relay Android 1.15.0, Hermes-Relay Plugin 1.11.1, and Hermes-Relay CLI+UI 0.4.0-beta.6 release.

## Changes

- Bump Android to 1.15.0 (version code 53) and publish upstream-first release notes and in-app What’s New metadata.
- Bump the optional Hermes-Relay Plugin to 1.11.1 with native installer compatibility and capability-gated phone context notes.
- Finalize Hermes-Relay CLI+UI 0.4.0-beta.6 release notes without changing its already-synchronized package version.
- Align Android changelog presentation tests with the new release entry.

## Verification

- `python scripts/check-version-tracks.py` — passed for Android 1.15.0 (53), Plugin 1.11.1, and CLI+UI 0.4.0-beta.6.
- Android metadata, locale, user-doc locale, website locale, and Plugin version-sync checks — passed.
- `python -m pytest plugin/tests -q` with the current Hermes runtime on `PYTHONPATH` — passed.
- `npm ci`, `npm --prefix tray ci`, and `npm run verify` in `desktop` — passed, including 182 CLI tests, compiled Windows binary smoke, tray formatting/Clippy/check, and 30 Rust tests.
- Android full candidate lane — passed: 2,978 unit tests (12 existing skips), `lintSideloadDebug`, Google Play release APK, sideload release APK, and Google Play release AAB.
- Focused What’s New/changelog UI tests — passed after updating release expectations.
- Physical Samsung phone smoke testing of the upstream-first chat, voice, attachment, and media path was completed before #523 merged.

## Screenshots

No new implementation UI beyond the already device-tested #523 changes. This release-prep diff updates the in-app What’s New content and its existing screenshot coverage.

## Compatibility / risk

Standard Hermes remains upstream-only for chat, sessions, Manage, voice, attachments, inbound files, current-session Git reads, usage, and notices. The Hermes-Relay Plugin remains optional and is described only for Relay-exclusive enhancements. Stable Android publication remains gated by an exact-tree private Play preflight before tag approval.

## Lineage / contributor credit

- Source PR(s): #523
- Attribution preserved by: the release branch contains the exact merged `dev` history and adds release metadata only.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: lint and focused tests ran, or rationale is listed above
- [x] Translation changes: locale validation/review ran, or N/A is listed above
- [x] Server/plugin changes: focused tests ran, or N/A/rationale is listed above
- [x] Desktop changes: build/tests ran, or N/A/rationale is listed above
- [x] Docs/site changes: generated-note alignment checks ran; no website code changed
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md` is updated for user-visible changes, or N/A is listed above
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above