### PR TITLE
perf(plugin): share one cached relay probe across tool availability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Tool availability checks no longer probe the relay once per tool.** `desktop_*` checks share one cached `GET /desktop/health` snapshot and `android_*` checks share one cached bridge status, so run start makes a couple of requests instead of ~78.
 - **`android_*` tools resolve bridge credentials written after host startup.** Requests retry profile-scoped env and active bridge-session credentials after a stale token is rejected, and vision navigation now shares the same current Relay transport instead of the retired standalone default.
 - **`android_setup` accepts both its canonical and legacy schema keys.** `bridge_session_token` and `pairing_code` are accepted, while a missing token returns a structured error.
 - **Android tool setup tests use a temporary Hermes home.** Test runs no longer write bridge settings into a developer environment.

--- a/plugin/tests/test_android_tool.py
+++ b/plugin/tests/test_android_tool.py
@@ -75,6 +75,12 @@ class TestPing:
 
 
 class TestRequirements:
+    @pytest.fixture(autouse=True)
+    def _reset_requirements_cache(self):
+        android_tool._requirements_cache = (0.0, None)
+        yield
+        android_tool._requirements_cache = (0.0, None)
+
     @responses.activate
     def test_requirements_true_for_device_control_phone(self, bridge_url):
         responses.add(
@@ -98,6 +104,36 @@ class TestRequirements:
             },
         )
         assert _check_requirements() is False
+
+    @responses.activate
+    def test_requirements_cached_across_registered_tools(self, bridge_url):
+        # The host runs check_fn for every android_* tool at run start;
+        # only the first evaluation inside the TTL window should hit the relay.
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/bridge/status",
+            json={"phone_connected": True, "bridge": {"device_control_supported": True}},
+        )
+        assert _check_requirements() is True
+        assert _check_requirements() is True
+        assert _check_requirements() is True
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_requirements_cache_expires(self, bridge_url):
+        responses.add(
+            responses.GET,
+            f"{bridge_url}/bridge/status",
+            json={"phone_connected": False},
+        )
+        assert _check_requirements() is False
+        stamp, cached = android_tool._requirements_cache
+        android_tool._requirements_cache = (
+            stamp - android_tool._REQUIREMENTS_CACHE_TTL_S - 1,
+            cached,
+        )
+        assert _check_requirements() is False
+        assert len(responses.calls) == 2
 
 
 class TestReadScreen:

--- a/plugin/tests/test_desktop_tool_availability.py
+++ b/plugin/tests/test_desktop_tool_availability.py
@@ -1,0 +1,94 @@
+"""Availability checks for ``desktop_*`` tools share one cached health snapshot."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from plugin.tools import desktop_tool
+
+
+def _health(connected: bool, tools: list[str]) -> Mock:
+    response = Mock(status_code=200)
+    response.json.return_value = {
+        "connected": connected,
+        "advertised_tools": tools,
+    }
+    return response
+
+
+class DesktopAvailabilityCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        desktop_tool._advertised_cache = (0.0, None)
+
+    def tearDown(self) -> None:
+        desktop_tool._advertised_cache = (0.0, None)
+
+    def test_sweep_across_all_tools_makes_one_health_request(self) -> None:
+        names = [n for n in desktop_tool._SCHEMAS if n not in desktop_tool._RELAY_ONLY_TOOLS]
+        self.assertGreater(len(names), 20)
+        with patch.object(
+            desktop_tool.requests,
+            "get",
+            return_value=_health(True, ["desktop_read_file", "desktop_powershell"]),
+        ) as get:
+            results = {name: desktop_tool._check_tool(name) for name in names}
+        self.assertEqual(get.call_count, 1)
+        self.assertTrue(get.call_args.args[0].endswith("/desktop/health"))
+        self.assertTrue(results["desktop_read_file"])
+        self.assertTrue(results["desktop_powershell"])
+        self.assertFalse(results["desktop_terminal"])
+        self.assertFalse(results["desktop_computer_action"])
+
+    def test_unreachable_relay_fails_closed_once_per_window(self) -> None:
+        with patch.object(
+            desktop_tool.requests,
+            "get",
+            side_effect=requests.ConnectionError("refused"),
+        ) as get:
+            self.assertFalse(desktop_tool._check_tool("desktop_read_file"))
+            self.assertFalse(desktop_tool._check_tool("desktop_terminal"))
+            self.assertFalse(desktop_tool._check_tool("desktop_job_start"))
+        self.assertEqual(get.call_count, 1)
+
+    def test_no_client_connected_is_unavailable(self) -> None:
+        with patch.object(
+            desktop_tool.requests, "get", return_value=_health(False, [])
+        ):
+            self.assertFalse(desktop_tool._check_tool("desktop_read_file"))
+
+    def test_client_without_advertisement_is_optimistic_except_computer_use(self) -> None:
+        # Mirrors DesktopHandler.has_client_for for older clients that never
+        # sent a desktop.status advertisement.
+        with patch.object(
+            desktop_tool.requests, "get", return_value=_health(True, [])
+        ):
+            self.assertTrue(desktop_tool._check_tool("desktop_read_file"))
+            self.assertFalse(desktop_tool._check_tool("desktop_computer_action"))
+
+    def test_cache_expires_after_ttl(self) -> None:
+        with patch.object(
+            desktop_tool.requests, "get", return_value=_health(True, ["desktop_read_file"])
+        ) as get:
+            self.assertTrue(desktop_tool._check_tool("desktop_read_file"))
+            stamp, cached = desktop_tool._advertised_cache
+            desktop_tool._advertised_cache = (
+                stamp - desktop_tool._ADVERTISED_CACHE_TTL_S - 1,
+                cached,
+            )
+            self.assertTrue(desktop_tool._check_tool("desktop_read_file"))
+        self.assertEqual(get.call_count, 2)
+
+    def test_relay_only_health_check_bypasses_snapshot(self) -> None:
+        # desktop_health stays callable with no client connected.
+        with patch.object(
+            desktop_tool.requests, "get", return_value=_health(False, [])
+        ):
+            self.assertTrue(desktop_tool._check_relay())
+            self.assertFalse(desktop_tool._check_tool("desktop_read_file"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugin/tools/android_tool.py
+++ b/plugin/tools/android_tool.py
@@ -314,8 +314,30 @@ def _path_with_device(path: str, device: Optional[str] = None) -> str:
     sep = "&" if "?" in path else "?"
     return f"{path}{sep}{urlencode({'device': selector})}"
 
+_REQUIREMENTS_CACHE_TTL_S = 3.0
+# (monotonic stamp, result). ``None`` result = never evaluated.
+_requirements_cache: tuple[float, Optional[bool]] = (0.0, None)
+
+
 def _check_requirements() -> bool:
     """Returns True if the relay is running and a phone is connected.
