### PR TITLE
test(android): await git commit success callback

### DIFF
--- a/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/GitStateWriteViewModelTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/viewmodel/GitStateWriteViewModelTest.kt
@@ -3,6 +3,7 @@ package com.hermesandroid.relay.viewmodel
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.hermesandroid.relay.network.upstream.DashboardApiClient
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterIsInstance
@@ -147,12 +148,14 @@ class GitStateWriteViewModelTest {
         val vm = viewModel()
         selectAlpha(vm)
         enqueuePostSuccess("abc")
-        var committedTarget: GitTarget? = null
+        val committedTarget = CompletableDeferred<GitTarget>()
 
-        vm.commit("add feature") { committedTarget = it }
+        vm.commit("add feature") { committedTarget.complete(it) }
         withTimeout(5_000) { vm.mutation.filterIsInstance<GitMutationState.Success>().first() }
 
-        assertEquals("alpha", committedTarget?.repoId)
+        // Success is published before detail refresh and the callback complete.
+        val target = withTimeout(5_000) { committedTarget.await() }
+        assertEquals("alpha", target.repoId)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix a race in the Android Git-state commit-success callback test. The test treated mutation success publication as proof that its callback had already run, although the ViewModel refreshes repository details before invoking the callback.

This is an independent test-only fix; it is not part of the hosted-room feature in #559.

## Changes

- Capture the callback's `GitTarget` in a `CompletableDeferred` and await delivery with a bounded timeout.
- Preserve the successful mutation-state observation and `alpha` repository assertion.
- Leave production behavior, response ordering, and the separate failure-callback test unchanged. No sleeps, retries, skipped tests, or timeout increases.

## Verification

Baseline: `df0fe59b0b11b5b1646b62b9d2c23ef791194984` (freshly fetched `origin/dev`).
Verified patch: `bb23e6ab483316b24931cfc3a9edc69197691a18`. Its [required hosted checks passed](https://github.com/Codename-11/hermes-relay/actions/runs/34184181565/job/101930776489), including Android tests, lint and build. Local test scope is recorded below.

All Android commands used the Windows machine-wide lane and the installed Android SDK, with `ANDROID_HOME` and `ANDROID_SDK_ROOT` set.

```powershell
powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/android-lane.ps1 gradle :app:testSideloadDebugUnitTest --tests '*GitStateWriteViewModelTest.commit success callback fires only after successful response' --console=plain
```

- Unmodified baseline: **1 test / 1 failure**, `expected:<alpha> but was:<null>` at the callback assertion.
- Fixed tree: **1 test / 0 failures**.

```powershell
powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/android-lane.ps1 gradle :app:testSideloadDebugUnitTest --tests '*GitState*ViewModelTest' :app:testGoogleplayDebugUnitTest --tests '*GitState*ViewModelTest' --console=plain
```

- Both Gradle test tasks executed successfully on the committed patch; the Google Play task resolves to `:app:testGooglePlayDebugUnitTest`.
- **66 tests passed, 0 failures/errors/skips**: 33 each for sideload and Google Play, covering `GitStateViewModelTest`, `GitStateWriteViewModelTest`, and `GitStateExtrasViewModelTest`.
- Independent diff review and `git diff --check` passed.
- Full Android lint, unrelated test shards, assemblies, and device/emulator testing were not run: this changes only synchronization inside a JVM unit test, not application/UI code. Existing compiler/deprecation warnings remain unchanged.

## Screenshots

No visual change.

## Compatibility / risk

Test-only. No upstream API, production behavior, storage, security/privacy, translation, server/plugin, desktop, or documentation changes. No migration or rollout required. Changelog: N/A, no user-visible change.

## Lineage / contributor credit

- Source PR(s): N/A; independent fix to an existing `dev` test, discovered while checking #559.
- Attribution preserved by: existing history unchanged; the new commit includes the author's DCO `Signed-off-by` trailer.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: lint and focused tests ran, or rationale is listed above
- [x] Translation changes: locale validation/review ran, or N/A is listed above
- [x] Server/plugin changes: focused tests ran, or N/A/rationale is listed above
- [x] Desktop changes: build/tests ran, or N/A/rationale is listed above
- [x] Docs/site changes: build or link/route checks ran, or N/A/rationale is listed above
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for user-visible changes, or N/A is listed above
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above
