### PR TITLE
fix(plugin): resolve bridge token after host startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **`android_*` tools resolve a bridge token written after host startup.** Token lookup now falls back from the process environment to the local Hermes env file and then to the newest paired session, preventing paired phones from being rejected until a restart.
+- **`android_*` tools resolve bridge credentials written after host startup.** Requests retry profile-scoped env and active bridge-session credentials after a stale token is rejected, and vision navigation now shares the same current Relay transport instead of the retired standalone default.
 - **`android_setup` accepts both its canonical and legacy schema keys.** `bridge_session_token` and `pairing_code` are accepted, while a missing token returns a structured error.
 - **Android tool setup tests use a temporary Hermes home.** Test runs no longer write bridge settings into a developer environment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **`android_*` tools resolve a bridge token written after host startup.** Token lookup now falls back from the process environment to the local Hermes env file and then to the newest paired session, preventing paired phones from being rejected until a restart.
+- **`android_setup` accepts both its canonical and legacy schema keys.** `bridge_session_token` and `pairing_code` are accepted, while a missing token returns a structured error.
+- **Android tool setup tests use a temporary Hermes home.** Test runs no longer write bridge settings into a developer environment.
+
 ## [Android 1.15.1] - 2026-09-02
 
 ### Changed

--- a/plugin/tests/test_android_navigate.py
+++ b/plugin/tests/test_android_navigate.py
@@ -34,6 +34,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from plugin.tools import android_navigate as nav  # noqa: E402
+from plugin.tools import android_tool  # noqa: E402
 from plugin.tools.android_navigate_prompt import (  # noqa: E402
     ParsedAction,
     VALID_ACTIONS,
@@ -239,6 +240,39 @@ class TestBuildPrompt(unittest.TestCase):
 
 def _mk_screenshot(token: str = "hermes-relay://fake-token") -> nav._Screenshot:
     return nav._Screenshot(token=token, local_path="/tmp/fake.jpg")
+
+
+class TestSharedBridgeTransport(unittest.TestCase):
+    def test_uses_the_canonical_unified_relay_config(self) -> None:
+        self.assertIs(nav._bridge_request, android_tool._bridge_request)
+        with mock.patch.dict(
+            os.environ,
+            {"ANDROID_BRIDGE_URL": "", "ANDROID_BRIDGE_TIMEOUT": "30"},
+        ):
+            os.environ.pop("ANDROID_BRIDGE_URL")
+            self.assertEqual(android_tool._bridge_url(), "http://localhost:8767")
+
+    def test_get_uses_android_tool_bridge_transport(self) -> None:
+        response = mock.Mock()
+        response.json.return_value = {"ok": True}
+        with mock.patch.object(
+            nav, "_bridge_request", return_value=response
+        ) as request:
+            self.assertEqual(nav._get("/screen"), {"ok": True})
+        request.assert_called_once_with("GET", "/screen", timeout=5.0)
+        response.raise_for_status.assert_called_once_with()
+
+    def test_post_uses_android_tool_bridge_transport(self) -> None:
+        response = mock.Mock()
+        response.json.return_value = {"ok": True}
+        with mock.patch.object(
+            nav, "_bridge_request", return_value=response
+        ) as request:
+            self.assertEqual(nav._post("/tap", {"x": 1, "y": 2}), {"ok": True})
+        request.assert_called_once_with(
+            "POST", "/tap", json={"x": 1, "y": 2}, timeout=5.0
+        )
+        response.raise_for_status.assert_called_once_with()
 
 
 class TestNavigateLoop(unittest.TestCase):

--- a/plugin/tests/test_android_tool.py
+++ b/plugin/tests/test_android_tool.py
@@ -1,10 +1,12 @@
 import json
 import os
+from pathlib import Path
 from unittest import mock
 import responses
 import pytest
 
 # Import tool functions directly (not via registry)
+from plugin.tools import android_tool
 from plugin.tools.android_tool import (
     android_ping,
     android_read_screen,
@@ -318,6 +320,26 @@ class TestCurrentApp:
 
 
 class TestSetup:
+    @pytest.fixture(autouse=True)
+    def _isolate_home(self, monkeypatch, tmp_path):
+        """Keep android_setup away from the developer's real ~/.hermes/.env.
+
+        android_setup persists ANDROID_BRIDGE_* by writing the host env file
+        (via hermes_cli.config.save_env_value when importable, otherwise
+        Path.home()/".hermes"/".env"). Without this fixture the suite
+        overwrites the real paired session token on the machine running the
+        tests — which silently 401s every subsequent android_* call.
+        """
+        fake_home = tmp_path / "home"
+        (fake_home / ".hermes").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        monkeypatch.setenv("HERMES_HOME", str(fake_home / ".hermes"))
+        monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
+        monkeypatch.delenv("ANDROID_BRIDGE_URL", raising=False)
+        android_tool._token_cache = (0.0, None)
+        yield
+        android_tool._token_cache = (0.0, None)
+
     @responses.activate
     def test_setup_saves_config(self, monkeypatch):
         """android_setup saves pairing code and sets env vars."""
@@ -328,3 +350,85 @@ class TestSetup:
         # Config should be saved regardless of relay import
         assert os.environ.get("ANDROID_BRIDGE_TOKEN") == "ABC123"
         assert "localhost" in os.environ.get("ANDROID_BRIDGE_URL", "")
+
+    @responses.activate
+    def test_setup_accepts_legacy_pairing_code_kwarg(self, monkeypatch):
+        """The published schema key `pairing_code` must not raise TypeError.
+
+        Regression: the schema advertised a required `pairing_code` while the
+        function signature had been renamed to `bridge_session_token`, so
+        every schema-conformant call died with
+        `TypeError: unexpected keyword argument 'pairing_code'`.
+        """
+        responses.add(responses.GET, "https://api.ipify.org", body="1.2.3.4")
+        result = json.loads(_HANDLERS["android_setup"]({"pairing_code": "LEGACY1"}))
+        assert result["status"] != "error" or "token" not in result.get("message", "")
+        assert os.environ.get("ANDROID_BRIDGE_TOKEN") == "LEGACY1"
+
+    @responses.activate
+    def test_setup_accepts_canonical_kwarg(self, monkeypatch):
+        responses.add(responses.GET, "https://api.ipify.org", body="1.2.3.4")
+        _HANDLERS["android_setup"]({"bridge_session_token": "CANON1"})
+        assert os.environ.get("ANDROID_BRIDGE_TOKEN") == "CANON1"
+
+    def test_setup_without_token_returns_structured_error(self):
+        result = json.loads(_HANDLERS["android_setup"]({}))
+        assert result["status"] == "error"
+        assert "bridge_session_token" in result["message"]
+
+    def test_setup_schema_has_no_required_key(self):
+        """Either spelling is valid, so neither may be schema-required."""
+        params = _SCHEMAS["android_setup"]["parameters"]
+        assert params.get("required") == []
+        assert "bridge_session_token" in params["properties"]
+        assert "pairing_code" in params["properties"]
+
+
+class TestBridgeTokenResolution:
+    """`_bridge_token` must survive a token written after process start."""
+
+    def _clear(self, monkeypatch):
+        monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
+        android_tool._token_cache = (0.0, None)
+
+    def test_env_var_wins(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("ANDROID_BRIDGE_TOKEN", "from-env")
+        android_tool._token_cache = (0.0, None)
+        (tmp_path / ".env").write_text("ANDROID_BRIDGE_TOKEN=from-file\n")
+        assert android_tool._bridge_token() == "from-env"
+
+    def test_falls_back_to_env_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear(monkeypatch)
+        (tmp_path / ".env").write_text(
+            "# comment\nOTHER=x\nANDROID_BRIDGE_TOKEN=\"from-file\"\n"
+        )
+        assert android_tool._bridge_token() == "from-file"
+
+    def test_falls_back_to_sessions_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear(monkeypatch)
+        (tmp_path / "hermes-relay-sessions.json").write_text(
+            json.dumps({
+                "sessions": [
+                    {"token": "older", "last_seen": 1.0},
+                    {"token": "newest", "last_seen": 2.0},
+                ]
+            })
+        )
+        assert android_tool._bridge_token() == "newest"
+
+    def test_returns_none_when_nothing_configured(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear(monkeypatch)
+        assert android_tool._bridge_token() is None
+
+    def test_auth_header_uses_resolved_token(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear(monkeypatch)
+        (tmp_path / ".env").write_text("ANDROID_BRIDGE_TOKEN=hdr-token\n")
+        assert android_tool._auth_headers() == {
+            "Authorization": "Bearer hdr-token"
+        }
+

--- a/plugin/tests/test_android_tool.py
+++ b/plugin/tests/test_android_tool.py
@@ -1,5 +1,7 @@
 import json
 import os
+import sys
+import time
 from pathlib import Path
 from unittest import mock
 import responses
@@ -334,11 +336,16 @@ class TestSetup:
         (fake_home / ".hermes").mkdir(parents=True)
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
         monkeypatch.setenv("HERMES_HOME", str(fake_home / ".hermes"))
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_constants",
+            mock.Mock(get_hermes_home=lambda: fake_home / ".hermes"),
+        )
         monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
         monkeypatch.delenv("ANDROID_BRIDGE_URL", raising=False)
-        android_tool._token_cache = (0.0, None)
+        android_tool._reset_token_cache()
         yield
-        android_tool._token_cache = (0.0, None)
+        android_tool._reset_token_cache()
 
     @responses.activate
     def test_setup_saves_config(self, monkeypatch):
@@ -350,6 +357,9 @@ class TestSetup:
         # Config should be saved regardless of relay import
         assert os.environ.get("ANDROID_BRIDGE_TOKEN") == "ABC123"
         assert "localhost" in os.environ.get("ANDROID_BRIDGE_URL", "")
+        assert "ANDROID_BRIDGE_TOKEN=ABC123" in (
+            Path(os.environ["HERMES_HOME"]) / ".env"
+        ).read_text()
 
     @responses.activate
     def test_setup_accepts_legacy_pairing_code_kwarg(self, monkeypatch):
@@ -389,12 +399,12 @@ class TestBridgeTokenResolution:
 
     def _clear(self, monkeypatch):
         monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
-        android_tool._token_cache = (0.0, None)
+        android_tool._reset_token_cache()
 
     def test_env_var_wins(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("ANDROID_BRIDGE_TOKEN", "from-env")
-        android_tool._token_cache = (0.0, None)
+        android_tool._reset_token_cache()
         (tmp_path / ".env").write_text("ANDROID_BRIDGE_TOKEN=from-file\n")
         assert android_tool._bridge_token() == "from-env"
 
@@ -412,8 +422,18 @@ class TestBridgeTokenResolution:
         (tmp_path / "hermes-relay-sessions.json").write_text(
             json.dumps({
                 "sessions": [
-                    {"token": "older", "last_seen": 1.0},
-                    {"token": "newest", "last_seen": 2.0},
+                    {
+                        "token": "older",
+                        "last_seen": 1.0,
+                        "expires_at": "never",
+                        "grants": {"bridge": "never"},
+                    },
+                    {
+                        "token": "newest",
+                        "last_seen": 2.0,
+                        "expires_at": "never",
+                        "grants": {"bridge": "never"},
+                    },
                 ]
             })
         )
@@ -431,3 +451,124 @@ class TestBridgeTokenResolution:
         assert android_tool._auth_headers() == {
             "Authorization": "Bearer hdr-token"
         }
+
+    def test_uses_request_scoped_profile_home(self, monkeypatch, tmp_path):
+        launch_home = tmp_path / "launch"
+        profile_home = tmp_path / "profile"
+        launch_home.mkdir()
+        profile_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(launch_home))
+        monkeypatch.setenv("ANDROID_BRIDGE_TOKEN", "launch-token")
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_constants",
+            mock.Mock(get_hermes_home=lambda: profile_home),
+        )
+        (profile_home / ".env").write_text("ANDROID_BRIDGE_TOKEN=profile-token\n")
+        android_tool._reset_token_cache()
+        assert android_tool._bridge_token() == "profile-token"
+
+    def test_cache_is_scoped_to_profile_home(self, monkeypatch, tmp_path):
+        active_home = tmp_path / "one"
+        active_home.mkdir()
+        monkeypatch.delenv("ANDROID_BRIDGE_TOKEN", raising=False)
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_constants",
+            mock.Mock(get_hermes_home=lambda: active_home),
+        )
+        (active_home / ".env").write_text("ANDROID_BRIDGE_TOKEN=one\n")
+        android_tool._reset_token_cache()
+        accepted = mock.Mock(status_code=200)
+        with mock.patch.object(android_tool.requests, "get", return_value=accepted):
+            android_tool._bridge_request("GET", "/ping")
+        assert android_tool._token_cache[active_home][1] == "one"
+
+        active_home = tmp_path / "two"
+        active_home.mkdir()
+        (active_home / ".env").write_text("ANDROID_BRIDGE_TOKEN=two\n")
+        assert android_tool._bridge_token() == "two"
+
+    def test_skips_expired_or_ungranted_sessions(self, monkeypatch, tmp_path):
+        now = time.time()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear(monkeypatch)
+        (tmp_path / "hermes-relay-sessions.json").write_text(json.dumps({
+            "sessions": [
+                {
+                    "token": "valid",
+                    "last_seen": 1.0,
+                    "expires_at": now + 60,
+                    "grants": {"bridge": now + 60},
+                },
+                {
+                    "token": "newer-expired-session",
+                    "last_seen": 2.0,
+                    "expires_at": now - 1,
+                    "grants": {"bridge": now + 60},
+                },
+                {
+                    "token": "newer-expired-bridge",
+                    "last_seen": 3.0,
+                    "expires_at": now + 60,
+                    "grants": {"bridge": now - 1},
+                },
+                {
+                    "token": "newest-no-bridge",
+                    "last_seen": 4.0,
+                    "expires_at": now + 60,
+                    "grants": {},
+                },
+            ]
+        }))
+        assert android_tool._bridge_token() == "valid"
+
+    def test_auth_denial_retries_disk_token_and_caches_success(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("ANDROID_BRIDGE_TOKEN", "startup-stale")
+        (tmp_path / ".env").write_text("ANDROID_BRIDGE_TOKEN=rotated-live\n")
+        android_tool._reset_token_cache()
+        denied = mock.Mock(status_code=401)
+        accepted = mock.Mock(status_code=200)
+        with mock.patch.object(
+            android_tool.requests,
+            "get",
+            side_effect=[denied, accepted],
+        ) as request:
+            response = android_tool._bridge_request("GET", "/ping")
+        assert response.status_code == 200
+        assert request.call_args_list[0].kwargs["headers"]["Authorization"] == (
+            "Bearer startup-stale"
+        )
+        assert request.call_args_list[1].kwargs["headers"]["Authorization"] == (
+            "Bearer rotated-live"
+        )
+        assert android_tool._bridge_token() == "rotated-live"
+
+    def test_auth_denial_stops_after_distinct_candidates(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("ANDROID_BRIDGE_TOKEN", "startup-stale")
+        (tmp_path / ".env").write_text("ANDROID_BRIDGE_TOKEN=file-stale\n")
+        now = time.time()
+        (tmp_path / "hermes-relay-sessions.json").write_text(json.dumps({
+            "sessions": [{
+                "token": "session-stale",
+                "last_seen": now,
+                "expires_at": now + 60,
+                "grants": {"bridge": now + 60},
+            }]
+        }))
+        android_tool._reset_token_cache()
+        denied = mock.Mock(status_code=401)
+        with mock.patch.object(
+            android_tool.requests,
+            "get",
+            return_value=denied,
+        ) as request:
+            response = android_tool._bridge_request("GET", "/ping")
+        assert response is denied
+        assert request.call_count == 3

--- a/plugin/tests/test_android_tool.py
+++ b/plugin/tests/test_android_tool.py
@@ -431,4 +431,3 @@ class TestBridgeTokenResolution:
         assert android_tool._auth_headers() == {
             "Authorization": "Bearer hdr-token"
         }
-

--- a/plugin/tests/test_android_tool_device_selector.py
+++ b/plugin/tests/test_android_tool_device_selector.py
@@ -9,6 +9,7 @@ from plugin.tools import android_tool
 class _FakeResponse:
     def __init__(self, payload):
         self._payload = payload
+        self.status_code = 200
 
     def raise_for_status(self):
         return None

--- a/plugin/tools/android_navigate.py
+++ b/plugin/tools/android_navigate.py
@@ -31,41 +31,19 @@ import logging
 import os
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Optional
-
-import requests
+from typing import Any, Callable
 
 from .android_navigate_prompt import ParsedAction, build_prompt, parse_response
+from .android_tool import _bridge_request, _timeout
 
 logger = logging.getLogger("hermes_relay.tools.android_navigate")
 
 # ── Config (shared with android_tool.py conventions) ─────────────────────────
 
 
-def _bridge_url() -> str:
-    return os.getenv("ANDROID_BRIDGE_URL", "http://localhost:8766")
-
-
-def _bridge_token() -> Optional[str]:
-    return os.getenv("ANDROID_BRIDGE_TOKEN")
-
-
-def _timeout() -> float:
-    return float(os.getenv("ANDROID_BRIDGE_TIMEOUT", "30"))
-
-
-def _auth_headers() -> dict:
-    token = _bridge_token()
-    if token:
-        return {"Authorization": f"Bearer {token}"}
-    return {}
-
-
 def _check_requirements() -> bool:
     try:
-        r = requests.get(
-            f"{_bridge_url()}/ping", headers=_auth_headers(), timeout=2
-        )
+        r = _bridge_request("GET", "/ping", timeout=2)
         if r.status_code == 200:
             data = r.json()
             return data.get("phone_connected", False) or data.get(
@@ -77,18 +55,16 @@ def _check_requirements() -> bool:
 
 
 def _get(path: str) -> dict:
-    r = requests.get(
-        f"{_bridge_url()}{path}", headers=_auth_headers(), timeout=_timeout()
-    )
+    r = _bridge_request("GET", path, timeout=_timeout())
     r.raise_for_status()
     return r.json()
 
 
 def _post(path: str, payload: dict) -> dict:
-    r = requests.post(
-        f"{_bridge_url()}{path}",
+    r = _bridge_request(
+        "POST",
+        path,
         json=payload,
-        headers=_auth_headers(),
         timeout=_timeout(),
     )
     r.raise_for_status()

--- a/plugin/tools/android_tool.py
+++ b/plugin/tools/android_tool.py
@@ -89,8 +89,94 @@ def _bridge_url() -> str:
     """URL of the relay (default) or direct phone connection."""
     return os.getenv("ANDROID_BRIDGE_URL", "http://localhost:8767")
 
+def _hermes_home() -> Path:
+    """Host Hermes home, honouring an explicit ``HERMES_HOME`` override."""
+    override = os.getenv("HERMES_HOME")
+    return Path(override) if override else Path.home() / ".hermes"
+
+
+def _token_from_env_file() -> Optional[str]:
+    """Read ``ANDROID_BRIDGE_TOKEN`` straight out of ``~/.hermes/.env``."""
+    try:
+        raw = (_hermes_home() / ".env").read_text(encoding="utf-8-sig")
+    except OSError:
+        return None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        if key.strip() != "ANDROID_BRIDGE_TOKEN":
+            continue
+        value = value.strip().strip('"').strip("'")
+        if value:
+            return value
+    return None
+
+
+def _token_from_sessions() -> Optional[str]:
+    """Fall back to the most recently seen paired session token."""
+    try:
+        raw = (_hermes_home() / "hermes-relay-sessions.json").read_text(
+            encoding="utf-8"
+        )
+        data = json.loads(raw)
+    except (OSError, ValueError):
+        return None
+    sessions = data.get("sessions") if isinstance(data, dict) else None
+    if not isinstance(sessions, list):
+        return None
+
+    def _last_seen(entry: Any) -> float:
+        seen = entry.get("last_seen") if isinstance(entry, dict) else None
+        return float(seen) if isinstance(seen, (int, float)) else 0.0
+
+    for entry in sorted(sessions, key=_last_seen, reverse=True):
+        if not isinstance(entry, dict):
+            continue
+        token = entry.get("token")
+        if isinstance(token, str) and token:
+            return token
+    return None
+
+
+# Disk fallbacks are re-read at most once per TTL so a long-lived host does
+# not stat two files on every single bridge call.
+_TOKEN_CACHE_TTL = 30.0
+_token_cache: tuple[float, Optional[str]] = (0.0, None)
+
+
 def _bridge_token() -> Optional[str]:
-    return os.getenv("ANDROID_BRIDGE_TOKEN")
+    """Bearer token for every relay bridge call.
+
+    Resolution order:
+
+    1. ``ANDROID_BRIDGE_TOKEN`` in the process environment.
+    2. ``ANDROID_BRIDGE_TOKEN`` in ``~/.hermes/.env`` — the file
+       :func:`android_setup` writes.
+    3. The most recently seen paired session in
+       ``~/.hermes/hermes-relay-sessions.json``.
+
+    Steps 2 and 3 exist because the environment is snapshotted when the host
+    process starts: a token written (by ``android_setup``, ``hermes-pair``, or
+    by hand) *after* that point stayed invisible until a full restart, and
+    every bridge endpoint answered ``401 Authorization: Bearer *** required``
+    on a phone that was in fact paired and connected.
+    """
+    global _token_cache
+
+    token = os.getenv("ANDROID_BRIDGE_TOKEN")
+    if token:
+        return token
+
+    cached_at, cached = _token_cache
+    now = time.monotonic()
+    if cached and (now - cached_at) < _TOKEN_CACHE_TTL:
+        return cached
+
+    resolved = _token_from_env_file() or _token_from_sessions()
+    _token_cache = (now, resolved)
+    return resolved
 
 def _relay_port() -> int:
     # Unified relay default. Override via ANDROID_RELAY_PORT or RELAY_PORT.
@@ -1229,7 +1315,10 @@ def _get_public_ip() -> str:
         return "<your-server-ip>"
 
 
-def android_setup(bridge_session_token: str) -> str:
+def android_setup(
+    bridge_session_token: Optional[str] = None,
+    pairing_code: Optional[str] = None,
+) -> str:
     """
     FALLBACK helper — tell the android_* tools about an existing session token.
 
@@ -1248,13 +1337,27 @@ def android_setup(bridge_session_token: str) -> str:
 
     The parameter name was historically ``pairing_code``, but the value is
     actually used as a long-lived bearer token, not a one-shot pairing code.
-    Renamed for clarity.
+    ``bridge_session_token`` is the canonical name; ``pairing_code`` is kept
+    as an accepted alias so older callers (and the tool schema that shipped
+    before the rename) keep working instead of raising ``TypeError``.
 
     Example: android_setup("eyJraWQiOi...long-token...")
     """
     # Local alias keeps the rest of the function readable without
-    # propagating the rename through every line.
-    pairing_code = bridge_session_token
+    # propagating the rename through every line. Either spelling is
+    # accepted; the canonical name wins when both are supplied.
+    token = bridge_session_token or pairing_code
+    if not token or not str(token).strip():
+        return json.dumps({
+            "status": "error",
+            "message": (
+                "android_setup requires a bridge session token. Pass it as "
+                "bridge_session_token (canonical) or pairing_code (legacy "
+                "alias). For a first-time pair use `hermes-pair` or "
+                "/hermes-relay-pair instead."
+            ),
+        })
+    pairing_code = str(token).strip()
     try:
         port = _relay_port()
         public_ip = _get_public_ip()
@@ -1967,16 +2070,38 @@ _SCHEMAS = {
     },
     "android_setup": {
         "name": "android_setup",
-        "description": "Start the Android bridge relay and set the pairing code. Call this when the user wants to connect their phone. The relay runs on this server — the phone connects to it remotely via WebSocket. Only needs the pairing code shown in the Hermes Bridge app on the phone.",
+        "description": (
+            "FALLBACK — teach this host's android_* tools about a bridge "
+            "session token you already have. This is NOT the pairing flow: "
+            "to pair a phone for the first time use `hermes-pair` or the "
+            "/hermes-relay-pair slash command (QR scan). Writes "
+            "ANDROID_BRIDGE_TOKEN/ANDROID_BRIDGE_URL to ~/.hermes/.env and "
+            "verifies the relay is reachable."
+        ),
         "parameters": {
             "type": "object",
             "properties": {
+                "bridge_session_token": {
+                    "type": "string",
+                    "description": (
+                        "Long-lived bridge session token from a previous "
+                        "successful pair (not a 6-character pairing code)."
+                    ),
+                },
                 "pairing_code": {
                     "type": "string",
-                    "description": "6-character pairing code shown in the Hermes Bridge app on the phone",
+                    "description": (
+                        "Deprecated alias for bridge_session_token, accepted "
+                        "for backwards compatibility. Prefer "
+                        "bridge_session_token."
+                    ),
                 },
             },
-            "required": ["pairing_code"],
+            # Neither key is schema-required: exactly one of the two must be
+            # supplied, which JSON Schema draft-07 cannot express in a way
+            # every tool-call validator honours. The handler returns a
+            # structured error when both are missing.
+            "required": [],
         },
     },
     "android_macro": {

--- a/plugin/tools/android_tool.py
+++ b/plugin/tools/android_tool.py
@@ -90,9 +90,14 @@ def _bridge_url() -> str:
     return os.getenv("ANDROID_BRIDGE_URL", "http://localhost:8767")
 
 def _hermes_home() -> Path:
-    """Host Hermes home, honouring an explicit ``HERMES_HOME`` override."""
-    override = os.getenv("HERMES_HOME")
-    return Path(override) if override else Path.home() / ".hermes"
+    """Return the request-scoped Hermes home when the host exposes one."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home())
+    except (ImportError, AttributeError, TypeError):
+        override = os.getenv("HERMES_HOME")
+        return Path(override) if override else Path.home() / ".hermes"
 
 
 def _token_from_env_file() -> Optional[str]:
@@ -115,7 +120,7 @@ def _token_from_env_file() -> Optional[str]:
 
 
 def _token_from_sessions() -> Optional[str]:
-    """Fall back to the most recently seen paired session token."""
+    """Return the newest unexpired session with an active bridge grant."""
     try:
         raw = (_hermes_home() / "hermes-relay-sessions.json").read_text(
             encoding="utf-8"
@@ -127,23 +132,78 @@ def _token_from_sessions() -> Optional[str]:
     if not isinstance(sessions, list):
         return None
 
+    def _timestamp_is_active(value: Any, now: float) -> bool:
+        if value == "never":
+            return True
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and float(value) > now
+        )
+
     def _last_seen(entry: Any) -> float:
         seen = entry.get("last_seen") if isinstance(entry, dict) else None
-        return float(seen) if isinstance(seen, (int, float)) else 0.0
+        return (
+            float(seen)
+            if isinstance(seen, (int, float)) and not isinstance(seen, bool)
+            else 0.0
+        )
 
+    now = time.time()
     for entry in sorted(sessions, key=_last_seen, reverse=True):
         if not isinstance(entry, dict):
             continue
+        if not _timestamp_is_active(entry.get("expires_at"), now):
+            continue
+        grants = entry.get("grants")
+        if not isinstance(grants, dict) or not _timestamp_is_active(
+            grants.get("bridge"), now
+        ):
+            continue
         token = entry.get("token")
-        if isinstance(token, str) and token:
-            return token
+        if isinstance(token, str) and token.strip():
+            return token.strip()
     return None
 
 
 # Disk fallbacks are re-read at most once per TTL so a long-lived host does
 # not stat two files on every single bridge call.
 _TOKEN_CACHE_TTL = 30.0
-_token_cache: tuple[float, Optional[str]] = (0.0, None)
+_token_cache: dict[Path, tuple[float, str]] = {}
+
+
+def _reset_token_cache() -> None:
+    _token_cache.clear()
+
+
+def _process_token_for_home(home: Path) -> Optional[str]:
+    """Use the process token only for the launch profile that owns it."""
+    launch_home = Path(os.getenv("HERMES_HOME") or (Path.home() / ".hermes"))
+    if home != launch_home:
+        return None
+    token = os.getenv("ANDROID_BRIDGE_TOKEN")
+    return token.strip() if token and token.strip() else None
+
+
+def _bridge_token_candidates(*, refresh: bool = False) -> list[str]:
+    """Return distinct bearer candidates for the active profile."""
+    home = _hermes_home()
+    cached = _token_cache.get(home)
+    now = time.monotonic()
+    values: list[Optional[str]] = []
+    if cached and now < cached[0]:
+        values.append(cached[1])
+    values.append(_process_token_for_home(home))
+    if refresh or not values or not any(values):
+        values.extend((_token_from_env_file(), _token_from_sessions()))
+
+    candidates: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            token = value.strip()
+            if token and token not in candidates:
+                candidates.append(token)
+    return candidates
 
 
 def _bridge_token() -> Optional[str]:
@@ -163,20 +223,47 @@ def _bridge_token() -> Optional[str]:
     every bridge endpoint answered ``401 Authorization: Bearer *** required``
     on a phone that was in fact paired and connected.
     """
-    global _token_cache
+    candidates = _bridge_token_candidates()
+    return candidates[0] if candidates else None
 
-    token = os.getenv("ANDROID_BRIDGE_TOKEN")
-    if token:
-        return token
 
-    cached_at, cached = _token_cache
-    now = time.monotonic()
-    if cached and (now - cached_at) < _TOKEN_CACHE_TTL:
-        return cached
+def _bridge_request(method: str, path: str, **kwargs: Any) -> requests.Response:
+    """Send a bridge request, retrying live disk credentials after auth denial."""
+    home = _hermes_home()
+    base_headers = dict(kwargs.pop("headers", {}) or {})
+    first = _bridge_token()
+    candidates: list[Optional[str]] = [first]
+    attempted: set[Optional[str]] = set()
+    response: Optional[requests.Response] = None
 
-    resolved = _token_from_env_file() or _token_from_sessions()
-    _token_cache = (now, resolved)
-    return resolved
+    while candidates:
+        token = candidates.pop(0)
+        attempted.add(token)
+        headers = dict(base_headers)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        request = requests.get if method.upper() == "GET" else requests.post
+        response = request(
+            f"{_bridge_url()}{path}",
+            headers=headers,
+            **kwargs,
+        )
+        if response.status_code not in (401, 403):
+            if token:
+                _token_cache[home] = (
+                    time.monotonic() + _TOKEN_CACHE_TTL,
+                    token,
+                )
+            return response
+        if not candidates:
+            candidates.extend(
+                candidate
+                for candidate in _bridge_token_candidates(refresh=True)
+                if candidate not in attempted
+            )
+
+    assert response is not None
+    return response
 
 def _relay_port() -> int:
     # Unified relay default. Override via ANDROID_RELAY_PORT or RELAY_PORT.
@@ -202,7 +289,7 @@ _DEVICE_SELECTOR_PROPERTY = {
 }
 
 def _auth_headers() -> dict:
-    """Build auth headers with pairing code if configured."""
+    """Build auth headers with the preferred bridge session token."""
     token = _bridge_token()
     if token:
         return {"Authorization": f"Bearer {token}"}
@@ -237,11 +324,7 @@ def _check_requirements() -> bool:
     direct-phone development shims that predate the unified relay.
     """
     try:
-        r = requests.get(
-            f"{_bridge_url()}/bridge/status",
-            headers=_auth_headers(),
-            timeout=2,
-        )
+        r = _bridge_request("GET", "/bridge/status", timeout=2)
         if r.status_code == 200:
             data = r.json()
             bridge = data.get("bridge") if isinstance(data, dict) else None
@@ -254,7 +337,7 @@ def _check_requirements() -> bool:
         pass
 
     try:
-        r = requests.get(f"{_bridge_url()}/ping", headers=_auth_headers(), timeout=2)
+        r = _bridge_request("GET", "/ping", timeout=2)
         if r.status_code == 200:
             data = r.json()
             return bool(
@@ -271,14 +354,14 @@ def _post(path: str, payload: dict, *, device: Optional[str] = None) -> dict:
     selector = _selected_device(device)
     if selector and "device" not in body:
         body["device"] = selector
-    r = requests.post(f"{_bridge_url()}{path}", json=body,
-                      headers=_auth_headers(), timeout=_timeout())
+    r = _bridge_request("POST", path, json=body, timeout=_timeout())
     r.raise_for_status()
     return r.json()
 
 def _get(path: str, *, device: Optional[str] = None) -> dict:
-    r = requests.get(f"{_bridge_url()}{_path_with_device(path, device)}",
-                     headers=_auth_headers(), timeout=_timeout())
+    r = _bridge_request(
+        "GET", _path_with_device(path, device), timeout=_timeout()
+    )
     r.raise_for_status()
     return r.json()
 
@@ -1370,8 +1453,7 @@ def android_setup(
             save_env_value("ANDROID_BRIDGE_TOKEN", pairing_code)
             save_env_value("ANDROID_RELAY_PORT", str(port))
         except ImportError:
-            from pathlib import Path
-            env_path = Path.home() / ".hermes" / ".env"
+            env_path = _hermes_home() / ".env"
             env_path.parent.mkdir(parents=True, exist_ok=True)
             _update_env_file(env_path, "ANDROID_BRIDGE_URL", relay_url)
             _update_env_file(env_path, "ANDROID_BRIDGE_TOKEN", pairing_code)
@@ -1394,11 +1476,7 @@ def android_setup(
 
         if relay_running:
             try:
-                ping = requests.get(
-                    f"http://localhost:{port}/ping",
-                    headers=_auth_headers(),
-                    timeout=2,
-                )
+                ping = _bridge_request("GET", "/ping", timeout=2)
                 if ping.status_code == 200:
                     phone_connected = True
             except Exception:


### PR DESCRIPTION
## Summary
Restores usable `android_*` bridge calls when pairing or configuration changes credentials after a long-lived host has started, and makes `android_setup` callable through both the canonical and legacy schema keys.

## Changes
- keep the process environment override for the launch profile, then retry live profile-scoped env/session credentials after an authentication denial
- cache successful credentials for 30 seconds per active profile and ignore expired sessions or sessions without a live `bridge` grant
- route `android_navigate` through the same bridge transport, removing its retired standalone-port default
- accept `bridge_session_token` and legacy `pairing_code`; return a structured error when neither is supplied
- isolate setup tests from the operator's real Hermes home

## Verification
- `python -m pytest plugin/tests/test_android_tool.py plugin/tests/test_android_tool_device_selector.py plugin/tests/test_android_navigate.py -q` → `86 passed`
- `python -m py_compile plugin/tools/android_tool.py plugin/tools/android_navigate.py plugin/tests/test_android_tool.py plugin/tests/test_android_navigate.py` → passed
- `python -m pytest plugin/tests -q` → `1575 passed, 11 skipped, 2 unrelated provider-usage failures`; both failures reproduce on the unchanged contributor head
- `git diff --check origin/dev...HEAD` → passed
- Physical phone/device proof was not rerun for this PR.

## Screenshots
No visual change.

## Compatibility / risk
Optional plugin-only change; Standard Hermes upstream behavior is unchanged. A rejected credential may cause the request to retry each distinct profile-owned fallback once. The successful credential is cached for at most 30 seconds and never crosses profile homes.

## Lineage / contributor credit
- Source PR(s): N/A
- Attribution preserved by: original contributor commits/authorship retained with one maintainer follow-up commit

## Checklist
- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A — no Android client code changed
- [x] Translation changes: N/A
- [x] Server/plugin changes: focused tests ran
- [x] Desktop changes: N/A
- [x] Docs/site changes: N/A
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for user-visible changes
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above