### PR TITLE
fix(android): release Gateway directory bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Android Dashboard-only connections start the profile-scoped session directory before Gateway readiness, so a cold LAN launch cannot leave both the directory and the passive Gateway socket waiting on each other. (#495, #528)
+
 ## [Android 1.16.0] - 2026-09-10
 
 ### Fixed

--- a/app/src/androidTest/kotlin/com/hermesandroid/relay/viewmodel/GatewayForegroundRecoveryInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/hermesandroid/relay/viewmodel/GatewayForegroundRecoveryInstrumentedTest.kt
@@ -31,9 +31,11 @@ import com.hermesandroid.relay.network.upstream.GatewayChatClient
 import com.hermesandroid.relay.network.upstream.GatewayConnectionState
 import com.hermesandroid.relay.network.upstream.HermesApiClient
 import com.hermesandroid.relay.network.upstream.models.MessageItem
+import com.hermesandroid.relay.network.upstream.models.SessionItem
 import com.hermesandroid.relay.ui.components.GatewayBackgroundProcessStrip
 import com.hermesandroid.relay.ui.components.SubagentPreviewVisibility
 import com.hermesandroid.relay.ui.screens.shouldOwnVisibleGateway
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -216,6 +218,75 @@ class GatewayForegroundRecoveryInstrumentedTest {
         controlMethods.forEach { method ->
             assertEquals(
                 "cold observation sent $method",
+                baseline.getValue(method),
+                fixture.rpcCount(method),
+            )
+        }
+    }
+
+    @Test
+    fun dashboardOnlyColdLaunch_waitsForExactDirectoryThenOpensObservationSocket() {
+        viewModel.setChatVisible(false)
+        viewModel.updateGatewayClient(null)
+        gatewayClient.shutdown()
+        gatewayScope.cancel()
+
+        val directoryStarted = CompletableDeferred<Unit>()
+        val directoryResult = CompletableDeferred<Result<List<SessionItem>>>()
+        viewModel.setProfileSessionLister { profile ->
+            assertEquals(PROFILE_NAME, profile)
+            directoryStarted.complete(Unit)
+            directoryResult.await()
+        }
+        handler.setSessionId(null)
+        viewModel.switchProfileContext(
+            AgentDisplay.profileContextKey("fixture-connection", PROFILE_NAME),
+            STORED_SESSION_ID,
+        )
+
+        val controlMethods = setOf(
+            "session.resume",
+            "session.activate",
+            "prompt.submit",
+            "session.interrupt",
+        )
+        val baseline = controlMethods.associateWith(fixture::rpcCount)
+        val ticketMintsBefore = fixture.requestsTo("/api/auth/ws-ticket")
+        gatewayScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val okHttp = OkHttpClient()
+        gatewayClient = GatewayChatClient(
+            initialDashboardClient = DashboardApiClient(
+                baseUrl = fixture.server.url("/").toString().trimEnd('/'),
+                okHttpClient = okHttp,
+            ),
+            okHttpClient = okHttp,
+            callbackDispatcher = { block -> Handler(Looper.getMainLooper()).post(block) },
+            scope = gatewayScope,
+            reconnectJitterUnit = { 0.0 },
+        )
+        viewModel.setChatTurnCheckpointStore(null)
+        viewModel.updateGatewayClient(gatewayClient)
+        viewModel.setChatVisible(true)
+
+        // This is the production binder's Dashboard/profile hydration edge.
+        // The socket must stay passive and closed until the exact-owner REST
+        // directory publishes, then open without a lifecycle bounce.
+        viewModel.refreshSessions()
+        compose.waitUntil(5_000) { directoryStarted.isCompleted }
+        assertEquals(ticketMintsBefore, fixture.requestsTo("/api/auth/ws-ticket"))
+
+        directoryResult.complete(
+            Result.success(listOf(SessionItem(id = STORED_SESSION_ID, title = "Fixture session"))),
+        )
+
+        compose.waitUntil(5_000) {
+            gatewayClient.connectionState.value == GatewayConnectionState.Ready
+        }
+        serverSocket = fixture.awaitServerSocket()
+        assertEquals(ticketMintsBefore + 1, fixture.requestsTo("/api/auth/ws-ticket"))
+        controlMethods.forEach { method ->
+            assertEquals(
+                "directory-gated cold observation sent $method",
                 baseline.getValue(method),
                 fixture.rpcCount(method),
             )

--- a/app/src/main/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinder.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinder.kt
@@ -351,14 +351,18 @@ internal class HermesRuntimeBinder(
                 connection.activeConnectionId,
                 connection.effectiveSessionProfileName,
                 connection.lastSessionId,
-                connection.activeEndpoint,
-            ) { ready, connectionId, profileName, sessionId, activeEndpoint ->
+                // The session directory belongs to the standard Dashboard
+                // route. connection.activeEndpoint is the optional Relay
+                // socket's selected candidate and stays null on a valid
+                // Dashboard-only LAN connection.
+                connection.effectiveDashboardUrl,
+            ) { ready, connectionId, profileName, sessionId, dashboardUrl ->
                 ProfileContextInputs(
                     ready,
                     connectionId,
                     profileName,
                     sessionId,
-                    dashboardRouteResolved = activeEndpoint != null,
+                    dashboardUrl = dashboardUrl,
                 )
             }
             combine(
@@ -374,7 +378,7 @@ internal class HermesRuntimeBinder(
                 )
             }.collectLatest { inputs ->
                 profileContextReady.value = false
-                if (!shouldRefreshSessionDirectory(inputs.chatReady, inputs.dashboardRouteResolved)) {
+                if (!shouldRefreshSessionDirectory(inputs.chatReady, inputs.dashboardUrl)) {
                     return@collectLatest
                 }
                 if (!inputs.profileSelectionSettled) {
@@ -600,7 +604,7 @@ internal class HermesRuntimeBinder(
         val connectionId: String?,
         val profileName: String?,
         val sessionId: String?,
-        val dashboardRouteResolved: Boolean,
+        val dashboardUrl: String,
         val profileSelectionSettled: Boolean = false,
         val profileLocked: Boolean = false,
         val hiddenSources: Set<String> = emptySet(),
@@ -632,12 +636,13 @@ internal class HermesRuntimeBinder(
 /**
  * Session browsing is Dashboard HTTP state, not Gateway-socket state. API-only
  * connections still use chat readiness; Dashboard connections can refresh once
- * the resolver has selected a live route, after the profile-settle fence.
+ * their persisted/resolved Dashboard origin publishes, after the profile-settle
+ * fence. The optional Relay endpoint is deliberately not part of this decision.
  */
 internal fun shouldRefreshSessionDirectory(
     chatReady: Boolean,
-    dashboardRouteResolved: Boolean,
-): Boolean = chatReady || dashboardRouteResolved
+    dashboardUrl: String,
+): Boolean = chatReady || dashboardUrl.isNotBlank()
 
 internal fun assistantCanTransmitScreenContext(engineMode: VoiceEngineMode): Boolean =
     engineMode == VoiceEngineMode.HermesVoiceOutput

--- a/app/src/test/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinderSessionDirectoryPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinderSessionDirectoryPolicyTest.kt
@@ -6,23 +6,29 @@ import org.junit.Test
 
 class HermesRuntimeBinderSessionDirectoryPolicyTest {
     @Test
-    fun `session directory can refresh from either standard route owner`() {
+    fun `session directory starts from dashboard publication before Gateway readiness`() {
         assertTrue(
             shouldRefreshSessionDirectory(
                 chatReady = true,
-                dashboardRouteResolved = false,
+                dashboardUrl = "",
             ),
         )
         assertTrue(
             shouldRefreshSessionDirectory(
                 chatReady = false,
-                dashboardRouteResolved = true,
+                dashboardUrl = "https://dashboard.example.test",
             ),
         )
         assertFalse(
             shouldRefreshSessionDirectory(
                 chatReady = false,
-                dashboardRouteResolved = false,
+                dashboardUrl = "",
+            ),
+        )
+        assertFalse(
+            shouldRefreshSessionDirectory(
+                chatReady = false,
+                dashboardUrl = "   ",
             ),
         )
     }

--- a/test-fixtures/vanilla-gateway/tests/test_fixture.py
+++ b/test-fixtures/vanilla-gateway/tests/test_fixture.py
@@ -247,6 +247,18 @@ class FixtureTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_cold_start_observer_opens_socket_without_control_rpc(self) -> None:
         _, base_url = await self.start("cold_start_observation")
+
+        # Android's cold-start barrier hydrates the profile-scoped Dashboard
+        # directory before it opens the passive Gateway observation socket.
+        # The REST read is independent of gateway.ready and must not create or
+        # attach a live runtime.
+        async with self.session.get(
+            f"{base_url}/api/sessions",
+            params={"profile": "default", "limit": 50, "offset": 0},
+        ) as response:
+            self.assertEqual(200, response.status)
+            self.assertEqual([], (await response.json())["sessions"])
+
         observer, _ = await self.connect(base_url)
         await self.rpc(observer, 1, "session.active_list")
         active = (await observer.receive_json())["result"]["sessions"]

--- a/test-fixtures/vanilla-gateway/vanilla_gateway/server.py
+++ b/test-fixtures/vanilla-gateway/vanilla_gateway/server.py
@@ -33,6 +33,7 @@ class GatewayFixture:
             [
                 web.post("/api/auth/ws-ticket", self._ticket),
                 web.get("/api/ws", self._websocket),
+                web.get("/api/sessions", self._sessions),
                 web.get("/api/sessions/{session_id}/messages", self._history),
                 web.get("/__fixture__/state", self._state),
                 web.get("/__fixture__/evidence", self._evidence),
@@ -287,6 +288,18 @@ class GatewayFixture:
     ) -> None:
         await socket.send_json(
             {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}},
+        )
+
+    async def _sessions(self, request: web.Request) -> web.Response:
+        profile = request.query.get("profile")
+        if profile not in (None, self.scenario.profile):
+            raise web.HTTPNotFound(text="profile not found")
+        self.evidence.add("directory", outcome="listed")
+        return web.json_response(
+            {
+                "sessions": [],
+                "pagination": {"limit": 50, "offset": 0, "returned": 0},
+            },
         )
 
     async def _history(self, request: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary

Refs #495 and #528. Follow-up to #571.

Android 1.16.0 admitted foreground Gateway observation before `gateway.ready`, but production still deferred that socket behind the exact profile-scoped Dashboard session directory. `HermesRuntimeBinder` started the directory from `activeEndpoint`, which belongs to the optional Relay socket and remains null on a valid Dashboard-only LAN connection. The directory and Gateway could therefore wait on each other until a lifecycle or route change retriggered binding.

Start the directory from the effective Dashboard origin instead. This preserves the existing profile-settle fence and directory ownership checks while allowing a standard Dashboard-only connection to reach the passive Gateway observation socket without a background/resume cycle.

## Changes

- Drive cold profile/session hydration from `effectiveDashboardUrl`, not the optional Relay endpoint.
- Add policy coverage for Dashboard publication before Gateway readiness.
- Add an API 36 Compose/instrumentation regression that starts from profile/session hydration, holds the directory read, and proves the socket opens after exact-owner publication without `session.resume`, `session.activate`, `prompt.submit`, or `session.interrupt`.
- Extend the vanilla Gateway fixture with the independent profile-scoped session-directory read used before passive socket observation.
- Add an Unreleased changelog entry.

## Verification

Exact PR head: `68fce1b1dabe1a8dd1f9f6a7a1999938dd1d09bb`.

- `scripts/android-lane.ps1 gradle :app:testSideloadDebugUnitTest --tests 'com.hermesandroid.relay.runtime.HermesRuntimeBinderSessionDirectoryPolicyTest' --tests 'com.hermesandroid.relay.viewmodel.ChatViewModelGatewayInboundTurnTest' --console=plain` — 128 tests passed; zero failures/errors/skips.
- `scripts/android-lane.ps1 gradle :app:testGooglePlayDebugUnitTest --tests 'com.hermesandroid.relay.runtime.HermesRuntimeBinderSessionDirectoryPolicyTest' --tests 'com.hermesandroid.relay.viewmodel.ChatViewModelGatewayInboundTurnTest' --console=plain` — 128 tests passed; zero failures/errors/skips.
- `scripts/android-lane.ps1 gradle :app:compileSideloadDebugAndroidTestKotlin --console=plain` — passed.
- `scripts/android-lane.ps1 gradle :app:standardPhoneApi36SideloadDebugAndroidTest '-Pandroid.testInstrumentationRunnerArguments.class=com.hermesandroid.relay.viewmodel.GatewayForegroundRecoveryInstrumentedTest#dashboardOnlyColdLaunch_waitsForExactDirectoryThenOpensObservationSocket' --rerun-tasks --console=plain` — one API 36 test passed. The first invocation assembled successfully but the managed emulator package service returned an ADB streamed-install broken pipe and produced no test result; the clean retry is the claimed result.
- `scripts/android-lane.ps1 gradle :app:lintSideloadDebug :app:lintGooglePlayDebug :app:assembleSideloadDebug :app:assembleGooglePlayDebug --console=plain` — passed.
- `python -m unittest discover -s test-fixtures/vanilla-gateway/tests -p 'test_*.py'` — 28 tests passed.
- `python -m unittest scripts.tests.check_gateway_scenario_conformance_test` — 8 tests passed.
- `python scripts/check-gateway-scenario-conformance.py <clean-current-upstream> --scenario-manifest test-fixtures/vanilla-gateway/vanilla_gateway/scenarios/cold_start_observation.json` — passed against clean `NousResearch/hermes-agent` commit `6c3d4a4af70d76b7365bf19e9420ffdcbb9830ad`; Gateway runtime and provider calls were not started.
- `python scripts/check-android-locales.py` — 12 catalogs passed.
- `python scripts/check-user-docs-locales.py` — five locales and five core pages passed.
- `python scripts/check-android-collection-apis.py` — passed.
- `python scripts/check-android-release-notes.py` — passed.
- `python scripts/check-version-tracks.py` — passed.
- `git diff --check` — passed.

## Screenshots

No visual change.

## Compatibility / risk

Current upstream keeps authenticated `GET /api/sessions?profile=...`, ticket minting, `/api/ws`, `gateway.ready`, and `session.active_list` independent. The official Dashboard/Desktop path opens the socket directly and reserves resume/activate for explicit session ownership. This change keeps Android on those upstream surfaces and adds no Hermes-Relay Plugin dependency or API/SSE fallback.

Route/credential ownership, profile/session generations, drafts/history, terminal auth and unsupported dispositions, bounded reconnect cooldowns, and lifecycle recovery are unchanged. The cold path remains socket-only after the exact directory barrier.

Physical Android 16 LAN/Tailscale certification remains outstanding. No phone install, release, deployment, merge, or issue mutation was performed.

## Lineage / contributor credit

- Source PR(s): #571 established visibility/client order independence; this follow-up covers the production directory-bootstrap path its manually bound tests bypassed.
- Attribution preserved by: no contributor history was rewritten.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: lint, focused tests for both flavors, both debug assemblies, and focused API 36 instrumentation passed
- [x] Translation changes: N/A; locale validators also passed
- [x] Server/plugin changes: N/A
- [x] Desktop changes: N/A
- [x] Docs/site changes: changelog only; release-note and version checks passed
- [x] UI changes were tested on API 36; physical LAN/Tailscale acceptance remains explicitly outstanding
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for user-visible changes
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A