### PR TITLE
fix(plugin): default relay tool URLs to 127.0.0.1 instead of localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Relay tool defaults use `127.0.0.1` instead of `localhost`.** On Windows, `localhost` resolves to `::1` first while the relay listens on IPv4 only, so every `desktop_*`/`android_*` availability probe burned its full 2 s timeout before falling back. `DESKTOP_RELAY_URL` and `ANDROID_BRIDGE_URL` overrides are unchanged.
 - **`android_*` tools resolve bridge credentials written after host startup.** Requests retry profile-scoped env and active bridge-session credentials after a stale token is rejected, and vision navigation now shares the same current Relay transport instead of the retired standalone default.
 - **`android_setup` accepts both its canonical and legacy schema keys.** `bridge_session_token` and `pairing_code` are accepted, while a missing token returns a structured error.
 - **Android tool setup tests use a temporary Hermes home.** Test runs no longer write bridge settings into a developer environment.

--- a/plugin/tests/test_android_navigate.py
+++ b/plugin/tests/test_android_navigate.py
@@ -250,7 +250,7 @@ class TestSharedBridgeTransport(unittest.TestCase):
             {"ANDROID_BRIDGE_URL": "", "ANDROID_BRIDGE_TIMEOUT": "30"},
         ):
             os.environ.pop("ANDROID_BRIDGE_URL")
-            self.assertEqual(android_tool._bridge_url(), "http://localhost:8767")
+            self.assertEqual(android_tool._bridge_url(), "http://127.0.0.1:8767")
 
     def test_get_uses_android_tool_bridge_transport(self) -> None:
         response = mock.Mock()

--- a/plugin/tools/android_tool.py
+++ b/plugin/tools/android_tool.py
@@ -86,8 +86,14 @@ except ImportError:  # pragma: no cover - direct-script fallback
 # by setting ANDROID_BRIDGE_URL to the phone's IP.
 
 def _bridge_url() -> str:
-    """URL of the relay (default) or direct phone connection."""
-    return os.getenv("ANDROID_BRIDGE_URL", "http://localhost:8767")
+    """URL of the relay (default) or direct phone connection.
+
+    ``127.0.0.1`` rather than ``localhost``: on Windows the latter resolves to
+    ``::1`` first, the relay listens on IPv4 only, and every availability probe
+    then burns its full timeout before falling back (a 2 s tax per check on
+    each run start).
+    """
+    return os.getenv("ANDROID_BRIDGE_URL", "http://127.0.0.1:8767")
 
 def _hermes_home() -> Path:
     """Return the request-scoped Hermes home when the host exposes one."""

--- a/plugin/tools/desktop_tool.py
+++ b/plugin/tools/desktop_tool.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from contextvars import ContextVar
 from typing import Any, Optional
 
@@ -112,8 +113,14 @@ def _trusted_call_context(kwargs: dict[str, Any]) -> dict[str, str]:
 
 
 def _relay_url() -> str:
-    """URL of the unified relay. Defaults to localhost:8767."""
-    return os.getenv("DESKTOP_RELAY_URL", "http://localhost:8767")
+    """URL of the unified relay. Defaults to 127.0.0.1:8767.
+
+    Deliberately not ``localhost``: on Windows that resolves to ``::1`` first,
+    the relay listens on IPv4 only, and each probe then burns the full 2 s
+    timeout before falling back. With ~48 desktop tools the availability sweep
+    added over 70 s to every run start when no desktop client was connected.
+    """
+    return os.getenv("DESKTOP_RELAY_URL", "http://127.0.0.1:8767")
 
 
 def _relay_token() -> Optional[str]:


### PR DESCRIPTION
## Summary

On Windows, `localhost` resolves to `::1` first and the relay listens on IPv4 only. Every `desktop_*` and `android_*` availability probe (`check_fn`, evaluated for each registered tool at run start) burned its full 2 s connect timeout on `::1` before falling back to `127.0.0.1`. With ~78 registered tools and no client connected, the availability sweep added over a minute to every run start.

Measured on Windows 11 with no desktop or phone client connected: the 78-check sweep took ~73 s before this change. Combined with #563 (one shared probe instead of one per tool) it drops to ~40 ms.

## Changes

- `plugin/tools/desktop_tool.py`: `_relay_url()` default `http://localhost:8767` → `http://127.0.0.1:8767`
- `plugin/tools/android_tool.py`: `_bridge_url()` default `http://localhost:8767` → `http://127.0.0.1:8767` (`android_navigate` already shares this function on `dev`)
- `plugin/tests/test_android_navigate.py`: default-URL assertion updated
- `CHANGELOG.md`: Unreleased / Fixed entry

`DESKTOP_RELAY_URL` and `ANDROID_BRIDGE_URL` overrides are unchanged. The relay itself is not touched; only the client-side default the plugin tools dial.

## Verification

- `python -m pytest plugin/tests/test_android_tool.py plugin/tests/test_desktop_multidevice.py plugin/tests/test_android_navigate.py plugin/tests/test_desktop_health.py` → 104 passed
- Full `plugin/tests` (excluding `test_native_layout_imports`): same 6 pre-existing failures as clean `origin/dev` on this host (`test_git_state`, `test_provider_usage`, `test_register_code`, `test_secure_proxy*`), none in touched files.
- Android: N/A (no Android changes).

## Screenshots

No visual change.

## Compatibility / risk

N/A for vanilla Hermes (plugin-only). Anyone who bound the relay to IPv6-only loopback and relied on the implicit `localhost` default would need to set `DESKTOP_RELAY_URL` / `ANDROID_BRIDGE_URL` explicitly; the relay's own default bind is IPv4.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A
- [x] Translation changes: N/A
- [x] Server/plugin changes: focused tests ran (see Verification)