+
+    Cached for a few seconds: the host evaluates this once per registered
+    ``android_*`` tool at every run start (~30 tools), and each uncached
+    evaluation is up to two HTTP calls.
+    """
+    global _requirements_cache
+    now = time.monotonic()
+    stamp, cached = _requirements_cache
+    if cached is not None and now - stamp < _REQUIREMENTS_CACHE_TTL_S:
+        return cached
+    result = _check_requirements_uncached()
+    _requirements_cache = (now, result)
+    return result
+
+
+def _check_requirements_uncached() -> bool:
+    """Live check behind ``_check_requirements``.
 
     The relay's ``/ping`` route is forwarded to the phone and only returns a
     basic ``{"pong": true}`` payload, so it cannot be used to decide whether

--- a/plugin/tools/desktop_tool.py
+++ b/plugin/tools/desktop_tool.py
@@ -56,10 +56,11 @@ forwards a ``desktop.command`` envelope to the connected desktop client
 (see ``plugin/relay/channels/desktop.py``), awaits a ``desktop.response``,
 and returns the structured result.
 
-``check_fn`` pings ``/desktop/_ping?tool=<name>`` — 200 if a client is
-connected and advertises the tool, 503 otherwise. This is how Hermes
-becomes aware: with no client, the tool fails closed and the LLM learns
-to stop calling it.
+``check_fn`` for each ``desktop_*`` tool reads one cached ``GET
+/desktop/health`` snapshot (see ``_advertised_snapshot``) — available if a
+client is connected and advertises the tool. This is how the host becomes
+aware: with no client, the tool fails closed and the LLM learns to stop
+calling it.
 
 ``desktop_health`` is the one tool that does NOT round-trip to the client
 — the relay already has the client's heartbeat-advertised metadata, so we
@@ -71,6 +72,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from contextvars import ContextVar
 from typing import Any, Optional
 
@@ -191,22 +193,66 @@ def _get(path: str, params: Optional[dict] = None) -> dict:
     return data
 
 
