### PR TITLE
fix(android): prevent duplicate Bot Mode keys across connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- Bot Mode no longer crashes when different connections have bots with the same profile name. Both the conversation list and Active Now strip preserve each bot's connection, and opening progress appears only on the selected bot.
 - **`android_*` tools resolve bridge credentials written after host startup.** Requests retry profile-scoped env and active bridge-session credentials after a stale token is rejected, and vision navigation now shares the same current Relay transport instead of the retired standalone default.
 - **`android_setup` accepts both its canonical and legacy schema keys.** `bridge_session_token` and `pairing_code` are accepted, while a missing token returns a structured error.
 - **Android tool setup tests use a temporary Hermes home.** Test runs no longer write bridge settings into a developer environment.

--- a/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/BotModeScreen.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/ui/screens/BotModeScreen.kt
@@ -73,6 +73,7 @@ import com.hermesandroid.relay.R
 import com.hermesandroid.relay.data.BotGroupMessage
 import com.hermesandroid.relay.data.BotGroupRoom
 import com.hermesandroid.relay.data.BotGatewayRoute
+import com.hermesandroid.relay.data.BotGatewayRouteKey
 import com.hermesandroid.relay.data.BotModeState
 import com.hermesandroid.relay.data.BotRosterEntry
 import com.hermesandroid.relay.data.Connection
