### PR TITLE
release(android): android-v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [Android 1.16.1] - 2026-09-12
+
 ### Fixed
 
-- Android Dashboard-only connections start the profile-scoped session directory before Gateway readiness, so a cold LAN launch cannot leave both the directory and the passive Gateway socket waiting on each other. (#495, #528)
+- Android Dashboard-only connections start the profile-scoped session directory before Gateway readiness, so a cold launch no longer leaves both the directory and passive Gateway socket waiting on each other. (#495, #528)
 
 ## [Android 1.16.0] - 2026-09-10
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Hermes-Relay Android v1.16.0
+# Hermes-Relay Android v1.16.1
 
-**Release Date:** September 10, 2026
+**Release Date:** September 12, 2026
 
 ## Download
 
-> Installing on your phone? Download `hermes-relay-1.16.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
+> Installing on your phone? Download `hermes-relay-1.16.1-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
 
 The `.aab` file is a Play Console upload bundle and cannot be installed by tapping it on a phone.
 
@@ -12,28 +12,16 @@ Verify the download against `SHA256SUMS.txt`. See the [sideload guide](https://h
 
 ## Summary
 
-This release makes startup and connection switching safer, prevents a network-change crash, and keeps Bot Mode and delegated work stable across multiple Hermes gateways. Chat feedback, attachment failures, and session preparation are also easier to understand and review.
-
-## Changed
-
-- Delegated-agent activity remains available after parent replies as compact, bounded, read-only history. The live strip appears only while work is active, and historical views cannot control a running process.
-- Android feedback uses themed banners and action cards. A long-press on the agent header opens session diagnostics, and Developer settings can preview message surfaces locally.
+This patch fixes a remaining cold-start path that could leave a Dashboard-only connection waiting for Gateway readiness until the app resumed or its network route changed.
 
 ## Fixed
 
-- An authenticated Gateway chat opens on the first foreground launch instead of waiting for a background-and-resume cycle.
-- Network changes can invalidate route probes without racing the endpoint cache or crashing Android.
-- Saved Dashboard sign-ins stay bound to their owning connection when switching gateways; an outgoing route cannot invalidate another connection's session.
-- Dashboard sign-in removes pasted line breaks from username and password fields while preserving every other credential character.
-- Bot Mode and Active Now keep connection identity when different gateways expose the same profile name, and progress opens only on the selected bot.
-- Missing attachments keep their error and Retry action in the attachment card without repeated global messages.
-- Chat distinguishes session preparation from response streaming and retains initialization errors received before session acknowledgement.
+- Dashboard-only connections now start the exact profile-scoped session directory before Gateway readiness, so the directory and passive Gateway socket no longer wait on each other during a cold launch.
 
 ## Install / Verify
 
-- App version: **1.16.0** (versionCode **55**).
+- App version: **1.16.1** (versionCode **56**).
 - Standard Chat, sessions, profiles, Manage, voice, and ordinary media use current upstream Hermes. Speech-to-text still requires a configured provider on the host.
-- Hermes-Relay Plugin **1.11.2** is the matching optional release for Relay tools; the Android connection, Bot Mode, and delegated-activity fixes do not require the plugin.
-- Already-erased or revoked Dashboard credentials still require a legitimate sign-in; this release prevents cross-connection invalidation going forward.
+- Hermes-Relay Plugin **1.11.2** remains the matching optional release for Relay tools; this Gateway startup fix does not require it.
 - Explicit Direct API/API-only connections remain supported and are not used as silent failover for Dashboard-owned chats.
 - Granular Device Control and the system Voice Focus overlay remain sideload-only.

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
-v1.16.0 - Safer startup, connections, and activity
+v1.16.1 - Dashboard-only cold starts recover
 
-Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.
+Dashboard-only connections now prepare the selected profile before Gateway readiness, fixing a remaining cold-start path that could stay on waking or waiting for Gateway until the app resumed or its network route changed.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -2,6 +2,27 @@
  "schema": 3,
  "versions": [
   {
+   "version": "1.16.1",
+   "title": "Dashboard-only cold starts recover",
+   "date": "2026-09-12",
+   "summary": "Dashboard-only connections can now prepare the selected profile and open Gateway chat without waiting for a background, resume, or network-route change.",
+   "changes": [
+    {
+     "id": "gateway-directory-bootstrap",
+     "kind": "fixed",
+     "title": "Open Gateway chat from a Dashboard-only cold start",
+     "summary": "The selected profile's session directory starts before Gateway readiness, so it cannot wait on the same passive socket that depends on its result.",
+     "highlight": true
+    }
+   ],
+   "compatibility": [
+    "Standard Dashboard and Gateway chat continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.",
+    "Hermes-Relay Plugin 1.11.2 remains the matching optional release for Relay tools."
+   ],
+   "playNotes": "Dashboard-only connections now prepare the selected profile before Gateway readiness, fixing a remaining cold-start path that could stay on waking or waiting for Gateway until the app resumed or its network route changed.",
+   "sections": []
+  },
+  {
    "version": "1.16.0",
    "title": "Safer startup, connections, and activity",
    "date": "2026-09-10",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,24 +1,11 @@
-v1.16.0 - Safer startup, connections, and activity
+v1.16.1 - Dashboard-only cold starts recover
 
 Summary
-* Gateway chat opens reliably from a cold launch, saved sign-ins stay with the correct connection, and network changes no longer race the route cache. Bot Mode and delegated-work feedback also remain stable across multiple gateways and later review.
+* Dashboard-only connections can now prepare the selected profile and open Gateway chat without waiting for a background, resume, or network-route change.
 
 Highlights
-* Open Gateway chat on the first launch — An authenticated Gateway wakes and opens from a cold foreground start instead of waiting for the app to background and resume.
-* Keep saved sign-ins with their connection — Switching gateways cannot reuse an outgoing resolver route to invalidate another connection's saved Dashboard session.
-* Recover safely when the network changes — Route-probe completion and endpoint-cache invalidation are serialized so Wi-Fi, mobile-data, VPN, or Tailscale changes do not trigger the reported crash.
-* Review delegated work after it finishes — Compact, bounded activity receipts survive parent replies and remain available read-only, while the live strip appears only during active work.
-
-Improved
-* Keep feedback with the surface that owns it — Themed banners and action cards replace platform popups, global actions stay clear of the composer, and local Developer previews make feedback states inspectable.
-* See session preparation and initialization failures — Chat distinguishes session preparation from response streaming, retains early initialization errors, and opens session diagnostics from the agent header.
-
-Fixed
-* Open same-named bots from multiple gateways — Bot Mode and Active Now keep connection and profile identity together, avoiding duplicate list keys and opening progress on the selected bot.
-* Retry missing attachments in place — A missing attachment keeps its error and Retry action in the attachment card without producing repeated global messages.
-* Paste Dashboard credentials without hidden line breaks — Username and password fields remove pasted carriage returns and line feeds while preserving every other credential character.
+* Open Gateway chat from a Dashboard-only cold start — The selected profile's session directory starts before Gateway readiness, so it cannot wait on the same passive socket that depends on its result.
 
 Compatibility
-* Standard Chat, sessions, profiles, Manage, voice, Bot Mode, and delegated activity continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.
-* Hermes-Relay Plugin 1.11.2 is the matching optional release for Relay tools. Existing erased or revoked Dashboard credentials still require a legitimate sign-in.
-* Granular Device Control and the system Voice Focus overlay remain sideload-only.
+* Standard Dashboard and Gateway chat continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.
+* Hermes-Relay Plugin 1.11.2 remains the matching optional release for Relay tools.

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -91,9 +91,9 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.16.0 - Safer startup, connections, and activity
+v1.16.1 - Dashboard-only cold starts recover
 
-Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.
+Dashboard-only connections now prepare the selected profile before Gateway readiness, fixing a remaining cold-start path that could stay on waking or waiting for Gateway until the app resumed or its network route changed.
 ```
 ## Category
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.16.0"
-appVersionCode = "55"
+appVersionName = "1.16.1"
+appVersionCode = "56"
 agp = "9.4.0"
 kotlin = "2.4.10"
 compose-bom = "2026.08.00"


### PR DESCRIPTION
## Summary

Prepare Hermes-Relay Android 1.16.1 as a focused patch for the remaining Dashboard-only cold-start Gateway wait reported in #495 and #528.

## Changes

- Bump Hermes-Relay Android to 1.16.1 (versionCode 56).
- Promote only the Gateway directory-bootstrap fix from Unreleased.
- Refresh schema-3 What's New, Play notes, listing notes, and the GitHub release body for September 12, 2026.
- Keep Hermes-Relay Plugin 1.11.2 and CLI+UI 0.4.0-beta.7 unchanged.

## Verification

- `python scripts/android-prepush.py --release-prep` — passed, including rendered Changelog History and What's New toast tests.
- `python scripts/check-android-locales.py` — 12 catalogs passed.
- `python scripts/check-android-collection-apis.py` — passed.
- `python scripts/check-version-tracks.py` — passed; Android 1.16.1/code 56, Plugin 1.11.2, CLI+UI 0.4.0-beta.7.
- `python scripts/check-android-release-notes.py` — passed.
- `python scripts/check-privacy-policy.py` — passed.
- `python -m unittest scripts.tests.check_android_release_notes_test` — 8 tests passed.
- `git diff --check` — passed.
- Post-merge Android CI for the fix passed on `c27ee439ef746582fafb864958dfb8857a2fa535` (run 34695004594).

## Screenshots

No visual change.

## Compatibility / risk

This patch changes only Android release metadata. The implementation already merged through #578 and preserves the upstream Dashboard/Gateway path without requiring the optional Hermes-Relay Plugin.

Physical LAN/Tailscale phone validation is unavailable and is not claimed. Exact-head CI, private signed Play preflight, DEX/native scans, and immutable-artifact reuse remain required before publication.

## Lineage / contributor credit

- Source PR(s): #578
- Attribution preserved by: the merged implementation history remains unchanged; this PR contains release metadata only.

## Checklist

- [x] Target branch is `dev`, unless this is a `dev` → `main` release PR or a focused production-tag hotfix PR to `main`
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: release-prep presentation tests passed; exact-head CI remains required
- [x] Translation changes: N/A; locale validation passed
- [x] Server/plugin changes: N/A; Plugin 1.11.2 is unchanged
- [x] Desktop changes: N/A; CLI+UI 0.4.0-beta.7 is unchanged
- [x] Docs/site changes: generated Play listing notes validated
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for user-visible changes
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A