-def _check_tool(tool_name: str) -> bool:
-    """Returns True if a desktop client is connected AND advertises ``tool_name``.
+_ADVERTISED_CACHE_TTL_S = 3.0
+# (monotonic stamp, snapshot). ``None`` snapshot = relay unreachable / never fetched.
+_advertised_cache: tuple[float, Optional[dict[str, Any]]] = (0.0, None)
 
-    Hits ``/desktop/_ping?tool=<tool_name>``. 200 = available, 503 = no
-    client / tool not advertised.
+
+def _advertised_snapshot() -> Optional[dict[str, Any]]:
+    """One cached ``GET /desktop/health`` shared by every ``check_fn``.
+
+    The host evaluates every registered tool's ``check_fn`` at each run start.
+    ~48 desktop tools each doing their own ``/desktop/_ping`` round-trip made
+    session start scale with the tool count (and with any connect timeout). A
+    single health call already carries ``connected`` plus the full
+    ``advertised_tools`` list, so the whole sweep collapses to one request per
+    ``_ADVERTISED_CACHE_TTL_S`` window.
+
+    Returns ``{"connected": bool, "advertised_tools": frozenset[str]}`` or
+    ``None`` when the relay could not be reached.
     """
+    global _advertised_cache
+    now = time.monotonic()
+    stamp, cached = _advertised_cache
+    if cached is not None and now - stamp < _ADVERTISED_CACHE_TTL_S:
+        return cached
+    snapshot: Optional[dict[str, Any]]
     try:
         r = requests.get(
-            f"{_relay_url()}/desktop/_ping",
-            params={"tool": tool_name},
+            f"{_relay_url()}/desktop/health",
             headers=_auth_headers(),
             timeout=2,
         )
-        return r.status_code == 200
+        data = r.json() if r.status_code == 200 else {}
+        if not isinstance(data, dict):
+            data = {}
+        snapshot = {
+            "connected": bool(data.get("connected", False)),
+            "advertised_tools": frozenset(data.get("advertised_tools") or []),
+        }
     except Exception:
+        snapshot = None
+    # Cache the miss too, so an unreachable relay costs one timeout per window
+    # instead of one per tool.
+    _advertised_cache = (now, snapshot or {"connected": False, "advertised_tools": frozenset()})
+    return snapshot
+
+
+def _check_tool(tool_name: str) -> bool:
+    """Returns True if a desktop client is connected AND advertises ``tool_name``.
+
+    Reads the cached ``/desktop/health`` snapshot instead of hitting
+    ``/desktop/_ping?tool=<name>`` per tool. Mirrors the relay's
+    ``has_client_for`` rule: a connected client that advertises nothing is
+    treated optimistically for everything except ``desktop_computer_*``.
+    """
+    snapshot = _advertised_snapshot()
+    if not snapshot or not snapshot["connected"]:
         return False
+    advertised = snapshot["advertised_tools"]
+    if advertised:
+        return tool_name in advertised
+    return not tool_name.startswith("desktop_computer_")
 
 
 def _check_relay() -> bool:


### PR DESCRIPTION
## Summary

The host evaluates every registered tool's `check_fn` at each run start. Each of the ~48 `desktop_*` tools hit `GET /desktop/_ping?tool=<name>` and each of the ~30 `android_*` tools called `GET /bridge/status` (with a `/ping` fallback), so a single run start cost up to ~78 relay round-trips, and with no client connected, up to 78 connect timeouts.

Measured on Windows 11 with no desktop or phone client connected: the 78-check sweep took ~73 s (together with the `localhost` → `::1` timeout fixed in #562). With both changes it takes ~40 ms.

## Changes

- `plugin/tools/desktop_tool.py`
  - New `_advertised_snapshot()`: one `GET /desktop/health`, cached for 3 s (`time.monotonic`), returning `{connected, advertised_tools}`. A miss (relay unreachable) is cached too, so an unreachable relay costs one timeout per window instead of one per tool.
  - `_check_tool(name)` becomes a lookup against the cached snapshot. The rule for a connected client that advertises nothing mirrors `DesktopHandler.has_client_for` (optimistic for everything except `desktop_computer_*`).
  - `_check_relay()` (used by `desktop_health`) is unchanged.
  - Module docstring updated; `import time` added.
- `plugin/tools/android_tool.py`
  - `_check_requirements()` now wraps the previous body (`_check_requirements_uncached()`) in the same 3 s cache. Probe semantics are unchanged.
- `plugin/tests/test_desktop_tool_availability.py` (new): one health request per sweep across all registered tools, fail-closed on unreachable relay, no-client, optimistic-when-unadvertised, TTL expiry, `desktop_health` bypass.
- `plugin/tests/test_android_tool.py`: cache reset fixture for `TestRequirements` plus two cache tests.
- `CHANGELOG.md`: Unreleased / Fixed entry.

`/desktop/_ping` stays on the relay; nothing else called it from the plugin tools.

## Verification

- `python -m pytest plugin/tests/test_android_tool.py plugin/tests/test_desktop_multidevice.py plugin/tests/test_android_navigate.py plugin/tests/test_desktop_health.py plugin/tests/test_desktop_tool_availability.py plugin/tests/test_desktop_computer_use.py plugin/tests/test_android_tool_device_selector.py` → 123 passed
- Full `plugin/tests` (excluding `test_native_layout_imports`): same 6 pre-existing failures as clean `origin/dev` on this host (`test_git_state`, `test_provider_usage`, `test_register_code`, `test_secure_proxy*`), none in touched files.
- Android: N/A.

## Screenshots

No visual change.

## Compatibility / risk

N/A for vanilla Hermes (plugin-only). Availability can lag a client connect/disconnect by up to 3 s; the previous per-tool ping was evaluated at the same moment for all tools, so the practical difference is nil. Tool calls themselves still go through the relay and fail with the usual structured error if the client is gone.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A
- [x] Translation changes: N/A
- [x] Server/plugin changes: focused tests ran (see Verification)