@@ -83,6 +84,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal enum class BotModeFilter { All, Bots, Groups }
+
+/** Bundle-compatible key; length-prefix the connection so delimiters cannot alias owners. */
+internal val BotRosterEntry.lazyItemKey: String
+    get() {
+        val owner = route?.key ?: return "bot:unbound:${profile.name}"
+        return "bot:route:${owner.connectionId.length}:${owner.connectionId}:${owner.profileName}"
+    }
 
 private sealed interface BotModeRow {
     val activityAtMs: Long
@@ -109,7 +117,7 @@ fun BotModeScreen(
     val scope = rememberCoroutineScope()
     val resources = LocalResources.current
     val snackbar = remember { SnackbarHostState() }
-    var openingProfile by remember { mutableStateOf<String?>(null) }
+    var openingRoute by remember { mutableStateOf<BotGatewayRouteKey?>(null) }
     var showCreateBot by remember { mutableStateOf(false) }
     var creatingBot by remember { mutableStateOf(false) }
     var selectedGatewayId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -136,10 +144,11 @@ fun BotModeScreen(
         onBack = onBack,
         onRefresh = connectionViewModel::refreshBotMode,
         onSelectGateway = { selectedGatewayId = it },
-        openingProfile = openingProfile,
+        openingRoute = openingRoute,
         onOpenBot = { bot ->
             val route = bot.route ?: return@BotModeContent
-            openingProfile = bot.profile.name
+            if (openingRoute != null) return@BotModeContent
+            openingRoute = route.key
             scope.launch {
                 val result = connectionViewModel.ensureCanonicalBotChat(route)
                     .map { it.resolvedSessionId }
@@ -147,7 +156,7 @@ fun BotModeScreen(
                     onSuccess = { onOpenBotChat(route, it) },
                     onFailure = { snackbar.showSnackbar(it.message ?: chatOpenFailed) },
                 )
-                openingProfile = null
+                openingRoute = null
             }
         },
         onOpenGroup = { onOpenGroup(it.key) },
@@ -206,7 +215,7 @@ internal fun BotModeContent(
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onSelectGateway: (String?) -> Unit,
-    openingProfile: String? = null,
+    openingRoute: BotGatewayRouteKey? = null,
     onOpenBot: (BotRosterEntry) -> Unit,
     onOpenGroup: (BotGroupRoom) -> Unit,
     onNewBot: () -> Unit,
@@ -404,12 +413,12 @@ internal fun BotModeContent(
                     contentPadding = PaddingValues(horizontal = 16.dp),
                     horizontalArrangement = Arrangement.spacedBy(18.dp),
                 ) {
-                    items(activeBots, key = { it.profile.name }) { bot ->
+                    items(activeBots, key = { it.lazyItemKey }) { bot ->
                         Column(
                             horizontalAlignment = Alignment.CenterHorizontally,
                             modifier = Modifier
                                 .width(78.dp)
-                                .clickable(enabled = openingProfile == null) { onOpenBot(bot) },
+                                .clickable(enabled = openingRoute == null) { onOpenBot(bot) },
                         ) {
                             Box {
                                 botAvatar(bot, 56.dp)
@@ -455,7 +464,7 @@ internal fun BotModeContent(
                     itemsIndexed(
                         items = rows,
                         key = { _, row -> when (row) {
-                            is BotModeRow.Bot -> "bot:${row.value.profile.name}"
+                            is BotModeRow.Bot -> row.value.lazyItemKey
                             is BotModeRow.Group -> "group:${row.value.key}"
                         } },
                     ) { index, row ->
@@ -463,7 +472,7 @@ internal fun BotModeContent(
                             is BotModeRow.Bot -> BotConversationRow(
                                 bot = row.value,
                                 connectionLabel = row.value.route?.connectionLabel,
-                                opening = openingProfile == row.value.profile.name,
+                                opening = openingRoute != null && openingRoute == row.value.route?.key,
                                 onClick = { onOpenBot(row.value) },
                                 avatar = { botAvatar(row.value, 56.dp) },
                                 nowMs = nowMs,

--- a/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/BotModeScreenTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/ui/screens/BotModeScreenTest.kt
@@ -2,8 +2,11 @@ package com.hermesandroid.relay.ui.screens
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performClick
 import com.hermesandroid.relay.data.BotGroupMessage
+import com.hermesandroid.relay.data.BotGatewayRoute
+import com.hermesandroid.relay.data.BotGatewayRouteKey
 import com.hermesandroid.relay.data.BotGroupRoom
 import com.hermesandroid.relay.data.BotModeRoster
 import com.hermesandroid.relay.data.BotModeState
@@ -13,6 +16,7 @@ import com.hermesandroid.relay.data.Connection
 import com.hermesandroid.relay.data.Profile
 import com.hermesandroid.relay.ui.theme.HermesRelayTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,10 +69,64 @@ class BotModeScreenTest {
         compose.onNodeWithText("Lucy").assertDoesNotExist()
     }
 
+    @Test
+    fun `same named bots on different gateways render and open their own conversation`() {
+        val opened = mutableListOf<String>()
+        render(onOpenBot = { opened += it.route!!.connectionId })
+
+        compose.onNodeWithText("Lucy").performClick()
+        compose.onNodeWithText("Researcher").performClick()
+
+        assertEquals(listOf("home", "lab"), opened)
+    }
+
+    @Test
+    fun `same named active bots on different gateways render and open their own owner`() {
+        val opened = mutableListOf<String>()
+        render(nowMs = NOW, onOpenBot = { opened += it.route!!.connectionId })
+
+        compose.onAllNodesWithText("Lucy")[0].performClick()
+        compose.onAllNodesWithText("Researcher")[0].performClick()
+
+        assertEquals(listOf("home", "lab"), opened)
+    }
+
+    @Test
+    fun `opening progress only replaces the selected owners preview`() {
+        render(openingRoute = BotGatewayRouteKey("home", "default"))
+
+        compose.onNodeWithText("Drafted a rollout plan").assertDoesNotExist()
+        compose.onNodeWithText("Findings ready").assertExists()
+    }
+
+    @Test
+    fun `item identity survives presentation refresh and separates delimiter containing owners`() {
+        val bot = state().roster.bots.first()
+        val refreshed = bot.copy(
+            displayName = "Renamed",
+            handle = "new-handle",
+            stale = true,
+            route = BotGatewayRoute(bot.route!!.key, "New label", "new-install-metadata"),
+            canonicalSession = BotSessionSummary(id = "compressed-tip"),
+        )
+        assertEquals(bot.lazyItemKey, refreshed.lazyItemKey)
+        assertNotEquals(
+            bot.copy(route = BotGatewayRoute(BotGatewayRouteKey("a:b", "c"), "Same label")).lazyItemKey,
+            bot.copy(route = BotGatewayRoute(BotGatewayRouteKey("a", "b:c"), "Same label")).lazyItemKey,
+        )
+        assertNotEquals(
+            bot.lazyItemKey,
+            bot.copy(route = BotGatewayRoute(BotGatewayRouteKey("home", "other"), "Hermes")).lazyItemKey,
+        )
+        assertNotEquals(bot.lazyItemKey, bot.copy(route = null).lazyItemKey)
+    }
+
     private fun render(
         onOpenBot: (BotRosterEntry) -> Unit = {},
         onOpenGroup: (BotGroupRoom) -> Unit = {},
         selectedGatewayId: String? = null,
+        nowMs: Long = NOW + 200_000L,
+        openingRoute: BotGatewayRouteKey? = null,
     ) {
         compose.setContent {
             HermesRelayTheme(appThemeId = "hermes-relay", themePreference = "dark") {
@@ -77,13 +135,14 @@ class BotModeScreenTest {
                     connections = listOf(connection(), labConnection()),
                     activeConnection = connection(),
                     selectedGatewayId = selectedGatewayId,
+                    openingRoute = openingRoute,
                     onBack = {},
                     onRefresh = {},
                     onSelectGateway = {},
                     onOpenBot = onOpenBot,
                     onOpenGroup = onOpenGroup,
                     onNewBot = {},
-                    nowMs = NOW + 200_000L,
+                    nowMs = nowMs,
                 )
             }
         }
@@ -106,10 +165,10 @@ class BotModeScreenTest {
                     ),
                 ),
                 BotRosterEntry(
-                    profile = Profile(name = "researcher", model = "gpt-5.6", description = "Research"),
+                    profile = Profile(name = "default", model = "gpt-5.6", description = "Research"),
                     displayName = "Researcher",
                     route = com.hermesandroid.relay.data.BotGatewayRoute(
-                        key = com.hermesandroid.relay.data.BotGatewayRouteKey("lab", "researcher"),
+                        key = com.hermesandroid.relay.data.BotGatewayRouteKey("lab", "default"),
                         connectionLabel = "Lab server",
                     ),
                     canonicalSession = BotSessionSummary(

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3982,7 +3982,13 @@ compression path instead of forking the relationship. New Bot creates an upstrea
 only the small `hermes-bots` metadata marker; profile skills/model remain managed
 through the established Hermes surfaces.
 
-Every Bot owner is the immutable `(connectionId, profile)` pair. A typed route
+Every Bot owner is the immutable `(connectionId, profile)` pair. Both the active
+Bot strip and conversation list use that pair for stable Compose item identity;
+opening progress belongs to the same exact owner. Profile names, display labels,
+and handles alone are not unique across installations. Upstream
+[`profiles.list`](https://github.com/NousResearch/hermes-agent/blob/2db0c7a2d8f29debe7d1cbfb4a72f4f98dc00808/tui_gateway/methods_profiles.py)
+returns installation-local profile names and profile-local session summaries.
+A typed route
 pool holds separate clients for separate owners, validates bearer authority
 against that connection's exact trusted Dashboard base, adds the profile to the
 WebSocket URL, mints a fresh one-use ticket on every dial, and uses request or


### PR DESCRIPTION
## Summary

Bot Mode crashes when two Hermes connections expose a profile named `default`. The conversation list collides on `bot:default` (#470), and the Active Now strip collides on `default` (#479). Both now use the existing connection/profile owner.

Related: #470, #479.

## Changes

- Use stable, delimiter-safe connection/profile keys in both Bot Mode lists.
- Scope opening progress to the selected route and prevent overlapping open requests.
- Cover duplicate names, correct selection, gateway filtering, and identity stability after metadata changes.
- Add an Unreleased note and document the upstream `profiles.list` reference.

## Verification

- Before the fix, rendered regression tests reproduced both duplicate-key exceptions.
- `scripts/android-lane.ps1 gradle :app:testSideloadDebugUnitTest --tests '*BotModeScreenTest' --tests '*BotModeRosterAggregationTest' :app:testGooglePlayDebugUnitTest --tests '*BotModeScreenTest' --tests '*BotModeRosterAggregationTest' --console=plain`: all 22 tests passed on `3b78a17bd7f8549e63a705dc3abba7df7a62fd7d`, including the merge with current `dev`.
- `git diff --check`: passed.
- [Required CI](https://github.com/Codename-11/hermes-relay/actions/runs/34416690122): Android lint, debug APK builds, focused tests, and the aggregate Required checks gate passed.
- Physical-device testing remains pending. Rendered tests use Robolectric native graphics at 390 x 844 dp.

## Screenshots

No layout or styling change. Rendered regression coverage exercises both lists; no device screenshots were captured.

## Compatibility / risk

Upstream profile names remain installation-local. This changes client UI identity only, with no protocol, authentication, stored-session, migration, or dependency changes. Translation, plugin, and desktop checks are N/A. Documentation changes are prose plus a verified upstream source link; no site routes changed.

## Lineage / contributor credit

- Source PR(s): N/A
- Attribution preserved by: N/A

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: lint and focused tests ran, or rationale is listed above
- [x] Translation changes: locale validation/review ran, or N/A is listed above
- [x] Server/plugin changes: focused tests ran, or N/A/rationale is listed above
- [x] Desktop changes: build/tests ran, or N/A/rationale is listed above
- [x] Docs/site changes: build or link/route checks ran, or N/A/rationale is listed above
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md` is updated for user-visible changes, or N/A is listed above
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A is listed above
