### PR TITLE
release(android): android-v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [Android 1.16.0] - 2026-09-09
+
 ### Fixed
 
 - Android no longer crashes when a route probe finishes while a network change invalidates the endpoint cache.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Hermes-Relay Android v1.15.1
+# Hermes-Relay Android v1.16.0
 
-**Release Date:** September 2, 2026
+**Release Date:** September 9, 2026
 
 ## Download
 
-> Installing on your phone? Download `hermes-relay-1.15.1-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
+> Installing on your phone? Download `hermes-relay-1.16.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
 
 The `.aab` file is a Play Console upload bundle and cannot be installed by tapping it on a phone.
 
@@ -12,29 +12,28 @@ Verify the download against `SHA256SUMS.txt`. See the [sideload guide](https://h
 
 ## Summary
 
-This patch improves chat, media, and voice reliability. It reduces memory-heavy work, keeps attachment previews stable through rotation, and makes follow-up message behavior and voice errors easier to understand.
+This release makes startup and connection switching safer, prevents a network-change crash, and keeps Bot Mode and delegated work stable across multiple Hermes gateways. Chat feedback, attachment failures, and session preparation are also easier to understand and review.
 
 ## Changed
 
-- Choose Correct now or Queue next from a slim tray behind the composer. Chat settings sets the default; the tray overrides one message. Stop pauses the queue, Resume continues it, and editing or removing an item preserves its successors.
-- Chat and Voice use readable centered layouts on wider screens, including landscape Voice Focus.
+- Delegated-agent activity remains available after parent replies as compact, bounded, read-only history. The live strip appears only while work is active, and historical views cannot control a running process.
+- Android feedback uses themed banners and action cards. A long-press on the agent header opens session diagnostics, and Developer settings can preview message surfaces locally.
 
 ## Fixed
 
-- Correction and delivery labels remain visible inside user-message bubbles.
-- Voice errors open in a scrollable dialog with separate Retry and Dismiss actions.
-- Attachment previews remain open through rotation, and video previews preserve their proportions.
-- Release optimization preserves the native speech configuration required for wake-word startup.
-- Standard Hermes attachments download directly to disk with bounded size checks.
-- Session refresh avoids repeated request loops; history loads, Markdown, image previews, and media exports keep memory use bounded.
-- Image-generation progress stays visible through gaps between interim replies and returned media.
-- The first prompt waits for Gateway session readiness. Ownership refusals retain the prompt for retry and show the original server error.
+- An authenticated Gateway chat opens on the first foreground launch instead of waiting for a background-and-resume cycle.
+- Network changes can invalidate route probes without racing the endpoint cache or crashing Android.
+- Saved Dashboard sign-ins stay bound to their owning connection when switching gateways; an outgoing route cannot invalidate another connection's session.
+- Dashboard sign-in removes pasted line breaks from username and password fields while preserving every other credential character.
+- Bot Mode and Active Now keep connection identity when different gateways expose the same profile name, and progress opens only on the selected bot.
+- Missing attachments keep their error and Retry action in the attachment card without repeated global messages.
+- Chat distinguishes session preparation from response streaming and retains initialization errors received before session acknowledgement.
 
 ## Install / Verify
 
-- App version: **1.15.1** (versionCode **54**).
+- App version: **1.16.0** (versionCode **55**).
 - Standard Chat, sessions, profiles, Manage, voice, and ordinary media use current upstream Hermes. Speech-to-text still requires a configured provider on the host.
-- Hermes-Relay Plugin **1.11.1** remains the current optional plugin release; this Android patch does not require a new plugin version.
-- Paused text queues can be restored. Attachment bytes are not persisted in preferences; unrestorable attachment queues must be reviewed and sent again.
+- Hermes-Relay Plugin **1.11.2** is the matching optional release for Relay tools; the Android connection, Bot Mode, and delegated-activity fixes do not require the plugin.
+- Already-erased or revoked Dashboard credentials still require a legitimate sign-in; this release prevents cross-connection invalidation going forward.
 - Explicit Direct API/API-only connections remain supported and are not used as silent failover for Dashboard-owned chats.
 - Granular Device Control and the system Voice Focus overlay remain sideload-only.

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
-v1.15.1 - Steadier chat, media, and voice
+v1.16.0 - Safer startup, connections, and activity
 
-More reliable chats and media: fewer memory-heavy refreshes, smoother large histories, and attachment previews that survive rotation. Choose whether follow-ups correct the current response or wait in a queue. Voice errors are easier to read, image-generation progress stays visible, and wake-word startup and first-message readiness are fixed.
+Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -2,6 +2,79 @@
  "schema": 3,
  "versions": [
   {
+   "version": "1.16.0",
+   "title": "Safer startup, connections, and activity",
+   "date": "2026-09-09",
+   "summary": "Gateway chat opens reliably from a cold launch, saved sign-ins stay with the correct connection, and network changes no longer race the route cache. Bot Mode and delegated-work feedback also remain stable across multiple gateways and later review.",
+   "changes": [
+    {
+     "id": "gateway-cold-start",
+     "kind": "fixed",
+     "title": "Open Gateway chat on the first launch",
+     "summary": "An authenticated Gateway wakes and opens from a cold foreground start instead of waiting for the app to background and resume.",
+     "highlight": true
+    },
+    {
+     "id": "connection-owned-signin",
+     "kind": "fixed",
+     "title": "Keep saved sign-ins with their connection",
+     "summary": "Switching gateways cannot reuse an outgoing resolver route to invalidate another connection's saved Dashboard session.",
+     "highlight": true
+    },
+    {
+     "id": "network-change-invalidation",
+     "kind": "fixed",
+     "title": "Recover safely when the network changes",
+     "summary": "Route-probe completion and endpoint-cache invalidation are serialized so Wi-Fi, mobile-data, VPN, or Tailscale changes do not trigger the reported crash.",
+     "highlight": true
+    },
+    {
+     "id": "bot-mode-connection-identity",
+     "kind": "fixed",
+     "title": "Open same-named bots from multiple gateways",
+     "summary": "Bot Mode and Active Now keep connection and profile identity together, avoiding duplicate list keys and opening progress on the selected bot."
+    },
+    {
+     "id": "delegated-activity-receipts",
+     "kind": "improved",
+     "title": "Review delegated work after it finishes",
+     "summary": "Compact, bounded activity receipts survive parent replies and remain available read-only, while the live strip appears only during active work.",
+     "highlight": true
+    },
+    {
+     "id": "chat-feedback-surfaces",
+     "kind": "improved",
+     "title": "Keep feedback with the surface that owns it",
+     "summary": "Themed banners and action cards replace platform popups, global actions stay clear of the composer, and local Developer previews make feedback states inspectable."
+    },
+    {
+     "id": "attachment-error-recovery",
+     "kind": "fixed",
+     "title": "Retry missing attachments in place",
+     "summary": "A missing attachment keeps its error and Retry action in the attachment card without producing repeated global messages."
+    },
+    {
+     "id": "session-preparation-diagnostics",
+     "kind": "improved",
+     "title": "See session preparation and initialization failures",
+     "summary": "Chat distinguishes session preparation from response streaming, retains early initialization errors, and opens session diagnostics from the agent header."
+    },
+    {
+     "id": "pasted-dashboard-credentials",
+     "kind": "fixed",
+     "title": "Paste Dashboard credentials without hidden line breaks",
+     "summary": "Username and password fields remove pasted carriage returns and line feeds while preserving every other credential character."
+    }
+   ],
+   "compatibility": [
+    "Standard Chat, sessions, profiles, Manage, voice, Bot Mode, and delegated activity continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.",
+    "Hermes-Relay Plugin 1.11.2 is the matching optional release for Relay tools. Existing erased or revoked Dashboard credentials still require a legitimate sign-in.",
+    "Granular Device Control and the system Voice Focus overlay remain sideload-only."
+   ],
+   "playNotes": "Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.",
+   "sections": []
+  },
+  {
    "version": "1.15.1",
    "title": "Steadier chat, media, and voice",
    "date": "2026-09-02",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,24 +1,24 @@
-v1.15.1 - Steadier chat, media, and voice
+v1.16.0 - Safer startup, connections, and activity
 
 Summary
-* Chats use less memory, attachment previews stay in place, and voice failures are easier to recover from. Follow-up controls make it clear whether a message changes the current response or waits for the next turn.
+* Gateway chat opens reliably from a cold launch, saved sign-ins stay with the correct connection, and network changes no longer race the route cache. Bot Mode and delegated-work feedback also remain stable across multiple gateways and later review.
 
 Highlights
-* Choose when follow-up messages are sent — A slim tray behind the composer offers Correct now or Queue next. Chat settings sets the default, and a composer choice applies to one message. Stop pauses pending work until Resume; editing or removing an item keeps the remaining queue usable.
-* Keep attachment previews open through rotation — Image, video, audio, PDF, text, and file previews stay open as the screen rotates. Videos retain their original proportions.
-* Keep large chats and media manageable — Automatic session refresh no longer loops. Routine history loads, chat rendering, image previews, and media exports use bounded memory instead of allocating entire large responses.
+* Open Gateway chat on the first launch — An authenticated Gateway wakes and opens from a cold foreground start instead of waiting for the app to background and resume.
+* Keep saved sign-ins with their connection — Switching gateways cannot reuse an outgoing resolver route to invalidate another connection's saved Dashboard session.
+* Recover safely when the network changes — Route-probe completion and endpoint-cache invalidation are serialized so Wi-Fi, mobile-data, VPN, or Tailscale changes do not trigger the reported crash.
+* Review delegated work after it finishes — Compact, bounded activity receipts survive parent replies and remain available read-only, while the live strip appears only during active work.
 
 Improved
-* Make better use of wider screens — Chat and Voice keep text and controls on readable centered layouts. Landscape Voice Focus separates identity controls from conversation activity.
+* Keep feedback with the surface that owns it — Themed banners and action cards replace platform popups, global actions stay clear of the composer, and local Developer previews make feedback states inspectable.
+* See session preparation and initialization failures — Chat distinguishes session preparation from response streaming, retains early initialization errors, and opens session diagnostics from the agent header.
 
 Fixed
-* Read message delivery status clearly — Correction and delivery labels use contrasting text instead of disappearing into the message bubble.
-* Read and dismiss voice errors — Voice errors open in a contained dialog with scrollable details and separate Retry and Dismiss actions, without overlapping chat controls.
-* Fix wake-word startup in release builds — Release optimization now preserves the native speech configuration names needed to initialize wake-word detection.
-* Download attachments with less memory — Standard Hermes attachments stream into the on-disk cache while download size limits remain enforced.
-* Keep image-generation progress visible — The working indicator stays visible between interim replies and the generated image, including gateways that omit tool activity events.
-* Wait for new chats to be ready — The first message waits for the Gateway session to initialize. Ownership refusals keep the prompt retryable and show the server's error.
+* Open same-named bots from multiple gateways — Bot Mode and Active Now keep connection and profile identity together, avoiding duplicate list keys and opening progress on the selected bot.
+* Retry missing attachments in place — A missing attachment keeps its error and Retry action in the attachment card without producing repeated global messages.
+* Paste Dashboard credentials without hidden line breaks — Username and password fields remove pasted carriage returns and line feeds while preserving every other credential character.
 
 Compatibility
-* Standard Chat, sessions, media, and voice continue to use upstream Hermes. Voice transcription still requires a configured speech-to-text provider on the Hermes host.
-* Paused text queues can be restored. Attachment bytes are not stored in preferences; an attachment queue that cannot be restored must be reviewed and sent again.
+* Standard Chat, sessions, profiles, Manage, voice, Bot Mode, and delegated activity continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.
+* Hermes-Relay Plugin 1.11.2 is the matching optional release for Relay tools. Existing erased or revoked Dashboard credentials still require a legitimate sign-in.
+* Granular Device Control and the system Voice Focus overlay remain sideload-only.

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -91,9 +91,9 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.15.1 - Steadier chat, media, and voice
+v1.16.0 - Safer startup, connections, and activity
 
-More reliable chats and media: fewer memory-heavy refreshes, smoother large histories, and attachment previews that survive rotation. Choose whether follow-ups correct the current response or wait in a queue. Voice errors are easier to read, image-generation progress stays visible, and wake-word startup and first-message readiness are fixed.
+Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.
 ```
 ## Category
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.15.1"
-appVersionCode = "54"
+appVersionName = "1.16.0"
+appVersionCode = "55"
 agp = "9.4.0"
 kotlin = "2.4.10"
 compose-bom = "2026.08.00"


### PR DESCRIPTION
## Summary

Prepare Hermes-Relay Android 1.16.0 from the verified integration head. This release makes cold startup and connection switching safer, prevents the reported network-change crash, and keeps Bot Mode and delegated-work feedback stable across multiple gateways.

## Changes

- Bump Android from 1.15.1/code 54 to 1.16.0/code 55.
- Promote the nine Android changes into an Android-only changelog block while preserving Plugin 1.11.2 separately and leaving CLI+UI unchanged.
- Add the complete schema-3 What's New inventory with four highlights and compatibility boundaries.
- Regenerate the legacy What's New fallback, Play release notes, and Play listing note from the structured record.
- Rewrite the GitHub Android release body with the required download and verification guidance.

## Verification

- `python scripts/android-prepush.py --release-prep` — passed, including 12 Android locale catalogs, localized docs, collection API compatibility, release-note/version alignment, and rendered Changelog/What's New tests; Gradle build completed successfully in 3m 15s.
- `python scripts/check-android-release-notes.py --write` followed by validation — passed for v1.16.0.
- `python scripts/check-version-tracks.py` — passed: Android 1.16.0/code 55, Plugin 1.11.2, CLI+UI 0.4.0-beta.7.
- `git diff --check` — passed.
- The base integration head `3ec89680eddad8412f32786e509da86f48bbd194` passed Android push CI run 34427976340, including tests, lint, both-flavor release smoke, DEX scanning, and packaged native compatibility.
- Combined physical-device certification and signed Play preflight remain release gates after this prep commit lands on `dev`; no device result is claimed by this metadata PR.

## Screenshots

Release presentation was exercised by the rendered Changelog History and What's New tests. No product-layout change is introduced by the release metadata itself.

## Compatibility / risk

Standard Chat, sessions, profiles, Manage, voice, Bot Mode, and delegated activity remain on current upstream Hermes. Plugin 1.11.2 is the matching optional Relay-tools release but is not required for the Android fixes. Existing erased or revoked Dashboard credentials still require legitimate sign-in. Direct API/API-only connections remain explicit, and Device Control plus the system Voice Focus overlay remain sideload-only.

## Lineage / contributor credit

- Source PR(s): #566, #567, #568, #570, #571, #572
- Attribution preserved by: original contributor and maintainer commits remain in history; this commit changes release metadata only.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: release-prep lane passed; exact-head hosted Android checks remain required before merge
- [x] Translation changes: locale validation passed for 12 catalogs; no translations changed
- [x] Server/plugin changes: N/A; Plugin 1.11.2 metadata was released separately
- [x] Desktop changes: N/A; CLI+UI remains unchanged
- [x] Docs/site changes: generated Play listing note validated; no site routes changed
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for user-visible changes
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship