### PR TITLE
release: prepare Android 1.15.1 and CLI+UI 0.4.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [Android 1.15.1] - 2026-09-02
+
 ### Changed
 
-- **Chat and Bot Chat expose a clear mid-response send choice.** A slim translucent tray slides up behind the composer for Correct now or Queue next without covering the input. Chat settings sets the default; the tray overrides it for one message. Stop pauses pending messages until Resume, and editing or removing a queued message keeps its successors deliverable.
-- **Android Chat and Voice use tablet space intentionally.** Expanded layouts keep introductions, transcripts, composer controls, and status chrome on readable centered rails, while landscape Voice Focus separates identity controls from conversation activity without changing phone or portrait interaction behavior.
+- Chat and Bot Chat offer a compact Correct now / Queue next tray behind the composer. Chat settings sets the default; each message can override it. Stop pauses pending work until Resume, and editing or removing queued messages preserves the remaining order.
+- Wider Chat and Voice layouts keep text and controls centered and readable, including landscape Voice Focus.
 
 ### Fixed
 
-- **Android message delivery labels remain readable inside user bubbles.** Steering confirmations and other delivery states use the bubble's contrasting text color instead of disappearing into its accent background.
-- **Android voice errors open in a readable dialog.** Long provider messages stay inside a scrollable, selectable detail area with separate Retry and Dismiss actions instead of overlapping Chat or Voice Focus controls.
-- **Android attachment previews survive rotation and preserve video proportions.** Full-screen image, video, audio, PDF, text, and file previews remain open while the chat reflows, respect the device rotation preference, and render portrait or landscape video through Media3's fitted content surface instead of a fixed 16:9 box. (#483)
-- **Android wake-word JNI configuration survives release shrinking.** R8 now preserves sherpa-onnx configuration class and field names that the native keyword spotter resolves at runtime. (#444)
-- **Android streams Standard Hermes attachments into its on-disk media cache.** Automatic Dashboard downloads no longer preallocate and duplicate the full response body on the OkHttp dispatcher, while declared and observed size limits remain enforced. (#531)
-- **Android bounds automatic session refresh and large chat allocations.** A foreground directory refresh can no longer sustain a request loop, routine history opens read one latest 500-row page, Dashboard JSON and in-memory media exports reject oversized bodies, Markdown renders through a bounded presentation window, and chat image previews downsample before allocating pixels.
-- **Android keeps visible progress through image-generation tool gaps.** Gateway interim replies immediately hand off to a new in-chat working owner, so the standard working animation remains visible until media arrives even when upstream hides tool lifecycle events. Older Tool Search gateways that do expose a structured `tool_call` bridge are normalized to the effective image tool.
-- **Android fresh Gateway chats wait for their upstream runtime before sending.** Android now consumes the lazy `session.create` readiness edge instead of racing the first prompt into compute-host ownership rejection. Genuine ownership refusals keep the exact holder-aware error and retryable local prompt instead of falling into unfinished-message history recovery.
-- **Windows desktop updates keep the installed CLI and UI on one release.** `hermes-relay update` now detects a colocated management UI, reports both installed versions, and uses the verified bundle installer to replace and restart the affected surfaces together. Explicit CLI-only installations retain the standalone binary updater.
+- Delivery and correction labels remain readable inside user-message bubbles.
+- Voice errors use a scrollable dialog with separate Retry and Dismiss actions.
+- Attachment previews stay open through rotation, and videos retain their original proportions. (#483)
+- Release builds preserve the native configuration names required for wake-word startup. (#444)
+- Standard Hermes attachments stream to disk while enforcing download size limits. (#531)
+- Session refresh no longer sustains a request loop. History loads, chat rendering, image previews, and media exports keep memory use bounded.
+- Image-generation progress remains visible between interim replies and media delivery.
+- New Gateway chats wait for session readiness before the first prompt; ownership refusals preserve the retryable prompt and server error.
+
+## [0.4.0-beta.7] - 2026-09-02
+
+### Fixed
+
+- Windows updates detect a colocated management UI, report both installed versions, and update the CLI and UI together through the verified bundle installer. CLI-only installations keep their standalone updater.
 
 ## [Android 1.15.0] - 2026-08-31
 

--- a/CLI_RELEASE_NOTES.md
+++ b/CLI_RELEASE_NOTES.md
@@ -1,22 +1,18 @@
 # Hermes-Relay CLI+UI v__VERSION__
 
-**Release Date:** 2026-08-31
+**Release Date:** 2026-09-02
 
-This beta preserves complete multi-route pairing while preventing Desktop from dialing Dashboard-ingress Relay routes before Dashboard WebSocket ticket support is available. (Related: #399)
+This beta fixes Windows updates so the installed CLI and management UI advance together. Explicit CLI-only installations keep their standalone update path.
 
 **Beta phase.** Assets remain unsigned, so Windows SmartScreen and macOS Gatekeeper may warn on first launch. Standalone CLI binaries ship for Windows x64, Linux x64/arm64, and macOS x64/arm64; the management UI is Windows-only.
 
 ## What's changed
 
-### Changed
-
-- **Saved hosts retain the full route topology.** Dashboard, Relay, optional API, route priority, transport protection, certificate pins, and the selected host survive LAN, Tailscale, and public-route changes without creating duplicate hosts.
-- **API-less pairing is first-class.** Dashboard plus direct Relay can pair without inventing an optional API server, while secure-first ranking retains plain LAN as the final fallback.
-
 ### Fixed
 
-- **Dashboard-ingress Relay routes fail closed on Desktop.** The daemon, host selector, and Relay transport reject ingress that requires a Dashboard WebSocket ticket and choose a compatible direct Relay fallback instead of attempting an unauthenticated dial.
-- **Pairing accepts the current v3 candidate shape.** Optional API records, same-origin Dashboard/Relay routes, and legacy top-level payloads remain compatible without collapsing route ownership.
+- `hermes-relay update` detects an installed management UI beside the CLI and reports both installed versions.
+- Bundle installations use the checksum-verified Windows installer to update and restart the affected CLI and UI together.
+- Explicit CLI-only installations continue to use the standalone binary updater.
 
 ## Install
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Hermes-Relay Android v1.15.0
+# Hermes-Relay Android v1.15.1
 
-**Release Date:** August 31, 2026
+**Release Date:** September 2, 2026
 
 ## Download
 
-> Installing on your phone? Download `hermes-relay-1.15.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
+> Installing on your phone? Download `hermes-relay-1.15.1-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
 
 The `.aab` file is a Play Console upload bundle and cannot be installed by tapping it on a phone.
 
@@ -12,32 +12,29 @@ Verify the download against `SHA256SUMS.txt`. See the [sideload guide](https://h
 
 ## Summary
 
-This release makes the everyday Android experience work through current upstream Hermes without treating the optional Hermes-Relay Plugin as a prerequisite. It also strengthens parent access, cross-client activity, transport ownership, recovery, and release visibility.
+This patch improves chat, media, and voice reliability. It reduces memory-heavy work, keeps attachment previews stable through rotation, and makes follow-up message behavior and voice errors easier to understand.
 
 ## Changed
 
-- **Upstream-first standard surfaces.** Chat attachments, inbound host files, current-session Git reads, Nous usage bars, and keyed Hermes notices use authenticated Dashboard/Gateway contracts first. Relay remains an additive compatibility and enhancement layer.
-- **Clear Settings ownership.** Media sits with Chat and Voice under Hermes. Proactive Threads, Terminal, Notification Companion, Relay sessions, enhanced voice, and Device Control stay grouped under Relay tools.
-- **App-specific supervised parent access.** Parents choose a PIN or password and receive a six-word recovery phrase; Android device credentials and biometrics no longer grant parent authority.
-- **Complete What's New history.** Release highlights, the remaining improvements and fixes, compatibility notes, toast counts, and history now come from one structured inventory.
+- Choose Correct now or Queue next from a slim tray behind the composer. Chat settings sets the default; the tray overrides one message. Stop pauses the queue, Resume continues it, and editing or removing an item preserves its successors.
+- Chat and Voice use readable centered layouts on wider screens, including landscape Voice Focus.
 
 ## Fixed
 
-- Host-local images, audio, video, and files download through the authenticated Dashboard and remain loaded across history reconciliation instead of flashing `Relay URL not configured` or returning to Loading.
-- Standard voice remains usable after explicit Relay removal, while temporary Relay outages preserve configured choices and default-profile preferences stay isolated across connections.
-- Android can display uniquely matched Desktop/TUI Working and Waiting activity without resuming, activating, or interrupting the external turn.
-- Dashboard/Gateway chats preserve their transcript, draft, profile, and session through sign-out or outages instead of silently changing to Direct API.
-- Completed text survives Dashboard-history authentication expiry and returns the existing sign-in recovery path.
-- Long-running context compaction refreshes the turn watchdog instead of being interrupted as idle.
-- Bot Chat history renders immediately after its route-owned handler binds.
-- An exact idle live-session snapshot settles an Android-owned turn whose terminal frame was lost, reconciles history, and drains its queued follow-up.
-- Supervised Add Gateway remains parent-owned across relock, back navigation, and pending setup cancellation.
-- Completed generated images stay visible during marker persistence lag and retain the intended image-generation presentation.
+- Correction and delivery labels remain visible inside user-message bubbles.
+- Voice errors open in a scrollable dialog with separate Retry and Dismiss actions.
+- Attachment previews remain open through rotation, and video previews preserve their proportions.
+- Release optimization preserves the native speech configuration required for wake-word startup.
+- Standard Hermes attachments download directly to disk with bounded size checks.
+- Session refresh avoids repeated request loops; history loads, Markdown, image previews, and media exports keep memory use bounded.
+- Image-generation progress stays visible through gaps between interim replies and returned media.
+- The first prompt waits for Gateway session readiness. Ownership refusals retain the prompt for retry and show the original server error.
 
 ## Install / Verify
 
-- App version: **1.15.0** (versionCode **53**).
-- Standard Chat, sessions, profiles, Manage, standard voice, outbound attachments, and ordinary inbound files work against current unmodified upstream Hermes without the optional Hermes-Relay Plugin.
-- Install Hermes-Relay Plugin v1.11.1 for Terminal, proactive Threads/offline delivery, Notification Companion, Relay sessions, provider-native/realtime voice, compatibility media metadata, Secure Link, and phone/device control.
-- Explicit Direct API/API-only connections remain supported and are never used as a silent failover for a Dashboard-owned chat.
-- Granular Device Control and the system Voice Focus overlay remain sideload-only; the Google Play build does not declare their restricted permissions.
+- App version: **1.15.1** (versionCode **54**).
+- Standard Chat, sessions, profiles, Manage, voice, and ordinary media use current upstream Hermes. Speech-to-text still requires a configured provider on the host.
+- Hermes-Relay Plugin **1.11.1** remains the current optional plugin release; this Android patch does not require a new plugin version.
+- Paused text queues can be restored. Attachment bytes are not persisted in preferences; unrestorable attachment queues must be reviewed and sent again.
+- Explicit Direct API/API-only connections remain supported and are not used as silent failover for Dashboard-owned chats.
+- Granular Device Control and the system Voice Focus overlay remain sideload-only.

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
-v1.15.0 - Standard Hermes first, with clearer Relay boundaries
+v1.15.1 - Steadier chat, media, and voice
 
-Standard Chat, Voice, attachments, returned files, current-session Git, usage, and Hermes notices now prefer upstream Dashboard and Gateway support without requiring Relay. Returned media stays loaded, voice survives Relay removal, and Settings clearly separates standard Hermes from Relay tools. Supervised Mode also gains app-specific parent access and recovery.
+More reliable chats and media: fewer memory-heavy refreshes, smoother large histories, and attachment previews that survive rotation. Choose whether follow-ups correct the current response or wait in a queue. Voice errors are easier to read, image-generation progress stays visible, and wake-word startup and first-message readiness are fixed.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -2,6 +2,83 @@
  "schema": 3,
  "versions": [
   {
+   "version": "1.15.1",
+   "title": "Steadier chat, media, and voice",
+   "date": "2026-09-02",
+   "summary": "Chats use less memory, attachment previews stay in place, and voice failures are easier to recover from. Follow-up controls make it clear whether a message changes the current response or waits for the next turn.",
+   "changes": [
+    {
+     "id": "follow-up-controls",
+     "kind": "improved",
+     "title": "Choose when follow-up messages are sent",
+     "summary": "A slim tray behind the composer offers Correct now or Queue next. Chat settings sets the default, and a composer choice applies to one message. Stop pauses pending work until Resume; editing or removing an item keeps the remaining queue usable.",
+     "highlight": true
+    },
+    {
+     "id": "tablet-layouts",
+     "kind": "improved",
+     "title": "Make better use of wider screens",
+     "summary": "Chat and Voice keep text and controls on readable centered layouts. Landscape Voice Focus separates identity controls from conversation activity."
+    },
+    {
+     "id": "delivery-labels",
+     "kind": "fixed",
+     "title": "Read message delivery status clearly",
+     "summary": "Correction and delivery labels use contrasting text instead of disappearing into the message bubble."
+    },
+    {
+     "id": "voice-error-dialog",
+     "kind": "fixed",
+     "title": "Read and dismiss voice errors",
+     "summary": "Voice errors open in a contained dialog with scrollable details and separate Retry and Dismiss actions, without overlapping chat controls."
+    },
+    {
+     "id": "attachment-previews",
+     "kind": "fixed",
+     "title": "Keep attachment previews open through rotation",
+     "summary": "Image, video, audio, PDF, text, and file previews stay open as the screen rotates. Videos retain their original proportions.",
+     "highlight": true
+    },
+    {
+     "id": "wake-word-startup",
+     "kind": "fixed",
+     "title": "Fix wake-word startup in release builds",
+     "summary": "Release optimization now preserves the native speech configuration names needed to initialize wake-word detection."
+    },
+    {
+     "id": "attachment-downloads",
+     "kind": "fixed",
+     "title": "Download attachments with less memory",
+     "summary": "Standard Hermes attachments stream into the on-disk cache while download size limits remain enforced."
+    },
+    {
+     "id": "chat-memory-safety",
+     "kind": "fixed",
+     "title": "Keep large chats and media manageable",
+     "summary": "Automatic session refresh no longer loops. Routine history loads, chat rendering, image previews, and media exports use bounded memory instead of allocating entire large responses.",
+     "highlight": true
+    },
+    {
+     "id": "image-progress",
+     "kind": "fixed",
+     "title": "Keep image-generation progress visible",
+     "summary": "The working indicator stays visible between interim replies and the generated image, including gateways that omit tool activity events."
+    },
+    {
+     "id": "first-message-readiness",
+     "kind": "fixed",
+     "title": "Wait for new chats to be ready",
+     "summary": "The first message waits for the Gateway session to initialize. Ownership refusals keep the prompt retryable and show the server's error."
+    }
+   ],
+   "compatibility": [
+    "Standard Chat, sessions, media, and voice continue to use upstream Hermes. Voice transcription still requires a configured speech-to-text provider on the Hermes host.",
+    "Paused text queues can be restored. Attachment bytes are not stored in preferences; an attachment queue that cannot be restored must be reviewed and sent again."
+   ],
+   "playNotes": "More reliable chats and media: fewer memory-heavy refreshes, smoother large histories, and attachment previews that survive rotation. Choose whether follow-ups correct the current response or wait in a queue. Voice errors are easier to read, image-generation progress stays visible, and wake-word startup and first-message readiness are fixed.",
+   "sections": []
+  },
+  {
    "version": "1.15.0",
    "title": "Standard Hermes first, with clearer Relay boundaries",
    "date": "2026-08-31",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,29 +1,24 @@
-v1.15.0 - Standard Hermes first, with clearer Relay boundaries
+v1.15.1 - Steadier chat, media, and voice
 
 Summary
-* Chat, voice, attachments, inbound files, current-session Git, usage, and Hermes notices now prefer current upstream Dashboard and Gateway support. Relay stays optional for compatibility and the tools it uniquely provides.
+* Chats use less memory, attachment previews stay in place, and voice failures are easier to recover from. Follow-up controls make it clear whether a message changes the current response or waits for the next turn.
 
 Highlights
-* Use standard Hermes without Relay prompts — Chat attachments, inbound files, current-session Git, Nous usage, and Hermes notices use upstream routes first.
-* Keep returned files loaded — Images, audio, video, and documents download through the Dashboard and no longer flash Relay errors or return to Loading.
-* Use app-specific parent access — A parent PIN or password plus recovery phrase protects Supervised Mode without trusting the phone unlock credential.
+* Choose when follow-up messages are sent — A slim tray behind the composer offers Correct now or Queue next. Chat settings sets the default, and a composer choice applies to one message. Stop pauses pending work until Resume; editing or removing an item keeps the remaining queue usable.
+* Keep attachment previews open through rotation — Image, video, audio, PDF, text, and file previews stay open as the screen rotates. Videos retain their original proportions.
+* Keep large chats and media manageable — Automatic session refresh no longer loops. Routine history loads, chat rendering, image previews, and media exports use bounded memory instead of allocating entire large responses.
 
 Improved
-* See which features need Relay — Media sits with standard Hermes settings while Threads, Terminal, notifications, enhanced voice, and device tools stay under Relay tools.
-* Read the complete release record — What's New shows one release summary, selected highlights, every remaining change, and relevant compatibility notes.
+* Make better use of wider screens — Chat and Voice keep text and controls on readable centered layouts. Landscape Voice Focus separates identity controls from conversation activity.
 
 Fixed
-* Keep Standard voice after removing Relay — Dashboard voice remains ready, temporary outages preserve choices, and shared default-profile settings stay isolated.
-* Observe another client's activity safely — A uniquely matched Desktop or TUI turn can show Working or Waiting without Android taking control.
-* Keep each chat on its chosen transport — Dashboard chats preserve their transcript, draft, profile, and session through sign-out or outages instead of silently changing databases.
-* Preserve completed replies at sign-in expiry — A Dashboard history authentication failure keeps completed text visible and opens the existing sign-in recovery path.
-* Let long context compaction finish — Visible compaction activity refreshes the turn watchdog instead of being interrupted as idle.
-* Render Bot Chat history immediately — Route-owned Bot Chats observe their bound history from first composition.
-* Settle turns after a lost terminal frame — An exact idle live-session snapshot reconciles the Android-owned turn and drains its queued follow-up.
-* Keep Gateway setup parent-owned — Relock and back navigation cancel the exact pending setup without bypassing parent authority.
-* Keep completed generated images visible — Generated media survives marker persistence lag and retains its intended Chat animation.
+* Read message delivery status clearly — Correction and delivery labels use contrasting text instead of disappearing into the message bubble.
+* Read and dismiss voice errors — Voice errors open in a contained dialog with scrollable details and separate Retry and Dismiss actions, without overlapping chat controls.
+* Fix wake-word startup in release builds — Release optimization now preserves the native speech configuration names needed to initialize wake-word detection.
+* Download attachments with less memory — Standard Hermes attachments stream into the on-disk cache while download size limits remain enforced.
+* Keep image-generation progress visible — The working indicator stays visible between interim replies and the generated image, including gateways that omit tool activity events.
+* Wait for new chats to be ready — The first message waits for the Gateway session to initialize. Ownership refusals keep the prompt retryable and show the server's error.
 
 Compatibility
-* Current upstream Hermes provides standard Chat, sessions, Manage, voice, attachments, inbound files, current-session Git reads, usage, and notices without the optional Hermes-Relay Plugin.
-* Hermes-Relay Plugin 1.11.1 remains required for Terminal, proactive Threads and offline delivery, Notification Companion, Relay sessions, enhanced voice, Secure Link, and phone or device control.
-* Granular Device Control and the system Voice Focus overlay remain sideload-only.
+* Standard Chat, sessions, media, and voice continue to use upstream Hermes. Voice transcription still requires a configured speech-to-text provider on the Hermes host.
+* Paused text queues can be restored. Attachment bytes are not stored in preferences; an attachment queue that cannot be restored must be reviewed and sent again.

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/cli",
-      "version": "0.4.0-beta.6",
+      "version": "0.4.0-beta.7",
       "license": "MIT",
       "bin": {
         "hermes-relay": "bin/hermes-relay.js"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-relay/cli",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "description": "Thin-client CLI for Hermes-Relay — talk to a remote Hermes agent over WSS with pairing auth, stream-renders tool calls and responses to plain stdout.",
   "type": "module",
   "bin": {

--- a/desktop/src/version.ts
+++ b/desktop/src/version.ts
@@ -1,2 +1,2 @@
 // Regenerated from package.json by gen:version script. Do not edit by hand.
-export const VERSION = "0.4.0-beta.6" as const
+export const VERSION = "0.4.0-beta.7" as const

--- a/desktop/tray/Cargo.lock
+++ b/desktop/tray/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-relay-tray"
-version = "0.4.0-beta.6"
+version = "0.4.0-beta.7"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/desktop/tray/Cargo.toml
+++ b/desktop/tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-relay-tray"
-version = "0.4.0-beta.6"
+version = "0.4.0-beta.7"
 description = "Compact Windows management UI for Hermes-Relay CLI"
 authors = ["Axiom Labs"]
 edition = "2021"

--- a/desktop/tray/package-lock.json
+++ b/desktop/tray/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hermes-relay/tray-ui",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hermes-relay/tray-ui",
-      "version": "0.4.0-beta.6",
+      "version": "0.4.0-beta.7",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0",
         "lucide-react": "^0.468.0",

--- a/desktop/tray/package.json
+++ b/desktop/tray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermes-relay/tray-ui",
   "private": true,
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/desktop/tray/tauri.conf.json
+++ b/desktop/tray/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes-Relay CLI UI",
-  "version": "0.4.0-beta.6",
+  "version": "0.4.0-beta.7",
   "identifier": "com.axiomlabs.hermes-relay-tray",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -91,9 +91,9 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.15.0 - Standard Hermes first, with clearer Relay boundaries
+v1.15.1 - Steadier chat, media, and voice
 
-Standard Chat, Voice, attachments, returned files, current-session Git, usage, and Hermes notices now prefer upstream Dashboard and Gateway support without requiring Relay. Returned media stays loaded, voice survives Relay removal, and Settings clearly separates standard Hermes from Relay tools. Supervised Mode also gains app-specific parent access and recovery.
+More reliable chats and media: fewer memory-heavy refreshes, smoother large histories, and attachment previews that survive rotation. Choose whether follow-ups correct the current response or wait in a queue. Voice errors are easier to read, image-generation progress stays visible, and wake-word startup and first-message readiness are fixed.
 ```
 ## Category
 

--- a/docs/project/DEVLOG.md
+++ b/docs/project/DEVLOG.md
@@ -1,5 +1,11 @@
 # Hermes-Relay — Dev Log
 
+## 2026-09-02 — Android 1.15.1 and CLI+UI beta.7 release preparation
+
+Prepared Android 1.15.1 (versionCode 54) and CLI+UI 0.4.0-beta.7 from the integrated release tree. Android notes cover chat memory bounds, media previews, Gateway readiness, follow-up controls, and voice recovery. CLI+UI notes cover the Windows unified updater. Plugin metadata remains at 1.11.1; its only unreleased change is a documentation-comment path.
+
+The Android release uses the immutable signed Play preflight artifact for public publication. CLI+UI remains a prerelease and is approved from the exact prepared dev commit.
+
 ## 2026-09-01 — Exact-tree release artifact promotion
 
 Android Play preflight now packages the signed sideload APK, Play AAB, R8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.15.0"
-appVersionCode = "53"
+appVersionName = "1.15.1"
+appVersionCode = "54"
 agp = "9.3.2"
 kotlin = "2.4.10"
 compose-bom = "2026.08.00"


### PR DESCRIPTION
## Summary

Prepare Hermes-Relay Android 1.15.1 and Hermes-Relay CLI+UI 0.4.0-beta.7 from the integrated development branch.

## Changes

- Bump Android to 1.15.1 / versionCode 54 and synchronize its GitHub, in-app, and Play release notes.
- Include the merged chat-memory, attachment-download, preview, wake-word, Gateway-readiness, and follow-up-control fixes, including #532, #535, #536, #537, and #538.
- Bump CLI+UI to 0.4.0-beta.7 for the Windows unified-updater fix; retain the beta track.
- Leave Plugin at 1.11.1 because it has no unreleased runtime changes.

## Verification

- `python scripts/check-android-release-notes.py` — passed.
- `python scripts/check-version-tracks.py` — passed.
- `python scripts/android-prepush.py --release-prep` — passed.
- `npm run check:version-sync`, `npm run type-check`, `npm test`, and `npm run build` in `desktop` — passed; 187 tests.
- Current-head required CI must pass before merge. Private Play preflight runs from the final prepared dev tree before public Android approval.

## Screenshots

The release-presentation tests render the in-app changelog and What's New surfaces. Feature UI and queue lifecycle were reviewed during the implementation PRs; this PR changes release copy and versions only.

## Compatibility / risk

Android is a stable patch; CLI+UI remains a beta. No Plugin version change, credential changes, or direct production-service restart. Public Android publication uses the exact signed Play-preflight artifact. Google Play review/store propagation is distinct from acceptance of the Production submission.

## Lineage / contributor credit

- Source PR(s): integrated development history, including #532, #535, #536, #537, and #538
- Attribution preserved by: existing commits; no replacement or rewritten implementation history

## Checklist

- [x] Target branch is `dev`
- [x] Release preparation is limited to the affected version tracks and notes
- [x] Android release-prep tests ran; lint and full checks run in CI
- [x] Locale validation ran
- [x] No server/plugin runtime changes
- [x] CLI checks and tests passed; Windows tray checks run in CI
- [x] Release-note metadata checks passed; no new site routes
- [x] In-app release presentation rendered by focused tests
- [x] Release commit messages follow repository conventions
- [x] Changelog updated
- [x] Public writing hygiene checked
- [x] Implementation authorship preserved
