### PR TITLE
release(server): server-v1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Android no longer crashes when a route probe finishes while a network change invalidates the endpoint cache.
 - Android opens an authenticated Gateway chat on the first foreground launch instead of waiting for a background-and-resume cycle to leave the waking state. (#495, #528)
 - Android Dashboard sign-in removes pasted line breaks from username and password fields, matching the browser login while preserving every other credential character. (#541)
-- **Relay tool availability avoids repeated Windows loopback delays and preserves multi-PC capabilities.** Host-local Android, Desktop, and Phone paths use explicit IPv4 loopback, while Desktop checks share a bounded health snapshot that preserves per-client advertisements and fails closed when Hermes-Relay is unavailable. (#562, #563)
 - Android keeps saved Dashboard sign-ins bound to their connection when switching gateways, rather than letting a stale resolver route invalidate another connection's session.
 - Bot Mode no longer crashes when different connections have bots with the same profile name. Both the conversation list and Active Now strip preserve each bot's connection, and opening progress appears only on the selected bot.
 - Android feedback uses themed banners and action cards instead of platform toasts and default snackbars. Dashboard errors no longer misidentify missing resources as an outdated Relay. Developer settings includes local-only message previews.
 - Missing chat attachments show their error and retry in the attachment card without repeated global popups. Global action messages occupy the top message area instead of covering the composer.
 - Chat distinguishes session preparation from response streaming and retains initialization errors that arrive before the session acknowledgement. Long-press the agent header to open a live session-diagnostics drawer.
 - Delegated-agent activity survives parent replies and leaves compact history entries for later read-only review. The activity strip appears only while work runs; historical process views cannot stop or dismiss live work. (#447)
+
+## [Plugin 1.11.2] - 2026-09-09
+
+### Fixed
+
+- **Relay tool availability avoids repeated Windows loopback delays and preserves multi-PC capabilities.** Host-local Android, Desktop, and Phone paths use explicit IPv4 loopback, while Desktop checks share a bounded health snapshot that preserves per-client advertisements and fails closed when Hermes-Relay is unavailable. (#562, #563)
 - **`android_*` tools resolve bridge credentials written after host startup.** Requests retry profile-scoped env and active bridge-session credentials after a stale token is rejected, and vision navigation now shares the same current Relay transport instead of the retired standalone default.
 - **`android_setup` accepts both its canonical and legacy schema keys.** `bridge_session_token` and `pairing_code` are accepted, while a missing token returns a structured error.
 - **Android tool setup tests use a temporary Hermes home.** Test runs no longer write bridge settings into a developer environment.

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,15 +1,17 @@
 # Hermes-Relay Plugin v__VERSION__
 
-**Release Date:** August 31, 2026
+**Release Date:** September 9, 2026
 
 ## Summary
 
-This patch restores native installation compatibility on affected Hermes versions and makes Relay prompt context advertise only capabilities the selected session can actually call. Standard Chat, Manage, standard voice, and ordinary inbound files remain upstream-owned.
+This patch makes Android and Desktop tool availability fast and reliable when Relay is unavailable, starts late-created Android bridge sessions without restarting Hermes, and restores compatibility with both current and legacy `android_setup` arguments. Standard Chat, Manage, standard voice, and ordinary inbound files remain upstream-owned.
 
 ## Fixed
 
-- **Native installer compatibility.** The plugin keeps its complete current manifest while avoiding the installer/runtime schema mismatch that caused `manifest_version 2` installs to fail after an apparent Hermes update.
-- **Capability-gated phone context.** Phone-control and cross-platform delivery guidance now follows the selected session/profile tool catalog instead of implying unavailable `android_*` or `send_message` callables.
+- **Fast, accurate tool availability.** Android and Desktop tool checks use explicit IPv4 loopback and one bounded health snapshot instead of repeated per-tool connection attempts. Multi-PC capability advertisements remain isolated, and unavailable Relay clients continue to fail closed.
+- **Late Android bridge recovery.** `android_*` calls retry profile-scoped and active bridge-session credentials after a stale token is rejected, so a phone connected after Hermes startup becomes usable without restarting the host.
+- **Compatible Android setup arguments.** `android_setup` accepts the canonical `bridge_session_token` and `pairing_code` fields as well as their legacy aliases, with structured errors when no usable credential is supplied.
+- **Isolated setup tests.** Android tool setup tests use a temporary Hermes home instead of writing bridge settings into the operator environment.
 
 ## Install / update
 

--- a/plugin/dashboard/manifest.json
+++ b/plugin/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Hermes-Relay",
   "description": "Paired devices, Bridge activity, media tokens, and remote access for Hermes-Relay",
   "icon": "Activity",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "tab": {
     "path": "/relay",
     "position": "after:skills"

--- a/plugin/dashboard/package-lock.json
+++ b/plugin/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-relay-dashboard",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "devDependencies": {
         "esbuild": "^0.25.12",
         "qrcode": "^1.5.4"

--- a/plugin/dashboard/package.json
+++ b/plugin/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-relay-dashboard",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "private": true,
   "description": "Hermes-Relay dashboard plugin frontend (IIFE bundle). Loaded verbatim by the hermes-agent dashboard via the Plugin SDK global.",
   "scripts": {

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -2,7 +2,7 @@ name: hermes-relay
 # Temporary v1 shim for Hermes installers that reject manifests the runtime supports; see docs/project/TODO.md.
 manifest_version: 1
 api_version: 1
-version: 1.11.1
+version: 1.11.2
 description: "Hermes-Relay plugin for QR pairing, relay sessions, dashboard management, remote desktop/phone tooling, and optional legacy compatibility diagnostics. Standard chat, Manage, and dashboard voice remain vanilla upstream Hermes surfaces."
 author: Axiom Labs
 license: MIT

--- a/plugin/relay/__init__.py
+++ b/plugin/relay/__init__.py
@@ -19,7 +19,7 @@ See ``plugin/relay/server.py`` for the aiohttp server,
 # CLI+UI releases use desktop/package.json and desktop-v* tags. The /health endpoint
 # reports this plugin version, and stale values make live diagnosis harder than
 # it should be.
-__version__ = "1.11.1"
+__version__ = "1.11.2"
 
 from .server import create_app, main  # noqa: E402 — must come after __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-relay"
-version = "1.11.1"
+version = "1.11.2"
 description = "Hermes-Relay plugin — Android device control toolset, QR pairing CLI, and WSS relay server for hermes-agent"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Prepare Hermes-Relay Plugin 1.11.2 from the verified integration head. This patch removes repeated availability-probe delays, preserves multi-PC capability isolation, and lets Android bridge tools recover credentials created after Hermes startup.

## Changes

- Bump all Plugin and Dashboard package metadata from 1.11.1 to 1.11.2.
- Promote only Plugin entries into the Plugin 1.11.2 changelog block; Android entries remain Unreleased.
- Rewrite the Plugin release body for the availability, bridge recovery, setup compatibility, and test-isolation fixes.
- Leave Android and CLI+UI versions unchanged.

## Verification

- `python scripts/check-plugin-version-sync.py --expect 1.11.2` — passed.
- `python scripts/check-version-tracks.py` — passed; Android 1.15.1/code 54 and CLI+UI 0.4.0-beta.7 remain unchanged.
- `python -m pytest plugin/tests/test_android_tool.py plugin/tests/test_desktop_tool_availability.py plugin/tests/test_android_navigate.py plugin/tests/test_android_tool_device_selector.py` — 98 passed.
- `git diff --check` — passed.

## Screenshots

No visual change.

## Compatibility / risk

Standard Chat, Manage, standard voice, and ordinary inbound files remain upstream-owned. No protocol, credential schema, database migration, Android package, or CLI+UI release change is included. Rollback is the previous immutable `server-v1.11.1` package.

## Lineage / contributor credit

- Source PR(s): #543, #569
- Attribution preserved by: the original merged contributor commits remain in history; this release commit changes only version and release metadata.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: N/A; Android version and source are unchanged
- [x] Translation changes: N/A
- [x] Server/plugin changes: focused tests and version checks passed
- [x] Desktop changes: N/A; only Plugin-hosted Desktop tool availability is released
- [x] Docs/site changes: release metadata only; no site routes changed
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for user-visible changes
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship