### PR TITLE
fix(release): validate extension tags before creation

### DIFF
--- a/.github/scripts/classify-ci-paths.cjs
+++ b/.github/scripts/classify-ci-paths.cjs
@@ -29,12 +29,16 @@ function classifyCiPaths(paths) {
     ]),
     desktop: forceAll || under(['desktop/']) || exact([
       '.github/workflows/ci-desktop.yml',
+      '.github/workflows/approve-release-extensions.yml',
+      '.github/workflows/release-cli.yml',
     ]),
     plugin: forceAll || paths.some((path) => /^plugin\/[^/]+\.py$/.test(path)) ||
       under(['plugin/relay/', 'plugin/tools/', 'plugin/tests/', 'relay_server/', 'hermes_relay_bootstrap/']) || exact([
         'plugin/plugin.yaml', 'pyproject.toml', 'scripts/check-plugin-version-sync.py',
         'scripts/check-server-version-sync.py', 'scripts/bump-plugin-version.sh',
         'scripts/bump-server-version.sh', '.github/workflows/ci-plugin.yml',
+        '.github/workflows/approve-release-extensions.yml',
+        '.github/workflows/release-plugin.yml',
       ]),
     dashboard: forceAll || under(['plugin/dashboard/']) || exact([
       '.github/workflows/ci-dashboard.yml',

--- a/.github/scripts/classify-ci-paths.test.cjs
+++ b/.github/scripts/classify-ci-paths.test.cjs
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
 const { classifyCiPaths } = require('./classify-ci-paths.cjs');
 
 const none = {
@@ -24,6 +26,13 @@ assert.deepEqual(classifyCiPaths(['scripts/dev.bat']), { ...none, android: true 
 assert.deepEqual(classifyCiPaths(['scripts/dev.sh']), { ...none, android: true });
 assert.deepEqual(classifyCiPaths(['scripts/tests/android_prepush_test.py']), { ...none, android: true });
 assert.deepEqual(classifyCiPaths(['.github/workflows/android-on-demand.yml']), { ...none, android: true });
+assert.deepEqual(classifyCiPaths(['.github/workflows/approve-release-extensions.yml']), {
+  ...none,
+  desktop: true,
+  plugin: true,
+});
+assert.deepEqual(classifyCiPaths(['.github/workflows/release-cli.yml']), { ...none, desktop: true });
+assert.deepEqual(classifyCiPaths(['.github/workflows/release-plugin.yml']), { ...none, plugin: true });
 assert.deepEqual(classifyCiPaths(['plugin/relay/server.py']), { ...none, plugin: true });
 assert.deepEqual(classifyCiPaths(['plugin/dashboard/src/App.tsx']), { ...none, dashboard: true });
 assert.deepEqual(classifyCiPaths(['user-docs/index.md']), { ...none, docs: true });
@@ -47,5 +56,31 @@ assert.deepEqual(classifyCiPaths(['.github/workflows/release-backmerge.yml']), {
   contract: true,
   docs: true,
 });
+
+const repoRoot = join(__dirname, '..', '..');
+const approvalWorkflow = readFileSync(
+  join(repoRoot, '.github', 'workflows', 'approve-release-extensions.yml'),
+  'utf8',
+);
+const cliReleaseWorkflow = readFileSync(
+  join(repoRoot, '.github', 'workflows', 'release-cli.yml'),
+  'utf8',
+);
+const pluginReleaseWorkflow = readFileSync(
+  join(repoRoot, '.github', 'workflows', 'release-plugin.yml'),
+  'utf8',
+);
+
+assert.match(approvalWorkflow, /permissions:\r?\n  contents: read/);
+assert.match(
+  approvalWorkflow,
+  /approve:[\s\S]*?permissions:\r?\n      actions: write\r?\n      contents: write/,
+);
+assert.match(
+  approvalWorkflow,
+  /ref: \$\{\{ contains\(inputs\.version, '-'\) && 'dev' \|\| 'main' \}\}/,
+);
+assert.match(cliReleaseWorkflow, /workflow_dispatch:[\s\S]*?Approved CLI\+UI version/);
+assert.match(pluginReleaseWorkflow, /workflow_dispatch:[\s\S]*?Approved Plugin version/);
 
 console.log('CI path classification tests passed.');

--- a/.github/workflows/approve-release-extensions.yml
+++ b/.github/workflows/approve-release-extensions.yml
@@ -1,0 +1,158 @@
+name: Hermes-Relay Plugin and CLI+UI Release Approval
+
+on:
+  workflow_dispatch:
+    inputs:
+      surface:
+        description: "Release surface"
+        required: true
+        type: choice
+        options:
+          - plugin
+          - desktop
+      version:
+        description: "Approved version (for example 1.11.2 or 0.4.0-beta.7)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: approve-${{ inputs.surface }}-release
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release source and metadata
+    runs-on: ubuntu-latest
+    outputs:
+      source_branch: ${{ steps.metadata.outputs.source_branch }}
+      source_sha: ${{ steps.metadata.outputs.source_sha }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      workflow: ${{ steps.metadata.outputs.workflow }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ contains(inputs.version, '-') && 'dev' || 'main' }}
+
+      - name: Validate approval request
+        id: metadata
+        env:
+          REQUESTED_SURFACE: ${{ inputs.surface }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REQUESTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Version must be SemVer with an optional prerelease suffix: $REQUESTED_VERSION"
+            exit 1
+          fi
+
+          if [[ "$REQUESTED_VERSION" == *-* ]]; then
+            source_branch="dev"
+          else
+            source_branch="main"
+          fi
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Release approval must run from the trusted main workflow definition, not $GITHUB_REF"
+            exit 1
+          fi
+          git fetch origin "$source_branch" --no-tags
+          source_sha="$(git rev-parse HEAD)"
+          expected_sha="$(git rev-parse FETCH_HEAD)"
+          if [ "$source_sha" != "$expected_sha" ]; then
+            echo "::error::Checked out $source_sha, but origin/$source_branch is $expected_sha"
+            exit 1
+          fi
+
+          case "$REQUESTED_SURFACE" in
+            plugin)
+              tag="server-v${REQUESTED_VERSION}"
+              workflow="release-plugin.yml"
+              python3 scripts/check-plugin-version-sync.py --expect "$REQUESTED_VERSION"
+              if ! grep -Eq "^## \[Plugin ${REQUESTED_VERSION}\]" CHANGELOG.md; then
+                echo "::error::CHANGELOG.md has no Plugin release heading for $REQUESTED_VERSION"
+                exit 1
+              fi
+              ;;
+            desktop)
+              tag="desktop-v${REQUESTED_VERSION}"
+              workflow="release-cli.yml"
+              node desktop/scripts/cli-version-sync.mjs --expect "$REQUESTED_VERSION"
+              if ! grep -Fq "## [$REQUESTED_VERSION]" CHANGELOG.md; then
+                echo "::error::CHANGELOG.md has no CLI+UI release heading for $REQUESTED_VERSION"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unsupported release surface: $REQUESTED_SURFACE"
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "workflow=$workflow" >> "$GITHUB_OUTPUT"
+          echo "source_branch=$source_branch" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
+  approve:
+    name: Create release tag and start publication
+    needs: validate
+    permissions:
+      actions: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify release source has not moved
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_BRANCH: ${{ needs.validate.outputs.source_branch }}
+          SOURCE_SHA: ${{ needs.validate.outputs.source_sha }}
+        run: |
+          current_sha=$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/heads/${SOURCE_BRANCH}" --jq .object.sha)
+          if [ "$current_sha" != "$SOURCE_SHA" ]; then
+            echo "::error::$SOURCE_BRANCH moved from $SOURCE_SHA to $current_sha; run approval again"
+            exit 1
+          fi
+
+      - name: Ensure release tag does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          if gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag $RELEASE_TAG already exists"
+            exit 1
+          fi
+
+      - name: Create approved release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          RELEASE_SHA: ${{ needs.validate.outputs.source_sha }}
+        run: |
+          gh api --method POST "/repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="$RELEASE_SHA"
+
+      - name: Start the immutable tag release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_WORKFLOW: ${{ needs.validate.outputs.workflow }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          # A tag created by GITHUB_TOKEN does not recursively start workflows.
+          # Dispatch the trusted definition from main; release jobs check out
+          # and validate the immutable tag created above.
+          gh workflow run "$RELEASE_WORKFLOW" \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f version="$RELEASE_VERSION"
+
+      - name: Approval summary
+        run: |
+          echo "## Release approved" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Created \`${{ needs.validate.outputs.tag }}\` from \`${{ needs.validate.outputs.source_branch }}\` at \`${{ needs.validate.outputs.source_sha }}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Dispatched \`${{ needs.validate.outputs.workflow }}\` to validate and publish that immutable tag." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,6 +3,12 @@ name: Hermes-Relay CLI+UI Release
 on:
   push:
     tags: ['desktop-v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Approved CLI+UI version"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -20,6 +26,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('desktop-v{0}', inputs.version) || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -34,10 +41,16 @@ jobs:
       - name: Extract and validate tag version
         id: version
         shell: bash
+        env:
+          DISPATCHED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#desktop-v}"
-          if [[ -z "$version" || "$version" == "$GITHUB_REF_NAME" ]]; then
+          if [ -n "$DISPATCHED_VERSION" ]; then
+            version="$DISPATCHED_VERSION"
+          else
+            version="${GITHUB_REF_NAME#desktop-v}"
+          fi
+          if [ -z "$version" ] || { [ -z "$DISPATCHED_VERSION" ] && [ "$version" = "$GITHUB_REF_NAME" ]; }; then
             echo "Expected a desktop-v* tag, got $GITHUB_REF_NAME" >&2
             exit 1
           fi
@@ -51,11 +64,12 @@ jobs:
       - name: Verify tag belongs to the correct integration branch
         shell: bash
         working-directory: .
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#desktop-v}"
-          tag_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
-          if [[ "$version" == *-* ]]; then
+          tag_commit="$(git rev-parse HEAD)"
+          if [[ "$TAG_VERSION" == *-* ]]; then
             git fetch origin dev --no-tags
             if ! git merge-base --is-ancestor "$tag_commit" origin/dev; then
               echo "CLI+UI prereleases must be tagged from dev; $tag_commit is not in origin/dev" >&2
@@ -78,6 +92,8 @@ jobs:
         working-directory: desktop
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('desktop-v{0}', inputs.version) || github.ref }}
 
       - name: Setup Node.js (for npm ci + tsc)
         uses: actions/setup-node@v7
@@ -271,6 +287,8 @@ jobs:
         working-directory: desktop
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('desktop-v{0}', inputs.version) || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -483,6 +501,7 @@ jobs:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     needs:
+      - validate-release
       - build-cli-binaries
       - smoke-windows-cli-release-asset
       - smoke-macos-cli-release-asset
@@ -492,10 +511,8 @@ jobs:
       # Needed so CLI_RELEASE_NOTES.md is available to render into the release body
       # (the other publish-release steps only consume downloaded build artifacts).
       - uses: actions/checkout@v7
-
-      - name: Extract CLI+UI version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#desktop-v}" >> "$GITHUB_OUTPUT"
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('desktop-v{0}', inputs.version) || github.ref }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -515,8 +532,8 @@ jobs:
       # (desktop-v0.3.0) so install/pin commands stay accurate without manual edits.
       - name: Render release notes
         env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          TAG: desktop-v${{ needs.validate-release.outputs.version }}
         run: |
           sed -e "s/__VERSION__/${VERSION}/g" -e "s/__TAG__/${TAG}/g" \
             CLI_RELEASE_NOTES.md > cli_release_notes_rendered.md
@@ -525,10 +542,10 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: Hermes-Relay CLI+UI v${{ steps.version.outputs.version }}
-          tag_name: ${{ github.ref_name }}
+          name: Hermes-Relay CLI+UI v${{ needs.validate-release.outputs.version }}
+          tag_name: desktop-v${{ needs.validate-release.outputs.version }}
           draft: false
-          prerelease: ${{ contains(steps.version.outputs.version, 'alpha') || contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'rc') }}
+          prerelease: ${{ contains(needs.validate-release.outputs.version, '-') }}
           fail_on_unmatched_files: true
           body_path: cli_release_notes_rendered.md
           files: |

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "server-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Approved Plugin version"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,10 +25,19 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('server-v{0}', inputs.version) || github.ref }}
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/server-v}" >> "$GITHUB_OUTPUT"
+        env:
+          DISPATCHED_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$DISPATCHED_VERSION" ]; then
+            version="$DISPATCHED_VERSION"
+          else
+            version="${GITHUB_REF#refs/tags/server-v}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Verify Plugin version sync and changelog
         run: |
@@ -61,6 +76,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('server-v{0}', inputs.version) || github.ref }}
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
@@ -99,6 +116,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('server-v{0}', inputs.version) || github.ref }}
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v7

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -743,14 +743,19 @@ git commit -m "release(server): server-v0.6.2"
 git push origin dev
 
 # Open the release PR (dev -> main) and merge with --no-ff.
-# After merge, tag from the new main tip:
-git checkout main
-git pull --ff-only origin main
-git tag server-v0.6.2
-git push origin server-v0.6.2
+# Then run "Hermes-Relay Plugin and CLI+UI Release Approval" from main,
+# select plugin, and enter 0.6.2. The workflow selects and validates main
+# before it creates server-v0.6.2 and starts the immutable-tag release workflow.
 ```
 
-Pushing `server-v*` triggers `.github/workflows/release-plugin.yml`, which
+For a Plugin prerelease, keep the release-prepared commit on `dev` and run the
+same trusted approval workflow from `main`; the version suffix makes it select
+and validate the exact `origin/dev` tip before creating the tag. Stable versions
+select `origin/main` instead.
+Direct `server-v*` tag pushes remain a recovery path and are guarded by the same
+branch-containment and metadata checks.
+
+The approval workflow dispatches `.github/workflows/release-plugin.yml`, which
 validates all plugin-owned version metadata with
 `scripts/check-plugin-version-sync.py`. Run
 `python scripts/check-version-tracks.py` locally before tagging when a change
@@ -781,20 +786,21 @@ git add desktop/package.json desktop/package-lock.json desktop/src/version.ts `
 git commit -m "release(desktop): desktop-v0.4.0-alpha.2"
 git push origin dev
 
-# Open the release PR (dev -> main) and merge with --no-ff.
-# After merge, tag from main:
-git switch main
-git pull --ff-only origin main
-cd desktop
-npm run check:version-sync -- --expect 0.4.0-alpha.2
-cd ..
-git tag desktop-v0.4.0-alpha.2
-git push origin desktop-v0.4.0-alpha.2
+# This is a prerelease: run "Hermes-Relay Plugin and CLI+UI Release Approval"
+# from main, select desktop, and enter 0.4.0-alpha.2. The workflow validates dev
+# before it creates the tag and starts the immutable-tag release workflow.
 ```
 
-The tag workflow rejects version drift and tags whose commit is not in
-`origin/main`, reruns CLI tests, builds all four standalone binaries, tests and
-packages the Windows tray, generates checksums, and publishes the GitHub Release.
+For a stable CLI+UI version, first merge the release PR from `dev` to `main`,
+then run the approval workflow from `main`. The version determines the source:
+prereleases select the exact `origin/dev` tip and stable releases select the
+exact `origin/main` tip before creating any tag. Direct `desktop-v*` tag pushes
+remain a recovery path.
+
+The release workflow rejects version drift and requires prerelease tags to be
+contained in `origin/dev` and stable tags to be contained in `origin/main`. It
+reruns CLI tests, builds all four standalone binaries, tests and packages the
+Windows tray, generates checksums, and publishes the GitHub Release.
 
 ### 6. Play review and publishing behavior
 
@@ -924,7 +930,8 @@ On every push of a tag matching `android-v*`, `.github/workflows/release-android
    containing a dash (e.g. `android-v0.2.0-beta.1`) as a prerelease automatically.
 8. Prints a `$GITHUB_STEP_SUMMARY` with the release and Play result.
 
-On every push of a tag matching `server-v*`,
+On every direct push of a tag matching `server-v*`, or after an approved
+dispatch from `.github/workflows/approve-release-extensions.yml`,
 `.github/workflows/release-plugin.yml`:
 
 1. Verifies a stable tag commit is contained in `main`, or a prerelease tag is
@@ -937,7 +944,8 @@ On every push of a tag matching `server-v*`,
 5. Creates a GitHub Release named `Hermes-Relay Plugin v<version>` with the wheel,
    sdist, and checksum file attached.
 
-On every push of a tag matching `desktop-v*`,
+On every direct push of a tag matching `desktop-v*`, or after an approved
+dispatch from `.github/workflows/approve-release-extensions.yml`,
 `.github/workflows/release-cli.yml` builds and publishes the CLI binaries and
 Windows tray installer. Its GitHub Release body comes from `CLI_RELEASE_NOTES.md`
 (rewritten per release — the CLI counterpart of `RELEASE_NOTES.md`); the workflow

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4304,3 +4304,45 @@ API-only/headless clients, compatibility testing, and existing API records, but
 they are no longer automatic recovery for standard Chat. Users retry or sign in
 without losing local work, named profiles cannot cross databases silently, and
 readiness reflects the conversation that will actually receive the next turn.
+
+---
+
+## ADR 72 — Plugin and CLI+UI release tags are approval-created
+
+**Status:** Accepted (2026-09-01).
+
+**Context.** Plugin and CLI+UI tag workflows correctly rejected stable tags
+outside `main` and prerelease tags outside `dev`, but that validation occurred
+only after an operator pushed the tag. The CLI+UI release recipe also told
+operators to tag a prerelease from `main`, contradicting the canonical branch
+contract. A rejected tag therefore left a failed check on an otherwise healthy
+release commit and required destructive tag recovery before publication.
+
+**Decision.** The normal Plugin and CLI+UI release path validates first and
+creates the tag second. A single manual approval workflow:
+
+- always runs the trusted workflow definition from `main`, then selects the
+  exact `origin/main` tip for stable versions or `origin/dev` for prereleases;
+- verifies the surface-owned version metadata and matching changelog heading;
+- refuses an existing tag, then creates the exact `server-v*` or `desktop-v*`
+  ref at the validated commit; and
+- dispatches the trusted release workflow from `main`, whose jobs explicitly
+  check out and revalidate that immutable tag.
+
+Direct tag pushes remain a recovery path and retain the same fail-closed
+metadata and branch-containment checks. Approval does not weaken release tests,
+change stable/prerelease source branches, or combine the independently
+versioned Plugin and CLI+UI artifacts.
+
+**Consequences.** Routine releases cannot create a known-invalid tag before
+discovering a branch mismatch. A tag created with `GITHUB_TOKEN` does not
+recursively trigger Actions, so approval explicitly dispatches the release
+workflow and the release workflow supports both tag-push and approved-dispatch
+events. The workflow must exist on `main` before the approval surface is used.
+
+**Key files:**
+
+- `.github/workflows/approve-release-extensions.yml`
+- `.github/workflows/release-plugin.yml`
+- `.github/workflows/release-cli.yml`
+- `RELEASE.md`


### PR DESCRIPTION
## Summary

Prevent Plugin and CLI+UI release tags from being created on the wrong source branch. The normal release path now validates version metadata and the selected source before creating a tag, while direct tag pushes remain a guarded recovery path.

## Changes

- Add a least-privilege approval workflow for Plugin and CLI+UI releases.
- Select `origin/dev` automatically for prereleases and `origin/main` for stable versions.
- Separate read-only repository validation from the write-capable tag/publication job and fail if the source branch moves between them.
- Allow the existing Plugin and CLI+UI workflows to publish an approval-created immutable tag through an explicit dispatch.
- Correct the contradictory CLI prerelease instructions and record the release decision.
- Route approval/release workflow changes through the appropriate Plugin and desktop CI lanes with regression assertions.

## Verification

- `node .github/scripts/classify-ci-paths.test.cjs` — passed.
- `python scripts/check-plugin-version-sync.py --expect 1.11.1` — passed.
- `node desktop/scripts/cli-version-sync.mjs --expect 0.4.0-beta.6` — passed.
- PyYAML parse of all three affected workflows — passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest ...` for all three affected workflows — passed.
- `git diff --cached --check` — passed before commit.

## Screenshots

No visual change.

## Compatibility / risk

Stable versions still originate from `main`; prereleases still originate from `dev`. Direct `server-v*` and `desktop-v*` pushes remain supported as a fail-closed recovery path. The new approval workflow must first reach `main` before it appears as a manual Actions workflow.

## Lineage / contributor credit

- Source PR(s): #525
- Attribution preserved by: N/A — focused release-automation correction.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A
- [x] Translation changes: N/A
- [x] Server/plugin changes: Plugin workflow validation ran
- [x] Desktop changes: CLI version validation and workflow lint ran
- [x] Docs/site changes: release policy was reviewed against workflow behavior
- [x] UI changes: N/A
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md`: N/A — operator workflow only
- [x] Public writing hygiene checked
- [x] Salvaged/replacement work: N/A