### PR TITLE
chore(context): remove duplicate Claude adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,10 @@ coding agent (Claude Code, Codex, Cursor, etc.).
 
 ## Read this first
 
-This file is the provider-neutral canonical agent context. Read it before
-touching code, then `docs/spec.md` and `docs/decisions.md`. Provider adapters
-such as **[CLAUDE.md](CLAUDE.md)** import this file instead of duplicating
-policy. They do not redefine the branch, release, hotfix, or verification
-contract here and in `RELEASE.md`.
+This file is the provider-neutral canonical agent context and the only
+automatically discovered project context. Read it before touching code, then
+`docs/spec.md` and `docs/decisions.md`. It defines the branch, release, hotfix,
+and verification contract alongside `RELEASE.md`.
 
 - Release process → **[RELEASE.md](RELEASE.md)**
 - Contributor setup → **[CONTRIBUTING.md](CONTRIBUTING.md)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Project context has one canonical entry point.** `AGENTS.md` is the sole automatically discovered agent contract; the redundant Claude-specific adapter was removed to prevent duplicate context loading.
+
 ## [Android 1.15.1] - 2026-09-02
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md


### PR DESCRIPTION
## Summary
- make `AGENTS.md` the sole automatically discovered project context
- remove the one-line `CLAUDE.md` adapter
- document the consolidation in the changelog

## Validation
- context-hygiene audit: clean
- `git diff --check`: passed

No runtime or production-code behavior changes.