### PR TITLE
docs(release): correct 1.16.0 and 1.11.2 dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-## [Android 1.16.0] - 2026-09-09
+## [Android 1.16.0] - 2026-09-10
 
 ### Fixed
 
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Chat distinguishes session preparation from response streaming and retains initialization errors that arrive before the session acknowledgement. Long-press the agent header to open a live session-diagnostics drawer.
 - Delegated-agent activity survives parent replies and leaves compact history entries for later read-only review. The activity strip appears only while work runs; historical process views cannot stop or dismiss live work. (#447)
 
-## [Plugin 1.11.2] - 2026-09-09
+## [Plugin 1.11.2] - 2026-09-10
 
 ### Fixed
 

--- a/PLUGIN_RELEASE_NOTES.md
+++ b/PLUGIN_RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Hermes-Relay Plugin v__VERSION__
 
-**Release Date:** September 9, 2026
+**Release Date:** September 10, 2026
 
 ## Summary
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Hermes-Relay Android v1.16.0
 
-**Release Date:** September 9, 2026
+**Release Date:** September 10, 2026
 
 ## Download
 

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -4,7 +4,7 @@
   {
    "version": "1.16.0",
    "title": "Safer startup, connections, and activity",
-   "date": "2026-09-09",
+   "date": "2026-09-10",
    "summary": "Gateway chat opens reliably from a cold launch, saved sign-ins stay with the correct connection, and network changes no longer race the route cache. Bot Mode and delegated-work feedback also remain stable across multiple gateways and later review.",
    "changes": [
     {


### PR DESCRIPTION
## Summary

Correct the repository release dates for Hermes-Relay Android 1.16.0 and Hermes-Relay Plugin 1.11.2 to September 10, 2026, matching their actual publication date.

## Changes

- Correct both versioned CHANGELOG headings.
- Correct the Android and Plugin release-note source files.
- Correct the Android schema-3 in-app release date.
- Keep versions, tags, artifacts, Play notes, and release content unchanged.

## Verification

- `python scripts/check-android-release-notes.py` — passed.
- `python scripts/check-plugin-version-sync.py --expect 1.11.2` — passed.
- `python scripts/check-version-tracks.py` — passed.
- `git diff --check` — passed.
- No stale September 9 date remains in the current Android/Plugin release metadata set.

## Screenshots

No visual layout change.

## Compatibility / risk

Metadata-only correction. No runtime, package, artifact, tag, signing, Play submission, or migration change.

## Lineage / contributor credit

- Source PR(s): #573, #574, #575
- Attribution preserved by: release history and tags remain unchanged.

## Checklist

- [x] Target branch is `dev`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: release metadata validation passed; no runtime change
- [x] Translation changes: N/A
- [x] Server/plugin changes: version sync passed; no runtime change
- [x] Desktop changes: N/A
- [x] Docs/site changes: release metadata validation passed
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated
- [x] Public writing hygiene checked
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship