### PR TITLE
release(android): 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [Android 1.16.1] - 2026-09-12
+
 ### Fixed
 
-- Android Dashboard-only connections start the profile-scoped session directory before Gateway readiness, so a cold LAN launch cannot leave both the directory and the passive Gateway socket waiting on each other. (#495, #528)
+- Android Dashboard-only connections start the profile-scoped session directory before Gateway readiness, so a cold launch no longer leaves both the directory and passive Gateway socket waiting on each other. (#495, #528)
 
 ## [Android 1.16.0] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Android Dashboard-only connections start the profile-scoped session directory before Gateway readiness, so a cold LAN launch cannot leave both the directory and the passive Gateway socket waiting on each other. (#495, #528)
+
 ## [Android 1.16.0] - 2026-09-10
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Hermes-Relay Android v1.16.0
+# Hermes-Relay Android v1.16.1
 
-**Release Date:** September 10, 2026
+**Release Date:** September 12, 2026
 
 ## Download
 
-> Installing on your phone? Download `hermes-relay-1.16.0-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
+> Installing on your phone? Download `hermes-relay-1.16.1-sideload-release.apk` and tap it for the full feature set, or install the conservative build from [Google Play](https://play.google.com/store/apps/details?id=com.axiomlabs.hermesrelay).
 
 The `.aab` file is a Play Console upload bundle and cannot be installed by tapping it on a phone.
 
@@ -12,28 +12,16 @@ Verify the download against `SHA256SUMS.txt`. See the [sideload guide](https://h
 
 ## Summary
 
-This release makes startup and connection switching safer, prevents a network-change crash, and keeps Bot Mode and delegated work stable across multiple Hermes gateways. Chat feedback, attachment failures, and session preparation are also easier to understand and review.
-
-## Changed
-
-- Delegated-agent activity remains available after parent replies as compact, bounded, read-only history. The live strip appears only while work is active, and historical views cannot control a running process.
-- Android feedback uses themed banners and action cards. A long-press on the agent header opens session diagnostics, and Developer settings can preview message surfaces locally.
+This patch fixes a remaining cold-start path that could leave a Dashboard-only connection waiting for Gateway readiness until the app resumed or its network route changed.
 
 ## Fixed
 
-- An authenticated Gateway chat opens on the first foreground launch instead of waiting for a background-and-resume cycle.
-- Network changes can invalidate route probes without racing the endpoint cache or crashing Android.
-- Saved Dashboard sign-ins stay bound to their owning connection when switching gateways; an outgoing route cannot invalidate another connection's session.
-- Dashboard sign-in removes pasted line breaks from username and password fields while preserving every other credential character.
-- Bot Mode and Active Now keep connection identity when different gateways expose the same profile name, and progress opens only on the selected bot.
-- Missing attachments keep their error and Retry action in the attachment card without repeated global messages.
-- Chat distinguishes session preparation from response streaming and retains initialization errors received before session acknowledgement.
+- Dashboard-only connections now start the exact profile-scoped session directory before Gateway readiness, so the directory and passive Gateway socket no longer wait on each other during a cold launch.
 
 ## Install / Verify
 
-- App version: **1.16.0** (versionCode **55**).
+- App version: **1.16.1** (versionCode **56**).
 - Standard Chat, sessions, profiles, Manage, voice, and ordinary media use current upstream Hermes. Speech-to-text still requires a configured provider on the host.
-- Hermes-Relay Plugin **1.11.2** is the matching optional release for Relay tools; the Android connection, Bot Mode, and delegated-activity fixes do not require the plugin.
-- Already-erased or revoked Dashboard credentials still require a legitimate sign-in; this release prevents cross-connection invalidation going forward.
+- Hermes-Relay Plugin **1.11.2** remains the matching optional release for Relay tools; this Gateway startup fix does not require it.
 - Explicit Direct API/API-only connections remain supported and are not used as silent failover for Dashboard-owned chats.
 - Granular Device Control and the system Voice Focus overlay remain sideload-only.

--- a/app/src/androidTest/kotlin/com/hermesandroid/relay/viewmodel/GatewayForegroundRecoveryInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/hermesandroid/relay/viewmodel/GatewayForegroundRecoveryInstrumentedTest.kt
@@ -31,9 +31,11 @@ import com.hermesandroid.relay.network.upstream.GatewayChatClient
 import com.hermesandroid.relay.network.upstream.GatewayConnectionState
 import com.hermesandroid.relay.network.upstream.HermesApiClient
 import com.hermesandroid.relay.network.upstream.models.MessageItem
+import com.hermesandroid.relay.network.upstream.models.SessionItem
 import com.hermesandroid.relay.ui.components.GatewayBackgroundProcessStrip
 import com.hermesandroid.relay.ui.components.SubagentPreviewVisibility
 import com.hermesandroid.relay.ui.screens.shouldOwnVisibleGateway
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -216,6 +218,75 @@ class GatewayForegroundRecoveryInstrumentedTest {
         controlMethods.forEach { method ->
             assertEquals(
                 "cold observation sent $method",
+                baseline.getValue(method),
+                fixture.rpcCount(method),
+            )
+        }
+    }
+
+    @Test
+    fun dashboardOnlyColdLaunch_waitsForExactDirectoryThenOpensObservationSocket() {
+        viewModel.setChatVisible(false)
+        viewModel.updateGatewayClient(null)
+        gatewayClient.shutdown()
+        gatewayScope.cancel()
+
+        val directoryStarted = CompletableDeferred<Unit>()
+        val directoryResult = CompletableDeferred<Result<List<SessionItem>>>()
+        viewModel.setProfileSessionLister { profile ->
+            assertEquals(PROFILE_NAME, profile)
+            directoryStarted.complete(Unit)
+            directoryResult.await()
+        }
+        handler.setSessionId(null)
+        viewModel.switchProfileContext(
+            AgentDisplay.profileContextKey("fixture-connection", PROFILE_NAME),
+            STORED_SESSION_ID,
+        )
+
+        val controlMethods = setOf(
+            "session.resume",
+            "session.activate",
+            "prompt.submit",
+            "session.interrupt",
+        )
+        val baseline = controlMethods.associateWith(fixture::rpcCount)
+        val ticketMintsBefore = fixture.requestsTo("/api/auth/ws-ticket")
+        gatewayScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val okHttp = OkHttpClient()
+        gatewayClient = GatewayChatClient(
+            initialDashboardClient = DashboardApiClient(
+                baseUrl = fixture.server.url("/").toString().trimEnd('/'),
+                okHttpClient = okHttp,
+            ),
+            okHttpClient = okHttp,
+            callbackDispatcher = { block -> Handler(Looper.getMainLooper()).post(block) },
+            scope = gatewayScope,
+            reconnectJitterUnit = { 0.0 },
+        )
+        viewModel.setChatTurnCheckpointStore(null)
+        viewModel.updateGatewayClient(gatewayClient)
+        viewModel.setChatVisible(true)
+
+        // This is the production binder's Dashboard/profile hydration edge.
+        // The socket must stay passive and closed until the exact-owner REST
+        // directory publishes, then open without a lifecycle bounce.
+        viewModel.refreshSessions()
+        compose.waitUntil(5_000) { directoryStarted.isCompleted }
+        assertEquals(ticketMintsBefore, fixture.requestsTo("/api/auth/ws-ticket"))
+
+        directoryResult.complete(
+            Result.success(listOf(SessionItem(id = STORED_SESSION_ID, title = "Fixture session"))),
+        )
+
+        compose.waitUntil(5_000) {
+            gatewayClient.connectionState.value == GatewayConnectionState.Ready
+        }
+        serverSocket = fixture.awaitServerSocket()
+        assertEquals(ticketMintsBefore + 1, fixture.requestsTo("/api/auth/ws-ticket"))
+        controlMethods.forEach { method ->
+            assertEquals(
+                "directory-gated cold observation sent $method",
                 baseline.getValue(method),
                 fixture.rpcCount(method),
             )

--- a/app/src/googlePlay/play/release-notes/en-US/default.txt
+++ b/app/src/googlePlay/play/release-notes/en-US/default.txt
@@ -1,3 +1,3 @@
-v1.16.0 - Safer startup, connections, and activity
+v1.16.1 - Dashboard-only cold starts recover
 
-Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.
+Dashboard-only connections now prepare the selected profile before Gateway readiness, fixing a remaining cold-start path that could stay on waking or waiting for Gateway until the app resumed or its network route changed.

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -2,6 +2,27 @@
  "schema": 3,
  "versions": [
   {
+   "version": "1.16.1",
+   "title": "Dashboard-only cold starts recover",
+   "date": "2026-09-12",
+   "summary": "Dashboard-only connections can now prepare the selected profile and open Gateway chat without waiting for a background, resume, or network-route change.",
+   "changes": [
+    {
+     "id": "gateway-directory-bootstrap",
+     "kind": "fixed",
+     "title": "Open Gateway chat from a Dashboard-only cold start",
+     "summary": "The selected profile's session directory starts before Gateway readiness, so it cannot wait on the same passive socket that depends on its result.",
+     "highlight": true
+    }
+   ],
+   "compatibility": [
+    "Standard Dashboard and Gateway chat continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.",
+    "Hermes-Relay Plugin 1.11.2 remains the matching optional release for Relay tools."
+   ],
+   "playNotes": "Dashboard-only connections now prepare the selected profile before Gateway readiness, fixing a remaining cold-start path that could stay on waking or waiting for Gateway until the app resumed or its network route changed.",
+   "sections": []
+  },
+  {
    "version": "1.16.0",
    "title": "Safer startup, connections, and activity",
    "date": "2026-09-10",

--- a/app/src/main/assets/whats_new.txt
+++ b/app/src/main/assets/whats_new.txt
@@ -1,24 +1,11 @@
-v1.16.0 - Safer startup, connections, and activity
+v1.16.1 - Dashboard-only cold starts recover
 
 Summary
-* Gateway chat opens reliably from a cold launch, saved sign-ins stay with the correct connection, and network changes no longer race the route cache. Bot Mode and delegated-work feedback also remain stable across multiple gateways and later review.
+* Dashboard-only connections can now prepare the selected profile and open Gateway chat without waiting for a background, resume, or network-route change.
 
 Highlights
-* Open Gateway chat on the first launch — An authenticated Gateway wakes and opens from a cold foreground start instead of waiting for the app to background and resume.
-* Keep saved sign-ins with their connection — Switching gateways cannot reuse an outgoing resolver route to invalidate another connection's saved Dashboard session.
-* Recover safely when the network changes — Route-probe completion and endpoint-cache invalidation are serialized so Wi-Fi, mobile-data, VPN, or Tailscale changes do not trigger the reported crash.
-* Review delegated work after it finishes — Compact, bounded activity receipts survive parent replies and remain available read-only, while the live strip appears only during active work.
-
-Improved
-* Keep feedback with the surface that owns it — Themed banners and action cards replace platform popups, global actions stay clear of the composer, and local Developer previews make feedback states inspectable.
-* See session preparation and initialization failures — Chat distinguishes session preparation from response streaming, retains early initialization errors, and opens session diagnostics from the agent header.
-
-Fixed
-* Open same-named bots from multiple gateways — Bot Mode and Active Now keep connection and profile identity together, avoiding duplicate list keys and opening progress on the selected bot.
-* Retry missing attachments in place — A missing attachment keeps its error and Retry action in the attachment card without producing repeated global messages.
-* Paste Dashboard credentials without hidden line breaks — Username and password fields remove pasted carriage returns and line feeds while preserving every other credential character.
+* Open Gateway chat from a Dashboard-only cold start — The selected profile's session directory starts before Gateway readiness, so it cannot wait on the same passive socket that depends on its result.
 
 Compatibility
-* Standard Chat, sessions, profiles, Manage, voice, Bot Mode, and delegated activity continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.
-* Hermes-Relay Plugin 1.11.2 is the matching optional release for Relay tools. Existing erased or revoked Dashboard credentials still require a legitimate sign-in.
-* Granular Device Control and the system Voice Focus overlay remain sideload-only.
+* Standard Dashboard and Gateway chat continue to use current upstream Hermes without requiring the optional Hermes-Relay Plugin.
+* Hermes-Relay Plugin 1.11.2 remains the matching optional release for Relay tools.

--- a/app/src/main/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinder.kt
+++ b/app/src/main/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinder.kt
@@ -351,14 +351,18 @@ internal class HermesRuntimeBinder(
                 connection.activeConnectionId,
                 connection.effectiveSessionProfileName,
                 connection.lastSessionId,
-                connection.activeEndpoint,
-            ) { ready, connectionId, profileName, sessionId, activeEndpoint ->
+                // The session directory belongs to the standard Dashboard
+                // route. connection.activeEndpoint is the optional Relay
+                // socket's selected candidate and stays null on a valid
+                // Dashboard-only LAN connection.
+                connection.effectiveDashboardUrl,
+            ) { ready, connectionId, profileName, sessionId, dashboardUrl ->
                 ProfileContextInputs(
                     ready,
                     connectionId,
                     profileName,
                     sessionId,
-                    dashboardRouteResolved = activeEndpoint != null,
+                    dashboardUrl = dashboardUrl,
                 )
             }
             combine(
@@ -374,7 +378,7 @@ internal class HermesRuntimeBinder(
                 )
             }.collectLatest { inputs ->
                 profileContextReady.value = false
-                if (!shouldRefreshSessionDirectory(inputs.chatReady, inputs.dashboardRouteResolved)) {
+                if (!shouldRefreshSessionDirectory(inputs.chatReady, inputs.dashboardUrl)) {
                     return@collectLatest
                 }
                 if (!inputs.profileSelectionSettled) {
@@ -600,7 +604,7 @@ internal class HermesRuntimeBinder(
         val connectionId: String?,
         val profileName: String?,
         val sessionId: String?,
-        val dashboardRouteResolved: Boolean,
+        val dashboardUrl: String,
         val profileSelectionSettled: Boolean = false,
         val profileLocked: Boolean = false,
         val hiddenSources: Set<String> = emptySet(),
@@ -632,12 +636,13 @@ internal class HermesRuntimeBinder(
 /**
  * Session browsing is Dashboard HTTP state, not Gateway-socket state. API-only
  * connections still use chat readiness; Dashboard connections can refresh once
- * the resolver has selected a live route, after the profile-settle fence.
+ * their persisted/resolved Dashboard origin publishes, after the profile-settle
+ * fence. The optional Relay endpoint is deliberately not part of this decision.
  */
 internal fun shouldRefreshSessionDirectory(
     chatReady: Boolean,
-    dashboardRouteResolved: Boolean,
-): Boolean = chatReady || dashboardRouteResolved
+    dashboardUrl: String,
+): Boolean = chatReady || dashboardUrl.isNotBlank()
 
 internal fun assistantCanTransmitScreenContext(engineMode: VoiceEngineMode): Boolean =
     engineMode == VoiceEngineMode.HermesVoiceOutput

--- a/app/src/test/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinderSessionDirectoryPolicyTest.kt
+++ b/app/src/test/kotlin/com/hermesandroid/relay/runtime/HermesRuntimeBinderSessionDirectoryPolicyTest.kt
@@ -6,23 +6,29 @@ import org.junit.Test
 
 class HermesRuntimeBinderSessionDirectoryPolicyTest {
     @Test
-    fun `session directory can refresh from either standard route owner`() {
+    fun `session directory starts from dashboard publication before Gateway readiness`() {
         assertTrue(
             shouldRefreshSessionDirectory(
                 chatReady = true,
-                dashboardRouteResolved = false,
+                dashboardUrl = "",
             ),
         )
         assertTrue(
             shouldRefreshSessionDirectory(
                 chatReady = false,
-                dashboardRouteResolved = true,
+                dashboardUrl = "https://dashboard.example.test",
             ),
         )
         assertFalse(
             shouldRefreshSessionDirectory(
                 chatReady = false,
-                dashboardRouteResolved = false,
+                dashboardUrl = "",
+            ),
+        )
+        assertFalse(
+            shouldRefreshSessionDirectory(
+                chatReady = false,
+                dashboardUrl = "   ",
             ),
         )
     }

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -91,9 +91,9 @@ This app is a community project and is not affiliated with or endorsed by NousRe
 Paste into Play Console → **What's new** (≤500 characters):
 
 ```
-v1.16.0 - Safer startup, connections, and activity
+v1.16.1 - Dashboard-only cold starts recover
 
-Gateway chat now opens reliably on a cold launch. Saved Dashboard sign-ins stay bound to the correct connection, pasted credentials ignore accidental line breaks, and network changes no longer race the route cache. Bot Mode supports duplicate profile names across gateways, while delegated work, session setup, attachment errors, and feedback remain visible and easier to review.
+Dashboard-only connections now prepare the selected profile before Gateway readiness, fixing a remaining cold-start path that could stay on waking or waiting for Gateway until the app resumed or its network route changed.
 ```
 ## Category
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-appVersionName = "1.16.0"
-appVersionCode = "55"
+appVersionName = "1.16.1"
+appVersionCode = "56"
 agp = "9.4.0"
 kotlin = "2.4.10"
 compose-bom = "2026.08.00"

--- a/test-fixtures/vanilla-gateway/tests/test_fixture.py
+++ b/test-fixtures/vanilla-gateway/tests/test_fixture.py
@@ -247,6 +247,18 @@ class FixtureTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_cold_start_observer_opens_socket_without_control_rpc(self) -> None:
         _, base_url = await self.start("cold_start_observation")
+
+        # Android's cold-start barrier hydrates the profile-scoped Dashboard
+        # directory before it opens the passive Gateway observation socket.
+        # The REST read is independent of gateway.ready and must not create or
+        # attach a live runtime.
+        async with self.session.get(
+            f"{base_url}/api/sessions",
+            params={"profile": "default", "limit": 50, "offset": 0},
+        ) as response:
+            self.assertEqual(200, response.status)
+            self.assertEqual([], (await response.json())["sessions"])
+
         observer, _ = await self.connect(base_url)
         await self.rpc(observer, 1, "session.active_list")
         active = (await observer.receive_json())["result"]["sessions"]

--- a/test-fixtures/vanilla-gateway/vanilla_gateway/server.py
+++ b/test-fixtures/vanilla-gateway/vanilla_gateway/server.py
@@ -33,6 +33,7 @@ class GatewayFixture:
             [
                 web.post("/api/auth/ws-ticket", self._ticket),
                 web.get("/api/ws", self._websocket),
+                web.get("/api/sessions", self._sessions),
                 web.get("/api/sessions/{session_id}/messages", self._history),
                 web.get("/__fixture__/state", self._state),
                 web.get("/__fixture__/evidence", self._evidence),
@@ -287,6 +288,18 @@ class GatewayFixture:
     ) -> None:
         await socket.send_json(
             {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}},
+        )
+
+    async def _sessions(self, request: web.Request) -> web.Response:
+        profile = request.query.get("profile")
+        if profile not in (None, self.scenario.profile):
+            raise web.HTTPNotFound(text="profile not found")
+        self.evidence.add("directory", outcome="listed")
+        return web.json_response(
+            {
+                "sessions": [],
+                "pagination": {"limit": 50, "offset": 0, "returned": 0},
+            },
         )
 
     async def _history(self, request: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary

Promote the verified `dev` release tree for Hermes-Relay Android 1.16.1. This Android-only patch fixes the remaining Dashboard-only cold-start path that could leave the profile/session directory and passive Gateway socket waiting on each other until a background, resume, or network-route change.

## Changes

- Android 1.16.1 / versionCode 56 with synchronized GitHub release notes, schema-3 What's New history, Play notes, and listing copy.
- The merged Gateway directory-bootstrap fix from #578.
- No Hermes-Relay Plugin or CLI+UI version change; held PRs #559 and #561 are excluded.

## Verification

- Final source: `dev` commit `c7f54321ad0b315a0f8f40090f453b37477f55de`, tree `3855fb39a8fda4c6d033b6e2faa5af80415cd430`.
- Implementation PR #578 exact-head focused tests, both-flavor lint/build, API 36 instrumentation, Gateway fixtures, and current-upstream conformance passed; post-merge Android CI run 34695004594 passed.
- Release-prep PR #579 exact-head Android test/lint/build and required checks passed; it had no unresolved review threads and merged as `c7f54321ad0b315a0f8f40090f453b37477f55de`.
- Post-merge `dev` Android CI run 34696460773 passed focused tests, lint, both-flavor release smoke, DEX scanning, and packaged native compatibility.
- `python scripts/android-prepush.py --release-prep` passed, including release metadata and rendered Changelog/What's New tests.
- Android Play Preflight run 34697226440 passed on the exact `dev` commit/tree, built release-signed artifacts, passed final DEX/native scans, and uploaded versionCode 56 as a private Production draft. Immutable artifact ID: 10299232264.

## Screenshots

No visual change. Release presentation passed rendered Changelog and What's New tests.

## Compatibility / risk

Standard Dashboard/Gateway chat remains on current upstream Hermes and does not require the optional Hermes-Relay Plugin. Direct API/API-only routes remain explicit and are not silent failover for Dashboard-owned chats.

The public Android release must reuse the exact successful private preflight artifact; any tree, signing, hash, version, or Play mismatch fails closed. Physical LAN/Tailscale phone validation is unavailable and is not claimed.

## Lineage / contributor credit

- Source PR(s): #578, #579
- Attribution preserved by: the original implementation and merge history remain intact.

## Checklist

- [x] Target branch is `main` for the canonical `dev` → `main` Android release PR
- [x] Scope is focused and related issues/PRs are linked
- [x] Android changes: exact-tree CI, release prep, final package scans, and private Play preflight passed
- [x] Translation changes: N/A; locale validation passed
- [x] Server/plugin changes: N/A; Hermes-Relay Plugin 1.11.2 remains unchanged
- [x] Desktop changes: N/A; CLI+UI 0.4.0-beta.7 remains unchanged
- [x] Docs/site changes: release and Play copy validated; no site routes changed
- [x] UI changes were tested on a relevant device/emulator/desktop surface, or the missing proof is stated above
- [x] Commit messages follow Conventional Commits
- [x] `CHANGELOG.md` is updated for the released Android surface
- [x] Public writing hygiene checked: no secrets, private infrastructure, personal names, or AI/process narration
- [x] Salvaged/replacement work links source PRs and preserves contributor authorship, or N/A